### PR TITLE
feat: add version command and improve context tool naming

### DIFF
--- a/cmd/doc.go
+++ b/cmd/doc.go
@@ -1,0 +1,33 @@
+// Package cmd provides the command-line interface for mcp-kubernetes.
+//
+// This package implements a Cobra-based CLI with multiple subcommands:
+//   - serve: Starts the MCP server (default behavior when no subcommand is provided)
+//   - version: Displays the application version
+//   - self-update: Updates the binary to the latest version from GitHub releases
+//
+// The CLI maintains backwards compatibility by running the serve command when
+// no subcommand is specified, preserving the original behavior of the application.
+//
+// Command Structure:
+//
+//	mcp-kubernetes [flags]                 # Starts the MCP server (default)
+//	mcp-kubernetes serve [flags]           # Explicitly starts the MCP server
+//	mcp-kubernetes version                 # Shows version information
+//	mcp-kubernetes self-update             # Updates to latest release
+//	mcp-kubernetes help [command]          # Shows help information
+//
+// The serve command supports multiple transport options:
+//   - stdio: Standard input/output (default) - for command-line integration
+//   - sse: Server-Sent Events over HTTP - for web-based clients
+//   - streamable-http: Streamable HTTP transport - for HTTP-based integration
+//
+// Transport Configuration Examples:
+//
+//	mcp-kubernetes serve --transport stdio           # Default STDIO transport
+//	mcp-kubernetes serve --transport sse --http-addr :8080 --sse-endpoint /sse
+//	mcp-kubernetes serve --transport streamable-http --http-addr :9000 --http-endpoint /mcp
+//
+// The serve command also supports configuration flags for controlling Kubernetes
+// client behavior, including non-destructive mode, dry-run mode, and API
+// rate limiting settings.
+package cmd

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// rootCmd represents the base command for the mcp-kubernetes application.
+// It is the entry point when the application is called without any subcommands.
+var rootCmd = &cobra.Command{
+	Use:   "mcp-kubernetes",
+	Short: "MCP server for Kubernetes operations",
+	Long: `mcp-kubernetes is a Model Context Protocol (MCP) server that provides
+tools for interacting with Kubernetes clusters. It offers various capabilities
+including resource management, pod operations, context switching, cluster
+information, and Helm operations.
+
+When run without subcommands, it starts the MCP server (equivalent to 'mcp-kubernetes serve').`,
+	// SilenceUsage prevents Cobra from printing the usage message on errors that are handled by the application.
+	// This is useful for providing cleaner error output to the user.
+	SilenceUsage: true,
+}
+
+// SetVersion sets the version for the root command.
+// This function is typically called from the main package to inject the application version at build time.
+func SetVersion(v string) {
+	rootCmd.Version = v
+}
+
+// Execute is the main entry point for the CLI application.
+// It initializes and executes the root command, which in turn handles subcommands and flags.
+// This function is called by main.main().
+func Execute() {
+	// SetVersionTemplate defines a custom template for displaying the version.
+	// This is used when the --version flag is invoked.
+	rootCmd.SetVersionTemplate(`{{printf "mcp-kubernetes version %s\n" .Version}}`)
+
+	// If no subcommand is provided, run the serve command by default
+	if len(os.Args) == 1 {
+		os.Args = append(os.Args, "serve")
+	}
+
+	err := rootCmd.Execute()
+	if err != nil {
+		// Cobra itself usually prints the error. Exiting with a non-zero status code
+		// indicates that an error occurred during execution.
+		os.Exit(1)
+	}
+}
+
+// init is a special Go function that is executed when the package is initialized.
+// It is used here to add subcommands to the root command.
+func init() {
+	rootCmd.AddCommand(newVersionCmd())
+	rootCmd.AddCommand(newSelfUpdateCmd())
+	rootCmd.AddCommand(newServeCmd())
+
+	// Example of how to define persistent flags (global for the application):
+	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.config/mcp-kubernetes/config.yaml)")
+
+	// Example of how to define local flags (only run when this action is called directly):
+	// rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRootCmdProperties(t *testing.T) {
+	assert.Equal(t, "mcp-kubernetes", rootCmd.Use)
+	assert.Equal(t, "MCP server for Kubernetes operations", rootCmd.Short)
+	assert.True(t, strings.Contains(rootCmd.Long, "Model Context Protocol"))
+	assert.True(t, strings.Contains(rootCmd.Long, "Kubernetes"))
+	assert.True(t, rootCmd.SilenceUsage)
+}
+
+func TestSetVersion(t *testing.T) {
+	originalVersion := rootCmd.Version
+	defer func() {
+		rootCmd.Version = originalVersion
+	}()
+
+	testVersion := "v1.2.3-test"
+	SetVersion(testVersion)
+
+	assert.Equal(t, testVersion, rootCmd.Version)
+}
+
+func TestRootCommandHasSubcommands(t *testing.T) {
+	subcommands := rootCmd.Commands()
+
+	// Check that expected subcommands exist
+	var foundCommands []string
+	for _, cmd := range subcommands {
+		foundCommands = append(foundCommands, cmd.Use)
+	}
+
+	assert.Contains(t, foundCommands, "version")
+	assert.Contains(t, foundCommands, "self-update")
+	assert.Contains(t, foundCommands, "serve")
+
+	// Ensure we have at least the minimum expected commands
+	assert.GreaterOrEqual(t, len(foundCommands), 3)
+}

--- a/cmd/selfupdate.go
+++ b/cmd/selfupdate.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/creativeprojects/go-selfupdate"
+	"github.com/spf13/cobra"
+)
+
+// githubRepoSlug specifies the GitHub repository (owner/repo) to check for updates.
+const (
+	githubRepoSlug = "giantswarm/mcp-kubernetes" // GitHub repository path
+)
+
+// newSelfUpdateCmd creates the Cobra command for the self-update functionality.
+// This allows the application to update itself to the latest version from GitHub.
+func newSelfUpdateCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "self-update",
+		Short: "Update mcp-kubernetes to the latest version",
+		Long: `Checks for the latest release of mcp-kubernetes on GitHub and 
+updates the current binary if a newer version is found.`,
+		RunE: runSelfUpdate,
+	}
+}
+
+// runSelfUpdate performs the self-update logic.
+// It checks the current version against the latest GitHub release and updates if necessary.
+func runSelfUpdate(cmd *cobra.Command, args []string) error {
+	currentVersion := rootCmd.Version
+	// Self-update is typically disabled for development versions (e.g., "dev")
+	// as they are not standard releases and might not follow semantic versioning.
+	if currentVersion == "" || currentVersion == "dev" {
+		return fmt.Errorf("cannot self-update a development version")
+	}
+
+	fmt.Printf("Current version: %s\n", currentVersion)
+	fmt.Println("Checking for updates...")
+
+	updater, err := selfupdate.NewUpdater(selfupdate.Config{
+		// For public GitHub repositories, no specific configuration is usually needed for the updater.
+		// The library can automatically detect releases.
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create updater: %w", err)
+	}
+
+	// DetectLatest fetches the latest release information from the specified GitHub repository.
+	latest, found, err := updater.DetectLatest(context.Background(), selfupdate.ParseSlug(githubRepoSlug))
+	if err != nil {
+		return fmt.Errorf("error detecting latest version: %w", err)
+	}
+	if !found {
+		return fmt.Errorf("latest release for %s could not be found", githubRepoSlug)
+	}
+
+	// Compare the latest version from GitHub with the current application version.
+	if !latest.GreaterThan(currentVersion) {
+		fmt.Println("Current version is the latest.")
+		return nil
+	}
+
+	fmt.Printf("Found newer version: %s (published at %s)\n", latest.Version(), latest.PublishedAt)
+	fmt.Printf("Release notes:\n%s\n", latest.ReleaseNotes)
+
+	// Get the path to the currently running executable to replace it with the new version.
+	exe, err := selfupdate.ExecutablePath()
+	if err != nil {
+		return fmt.Errorf("could not locate executable path: %w", err)
+	}
+
+	fmt.Printf("Updating %s to version %s...\n", exe, latest.Version())
+
+	// Perform the update. This will download the new binary and replace the current one.
+	if err := updater.UpdateTo(context.Background(), latest, exe); err != nil {
+		return fmt.Errorf("update failed: %w", err)
+	}
+
+	fmt.Printf("Successfully updated to version %s\n", latest.Version())
+	return nil
+}

--- a/cmd/selfupdate_test.go
+++ b/cmd/selfupdate_test.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSelfUpdateCmd(t *testing.T) {
+	tests := []struct {
+		name          string
+		version       string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:          "self-update with dev version should fail",
+			version:       "dev",
+			expectError:   true,
+			errorContains: "cannot self-update a development version",
+		},
+		{
+			name:          "self-update with empty version should fail",
+			version:       "",
+			expectError:   true,
+			errorContains: "cannot self-update a development version",
+		},
+		// Note: Testing actual updates would require network access and real releases
+		// which is not suitable for unit tests
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up the root command version
+			originalVersion := rootCmd.Version
+			defer func() {
+				rootCmd.Version = originalVersion
+			}()
+			rootCmd.Version = tt.version
+
+			// Create the self-update command
+			cmd := newSelfUpdateCmd()
+
+			// Execute the command
+			err := cmd.Execute()
+
+			// Assertions
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorContains)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestSelfUpdateCmdProperties(t *testing.T) {
+	cmd := newSelfUpdateCmd()
+
+	assert.Equal(t, "self-update", cmd.Use)
+	assert.Equal(t, "Update mcp-kubernetes to the latest version", cmd.Short)
+	assert.True(t, strings.Contains(cmd.Long, "mcp-kubernetes"))
+	assert.True(t, strings.Contains(cmd.Long, "GitHub"))
+}
+
+func TestGithubRepoSlug(t *testing.T) {
+	// Ensure the GitHub repository slug is correctly set
+	assert.Equal(t, "giantswarm/mcp-kubernetes", githubRepoSlug)
+}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -1,0 +1,322 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/mcp-kubernetes/internal/k8s"
+	"github.com/giantswarm/mcp-kubernetes/internal/server"
+	"github.com/giantswarm/mcp-kubernetes/internal/tools/cluster"
+	contexttools "github.com/giantswarm/mcp-kubernetes/internal/tools/context"
+	"github.com/giantswarm/mcp-kubernetes/internal/tools/helm"
+	"github.com/giantswarm/mcp-kubernetes/internal/tools/pod"
+	"github.com/giantswarm/mcp-kubernetes/internal/tools/resource"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+)
+
+// simpleLogger provides basic logging for the Kubernetes client
+type simpleLogger struct{}
+
+func (l *simpleLogger) Debug(msg string, args ...interface{}) {
+	log.Printf("[DEBUG] %s %v", msg, args)
+}
+
+func (l *simpleLogger) Info(msg string, args ...interface{}) {
+	log.Printf("[INFO] %s %v", msg, args)
+}
+
+func (l *simpleLogger) Warn(msg string, args ...interface{}) {
+	log.Printf("[WARN] %s %v", msg, args)
+}
+
+func (l *simpleLogger) Error(msg string, args ...interface{}) {
+	log.Printf("[ERROR] %s %v", msg, args)
+}
+
+// newServeCmd creates the Cobra command for starting the MCP server.
+func newServeCmd() *cobra.Command {
+	var (
+		nonDestructiveMode bool
+		dryRun             bool
+		qpsLimit           float32
+		burstLimit         int
+		debugMode          bool
+
+		// Transport options
+		transport       string
+		httpAddr        string
+		sseEndpoint     string
+		messageEndpoint string
+		httpEndpoint    string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "serve",
+		Short: "Start the MCP Kubernetes server",
+		Long: `Start the MCP Kubernetes server to provide tools for interacting
+with Kubernetes clusters via the Model Context Protocol.
+
+Supports multiple transport types:
+  - stdio: Standard input/output (default)
+  - sse: Server-Sent Events over HTTP
+  - streamable-http: Streamable HTTP transport`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runServe(transport, nonDestructiveMode, dryRun, qpsLimit, burstLimit, debugMode,
+				httpAddr, sseEndpoint, messageEndpoint, httpEndpoint)
+		},
+	}
+
+	// Add flags for configuring the server
+	cmd.Flags().BoolVar(&nonDestructiveMode, "non-destructive", true, "Enable non-destructive mode (default: true)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Enable dry run mode (default: false)")
+	cmd.Flags().Float32Var(&qpsLimit, "qps-limit", 20.0, "QPS limit for Kubernetes API calls (default: 20.0)")
+	cmd.Flags().IntVar(&burstLimit, "burst-limit", 30, "Burst limit for Kubernetes API calls (default: 30)")
+	cmd.Flags().BoolVar(&debugMode, "debug", false, "Enable debug logging (default: false)")
+
+	// Transport flags
+	cmd.Flags().StringVar(&transport, "transport", "stdio", "Transport type: stdio, sse, or streamable-http")
+	cmd.Flags().StringVar(&httpAddr, "http-addr", ":8080", "HTTP server address (for sse and streamable-http transports)")
+	cmd.Flags().StringVar(&sseEndpoint, "sse-endpoint", "/sse", "SSE endpoint path (for sse transport)")
+	cmd.Flags().StringVar(&messageEndpoint, "message-endpoint", "/message", "Message endpoint path (for sse transport)")
+	cmd.Flags().StringVar(&httpEndpoint, "http-endpoint", "/mcp", "HTTP endpoint path (for streamable-http transport)")
+
+	return cmd
+}
+
+// runServe contains the main server logic with support for multiple transports
+func runServe(transport string, nonDestructiveMode, dryRun bool, qpsLimit float32, burstLimit int, debugMode bool,
+	httpAddr, sseEndpoint, messageEndpoint, httpEndpoint string) error {
+
+	// Create Kubernetes client configuration
+	k8sConfig := &k8s.ClientConfig{
+		NonDestructiveMode: nonDestructiveMode,
+		DryRun:             dryRun,
+		QPSLimit:           qpsLimit,
+		BurstLimit:         burstLimit,
+		Timeout:            30 * time.Second,
+		DebugMode:          debugMode,
+		Logger:             &simpleLogger{},
+	}
+
+	// Create Kubernetes client
+	k8sClient, err := k8s.NewClient(k8sConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create Kubernetes client: %w", err)
+	}
+
+	// Setup graceful shutdown - listen for both SIGINT and SIGTERM
+	shutdownCtx, cancel := signal.NotifyContext(context.Background(),
+		os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	// Create server context with kubernetes client and shutdown context
+	serverContext, err := server.NewServerContext(shutdownCtx, server.WithK8sClient(k8sClient))
+	if err != nil {
+		return fmt.Errorf("failed to create server context: %w", err)
+	}
+	defer func() {
+		if err := serverContext.Shutdown(); err != nil {
+			log.Printf("Error during server context shutdown: %v", err)
+		}
+	}()
+
+	// Create MCP server
+	mcpSrv := mcpserver.NewMCPServer("mcp-kubernetes", rootCmd.Version,
+		mcpserver.WithToolCapabilities(true),
+	)
+
+	// Register all tool categories
+	if err := resource.RegisterResourceTools(mcpSrv, serverContext); err != nil {
+		return fmt.Errorf("failed to register resource tools: %w", err)
+	}
+
+	if err := pod.RegisterPodTools(mcpSrv, serverContext); err != nil {
+		return fmt.Errorf("failed to register pod tools: %w", err)
+	}
+
+	if err := contexttools.RegisterContextTools(mcpSrv, serverContext); err != nil {
+		return fmt.Errorf("failed to register context tools: %w", err)
+	}
+
+	if err := cluster.RegisterClusterTools(mcpSrv, serverContext); err != nil {
+		return fmt.Errorf("failed to register cluster tools: %w", err)
+	}
+
+	if err := helm.RegisterHelmTools(mcpSrv, serverContext); err != nil {
+		return fmt.Errorf("failed to register helm tools: %w", err)
+	}
+
+	fmt.Printf("Starting MCP Kubernetes server with %s transport...\n", transport)
+
+	// Start the appropriate server based on transport type
+	switch transport {
+	case "stdio":
+		return runStdioServer(mcpSrv)
+	case "sse":
+		return runSSEServer(mcpSrv, httpAddr, sseEndpoint, messageEndpoint, shutdownCtx, debugMode)
+	case "streamable-http":
+		return runStreamableHTTPServer(mcpSrv, httpAddr, httpEndpoint, shutdownCtx, debugMode)
+	default:
+		return fmt.Errorf("unsupported transport type: %s (supported: stdio, sse, streamable-http)", transport)
+	}
+}
+
+// runStdioServer runs the server with STDIO transport
+func runStdioServer(mcpSrv *mcpserver.MCPServer) error {
+	// Start the server in a goroutine so we can handle shutdown signals
+	serverDone := make(chan error, 1)
+	go func() {
+		defer close(serverDone)
+		if err := mcpserver.ServeStdio(mcpSrv); err != nil {
+			serverDone <- err
+		}
+	}()
+
+	// Wait for server completion
+	select {
+	case err := <-serverDone:
+		if err != nil {
+			return fmt.Errorf("server stopped with error: %w", err)
+		} else {
+			fmt.Println("Server stopped normally")
+		}
+	}
+
+	fmt.Println("Server gracefully stopped")
+	return nil
+}
+
+// runSSEServer runs the server with SSE transport
+func runSSEServer(mcpSrv *mcpserver.MCPServer, addr, sseEndpoint, messageEndpoint string, ctx context.Context, debugMode bool) error {
+	if debugMode {
+		log.Printf("[DEBUG] Initializing SSE server with configuration:")
+		log.Printf("[DEBUG]   Address: %s", addr)
+		log.Printf("[DEBUG]   SSE Endpoint: %s", sseEndpoint)
+		log.Printf("[DEBUG]   Message Endpoint: %s", messageEndpoint)
+	}
+
+	// Create SSE server with custom endpoints
+	sseServer := mcpserver.NewSSEServer(mcpSrv,
+		mcpserver.WithSSEEndpoint(sseEndpoint),
+		mcpserver.WithMessageEndpoint(messageEndpoint),
+	)
+
+	if debugMode {
+		log.Printf("[DEBUG] SSE server instance created successfully")
+	}
+
+	fmt.Printf("SSE server starting on %s\n", addr)
+	fmt.Printf("  SSE endpoint: %s\n", sseEndpoint)
+	fmt.Printf("  Message endpoint: %s\n", messageEndpoint)
+
+	// Start server in goroutine
+	serverDone := make(chan error, 1)
+	go func() {
+		defer close(serverDone)
+		if debugMode {
+			log.Printf("[DEBUG] Starting SSE server listener on %s", addr)
+		}
+		if err := sseServer.Start(addr); err != nil {
+			if debugMode {
+				log.Printf("[DEBUG] SSE server start failed: %v", err)
+			}
+			serverDone <- err
+		} else {
+			if debugMode {
+				log.Printf("[DEBUG] SSE server listener stopped cleanly")
+			}
+		}
+	}()
+
+	if debugMode {
+		log.Printf("[DEBUG] SSE server goroutine started, waiting for shutdown signal or server completion")
+	}
+
+	// Wait for either shutdown signal or server completion
+	select {
+	case <-ctx.Done():
+		if debugMode {
+			log.Printf("[DEBUG] Shutdown signal received, initiating SSE server shutdown")
+		}
+		fmt.Println("Shutdown signal received, stopping SSE server...")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 30)
+		defer cancel()
+		if debugMode {
+			log.Printf("[DEBUG] Starting graceful shutdown with 30s timeout")
+		}
+		if err := sseServer.Shutdown(shutdownCtx); err != nil {
+			if debugMode {
+				log.Printf("[DEBUG] Error during SSE server shutdown: %v", err)
+			}
+			return fmt.Errorf("error shutting down SSE server: %w", err)
+		}
+		if debugMode {
+			log.Printf("[DEBUG] SSE server shutdown completed successfully")
+		}
+	case err := <-serverDone:
+		if err != nil {
+			if debugMode {
+				log.Printf("[DEBUG] SSE server stopped with error: %v", err)
+			}
+			return fmt.Errorf("SSE server stopped with error: %w", err)
+		} else {
+			if debugMode {
+				log.Printf("[DEBUG] SSE server stopped normally")
+			}
+			fmt.Println("SSE server stopped normally")
+		}
+	}
+
+	fmt.Println("SSE server gracefully stopped")
+	if debugMode {
+		log.Printf("[DEBUG] SSE server shutdown sequence completed")
+	}
+	return nil
+}
+
+// runStreamableHTTPServer runs the server with Streamable HTTP transport
+func runStreamableHTTPServer(mcpSrv *mcpserver.MCPServer, addr, endpoint string, ctx context.Context, debugMode bool) error {
+	// Create Streamable HTTP server with custom endpoint
+	httpServer := mcpserver.NewStreamableHTTPServer(mcpSrv,
+		mcpserver.WithEndpointPath(endpoint),
+	)
+
+	fmt.Printf("Streamable HTTP server starting on %s\n", addr)
+	fmt.Printf("  HTTP endpoint: %s\n", endpoint)
+
+	// Start server in goroutine
+	serverDone := make(chan error, 1)
+	go func() {
+		defer close(serverDone)
+		if err := httpServer.Start(addr); err != nil {
+			serverDone <- err
+		}
+	}()
+
+	// Wait for either shutdown signal or server completion
+	select {
+	case <-ctx.Done():
+		fmt.Println("Shutdown signal received, stopping HTTP server...")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 30)
+		defer cancel()
+		if err := httpServer.Shutdown(shutdownCtx); err != nil {
+			return fmt.Errorf("error shutting down HTTP server: %w", err)
+		}
+	case err := <-serverDone:
+		if err != nil {
+			return fmt.Errorf("HTTP server stopped with error: %w", err)
+		} else {
+			fmt.Println("HTTP server stopped normally")
+		}
+	}
+
+	fmt.Println("HTTP server gracefully stopped")
+	return nil
+}

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1,0 +1,153 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServeCmdProperties(t *testing.T) {
+	cmd := newServeCmd()
+
+	assert.Equal(t, "serve", cmd.Use)
+	assert.Equal(t, "Start the MCP Kubernetes server", cmd.Short)
+	assert.True(t, strings.Contains(cmd.Long, "Model Context Protocol"))
+	assert.True(t, strings.Contains(cmd.Long, "stdio"))
+	assert.True(t, strings.Contains(cmd.Long, "sse"))
+	assert.True(t, strings.Contains(cmd.Long, "streamable-http"))
+}
+
+func TestServeCmdFlags(t *testing.T) {
+	cmd := newServeCmd()
+
+	// Test that all expected flags exist
+	flagNames := []string{
+		"non-destructive",
+		"dry-run",
+		"qps-limit",
+		"burst-limit",
+		"transport",
+		"http-addr",
+		"sse-endpoint",
+		"message-endpoint",
+		"http-endpoint",
+	}
+
+	for _, flagName := range flagNames {
+		flag := cmd.Flags().Lookup(flagName)
+		assert.NotNil(t, flag, "Flag %s should exist", flagName)
+	}
+}
+
+func TestServeCmdFlagDefaults(t *testing.T) {
+	cmd := newServeCmd()
+
+	// Test flag default values
+	tests := []struct {
+		flagName string
+		expected string
+	}{
+		{"non-destructive", "true"},
+		{"dry-run", "false"},
+		{"qps-limit", "20"},
+		{"burst-limit", "30"},
+		{"transport", "stdio"},
+		{"http-addr", ":8080"},
+		{"sse-endpoint", "/sse"},
+		{"message-endpoint", "/message"},
+		{"http-endpoint", "/mcp"},
+	}
+
+	for _, test := range tests {
+		flag := cmd.Flags().Lookup(test.flagName)
+		assert.Equal(t, test.expected, flag.DefValue,
+			"Flag %s should have default value %s", test.flagName, test.expected)
+	}
+}
+
+func TestServeCmdTransportValidation(t *testing.T) {
+	tests := []struct {
+		name          string
+		transport     string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:        "valid stdio transport",
+			transport:   "stdio",
+			expectError: false,
+		},
+		{
+			name:        "valid sse transport",
+			transport:   "sse",
+			expectError: false,
+		},
+		{
+			name:        "valid streamable-http transport",
+			transport:   "streamable-http",
+			expectError: false,
+		},
+		{
+			name:          "invalid transport",
+			transport:     "invalid",
+			expectError:   true,
+			errorContains: "unsupported transport type",
+		},
+		{
+			name:          "empty transport",
+			transport:     "",
+			expectError:   true,
+			errorContains: "unsupported transport type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test transport validation by checking if it's in valid transports
+			validTransports := map[string]bool{
+				"stdio":           true,
+				"sse":             true,
+				"streamable-http": true,
+			}
+
+			isValid := validTransports[tt.transport]
+
+			if tt.expectError {
+				assert.False(t, isValid, "Transport %s should be invalid", tt.transport)
+			} else {
+				assert.True(t, isValid, "Transport %s should be valid", tt.transport)
+			}
+		})
+	}
+}
+
+func TestServeCmdFlagUsage(t *testing.T) {
+	cmd := newServeCmd()
+
+	// Test that help text contains transport information
+	usage := cmd.UsageString()
+	assert.Contains(t, usage, "--transport")
+	assert.Contains(t, usage, "stdio, sse, or streamable-http")
+}
+
+func TestServeCmdTransportSpecificFlags(t *testing.T) {
+	cmd := newServeCmd()
+
+	// Test that HTTP-related flags have appropriate descriptions
+	httpAddrFlag := cmd.Flags().Lookup("http-addr")
+	assert.Contains(t, httpAddrFlag.Usage, "HTTP server address")
+	assert.Contains(t, httpAddrFlag.Usage, "sse and streamable-http")
+
+	sseEndpointFlag := cmd.Flags().Lookup("sse-endpoint")
+	assert.Contains(t, sseEndpointFlag.Usage, "SSE endpoint path")
+	assert.Contains(t, sseEndpointFlag.Usage, "sse transport")
+
+	messageEndpointFlag := cmd.Flags().Lookup("message-endpoint")
+	assert.Contains(t, messageEndpointFlag.Usage, "Message endpoint path")
+	assert.Contains(t, messageEndpointFlag.Usage, "sse transport")
+
+	httpEndpointFlag := cmd.Flags().Lookup("http-endpoint")
+	assert.Contains(t, httpEndpointFlag.Usage, "HTTP endpoint path")
+	assert.Contains(t, httpEndpointFlag.Usage, "streamable-http transport")
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// newVersionCmd creates the Cobra command for displaying the application version.
+// The actual version information is typically managed by the root command or a global variable.
+func newVersionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print the version number of mcp-kubernetes",
+		Long:  `All software has versions. This is mcp-kubernetes's.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			// rootCmd.Version is expected to be set, typically in root.go during build time.
+			fmt.Fprintf(cmd.OutOrStdout(), "mcp-kubernetes version %s\n", rootCmd.Version)
+		},
+	}
+}

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVersionCmd(t *testing.T) {
+	tests := []struct {
+		name           string
+		version        string
+		expectedOutput string
+	}{
+		{
+			name:           "version command with dev version",
+			version:        "dev",
+			expectedOutput: "mcp-kubernetes version dev\n",
+		},
+		{
+			name:           "version command with semantic version",
+			version:        "v1.2.3",
+			expectedOutput: "mcp-kubernetes version v1.2.3\n",
+		},
+		{
+			name:           "version command with empty version",
+			version:        "",
+			expectedOutput: "mcp-kubernetes version \n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up the root command version
+			originalVersion := rootCmd.Version
+			defer func() {
+				rootCmd.Version = originalVersion
+			}()
+			rootCmd.Version = tt.version
+
+			// Create the version command
+			cmd := newVersionCmd()
+
+			// Capture output
+			var buf bytes.Buffer
+			cmd.SetOut(&buf)
+
+			// Execute the command
+			err := cmd.Execute()
+
+			// Assertions
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedOutput, buf.String())
+		})
+	}
+}
+
+func TestVersionCmdProperties(t *testing.T) {
+	cmd := newVersionCmd()
+
+	assert.Equal(t, "version", cmd.Use)
+	assert.Equal(t, "Print the version number of mcp-kubernetes", cmd.Short)
+	assert.True(t, strings.Contains(cmd.Long, "mcp-kubernetes"))
+}

--- a/go.mod
+++ b/go.mod
@@ -3,16 +3,24 @@ module github.com/giantswarm/mcp-kubernetes
 go 1.24.4
 
 require (
+	github.com/creativeprojects/go-selfupdate v1.5.0
 	github.com/mark3labs/mcp-go v0.32.0
+	github.com/spf13/cobra v1.9.1
+	github.com/stretchr/testify v1.10.0
 	k8s.io/api v0.33.1
 	k8s.io/apimachinery v0.33.1
 	k8s.io/client-go v0.33.1
 )
 
 require (
+	code.gitea.io/sdk/gitea v0.21.0 // indirect
+	github.com/42wim/httpsig v1.2.2 // indirect
+	github.com/Masterminds/semver/v3 v3.3.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/davidmz/go-pageant v1.0.2 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
+	github.com/go-fed/httpsig v1.1.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
@@ -20,8 +28,14 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/gnostic-models v0.6.9 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/google/go-github/v30 v30.1.0 // indirect
+	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
+	github.com/hashicorp/go-version v1.7.0 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
@@ -30,17 +44,22 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
-	github.com/spf13/cast v1.7.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/cast v1.7.1 // indirect
+	github.com/spf13/pflag v1.0.6 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
+	github.com/ulikunitz/xz v0.5.12 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
+	github.com/xanzy/go-gitlab v0.115.0 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
+	golang.org/x/crypto v0.37.0 // indirect
 	golang.org/x/net v0.38.0 // indirect
-	golang.org/x/oauth2 v0.27.0 // indirect
-	golang.org/x/sys v0.31.0 // indirect
-	golang.org/x/term v0.30.0 // indirect
-	golang.org/x/text v0.23.0 // indirect
-	golang.org/x/time v0.9.0 // indirect
+	golang.org/x/oauth2 v0.29.0 // indirect
+	golang.org/x/sys v0.32.0 // indirect
+	golang.org/x/term v0.31.0 // indirect
+	golang.org/x/text v0.24.0 // indirect
+	golang.org/x/time v0.11.0 // indirect
 	google.golang.org/protobuf v1.36.5 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -80,6 +80,9 @@ type PodManager interface {
 
 	// PortForward sets up port forwarding to a pod.
 	PortForward(ctx context.Context, kubeContext, namespace, podName string, ports []string, opts PortForwardOptions) (*PortForwardSession, error)
+
+	// PortForwardToService sets up port forwarding to the first available pod behind a service.
+	PortForwardToService(ctx context.Context, kubeContext, namespace, serviceName string, ports []string, opts PortForwardOptions) (*PortForwardSession, error)
 }
 
 // ClusterManager handles cluster-level operations.

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -1,0 +1,342 @@
+package k8s
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+// MockLogger for testing
+type MockLogger struct {
+	mock.Mock
+}
+
+func (m *MockLogger) Debug(msg string, args ...interface{}) {
+	m.Called(msg, args)
+}
+
+func (m *MockLogger) Info(msg string, args ...interface{}) {
+	m.Called(msg, args)
+}
+
+func (m *MockLogger) Warn(msg string, args ...interface{}) {
+	m.Called(msg, args)
+}
+
+func (m *MockLogger) Error(msg string, args ...interface{}) {
+	m.Called(msg, args)
+}
+
+// Helper function to create test kubeconfig
+func createTestKubeconfig() *api.Config {
+	return &api.Config{
+		Clusters: map[string]*api.Cluster{
+			"test-cluster": {
+				Server: "https://test.example.com",
+			},
+		},
+		AuthInfos: map[string]*api.AuthInfo{
+			"test-user": {
+				Token: "test-token",
+			},
+		},
+		Contexts: map[string]*api.Context{
+			"test-context": {
+				Cluster:   "test-cluster",
+				AuthInfo:  "test-user",
+				Namespace: "test-namespace",
+			},
+			"another-context": {
+				Cluster:   "test-cluster",
+				AuthInfo:  "test-user",
+				Namespace: "another-namespace",
+			},
+		},
+		CurrentContext: "test-context",
+	}
+}
+
+// Test NewClient function with simplified approach
+func TestNewClient(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      *ClientConfig
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:        "nil config",
+			config:      nil,
+			expectError: true,
+			errorMsg:    "client configuration is required",
+		},
+		{
+			name: "valid config with defaults",
+			config: &ClientConfig{
+				NonDestructiveMode: true,
+			},
+			expectError: false,
+		},
+		{
+			name: "valid config with custom values",
+			config: &ClientConfig{
+				QPSLimit:             50.0,
+				BurstLimit:           100,
+				Timeout:              60 * time.Second,
+				NonDestructiveMode:   false,
+				DryRun:               true,
+				AllowedOperations:    []string{"get", "list"},
+				RestrictedNamespaces: []string{"kube-system"},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a temporary kubeconfig file for testing
+			tmpDir := t.TempDir()
+			kubeconfigPath := filepath.Join(tmpDir, "kubeconfig")
+
+			if tt.config != nil {
+				tt.config.KubeconfigPath = kubeconfigPath
+				// Create a minimal kubeconfig file
+				createMinimalKubeconfig(t, kubeconfigPath)
+			}
+
+			client, err := NewClient(tt.config)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorMsg)
+				assert.Nil(t, client)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, client)
+
+				// Verify defaults are set correctly
+				if tt.config.QPSLimit == 0 {
+					assert.Equal(t, float32(20.0), client.qpsLimit)
+				} else {
+					assert.Equal(t, tt.config.QPSLimit, client.qpsLimit)
+				}
+
+				if tt.config.BurstLimit == 0 {
+					assert.Equal(t, 30, client.burstLimit)
+				} else {
+					assert.Equal(t, tt.config.BurstLimit, client.burstLimit)
+				}
+
+				if tt.config.Timeout == 0 {
+					assert.Equal(t, 30*time.Second, client.timeout)
+				} else {
+					assert.Equal(t, tt.config.Timeout, client.timeout)
+				}
+			}
+		})
+	}
+}
+
+func TestKubernetesClient_BasicContextOperations(t *testing.T) {
+	client := &kubernetesClient{
+		config:         &ClientConfig{},
+		kubeconfigData: createTestKubeconfig(),
+		currentContext: "test-context",
+	}
+
+	ctx := context.Background()
+
+	t.Run("ListContexts", func(t *testing.T) {
+		contexts, err := client.ListContexts(ctx)
+		require.NoError(t, err)
+		require.Len(t, contexts, 2)
+
+		// Verify contexts
+		contextNames := make(map[string]bool)
+		for _, context := range contexts {
+			contextNames[context.Name] = context.Current
+		}
+
+		assert.True(t, contextNames["test-context"])
+		assert.False(t, contextNames["another-context"])
+	})
+
+	t.Run("GetCurrentContext", func(t *testing.T) {
+		currentContext, err := client.GetCurrentContext(ctx)
+		require.NoError(t, err)
+
+		assert.Equal(t, "test-context", currentContext.Name)
+		assert.Equal(t, "test-cluster", currentContext.Cluster)
+		assert.Equal(t, "test-user", currentContext.User)
+		assert.Equal(t, "test-namespace", currentContext.Namespace)
+		assert.True(t, currentContext.Current)
+	})
+
+	t.Run("SwitchContext", func(t *testing.T) {
+		err := client.SwitchContext(ctx, "another-context")
+		require.NoError(t, err)
+		assert.Equal(t, "another-context", client.currentContext)
+
+		// Test switching to non-existent context
+		err = client.SwitchContext(ctx, "non-existent")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "does not exist in kubeconfig")
+	})
+}
+
+func TestKubernetesClient_SecurityValidation(t *testing.T) {
+	tests := []struct {
+		name                 string
+		nonDestructiveMode   bool
+		dryRun               bool
+		allowedOperations    []string
+		restrictedNamespaces []string
+		operation            string
+		namespace            string
+		expectError          bool
+		errorContains        string
+	}{
+		{
+			name:              "allowed operation",
+			allowedOperations: []string{"get", "list"},
+			operation:         "get",
+			expectError:       false,
+		},
+		{
+			name:              "disallowed operation",
+			allowedOperations: []string{"get", "list"},
+			operation:         "delete",
+			expectError:       true,
+			errorContains:     "is not allowed",
+		},
+		{
+			name:               "destructive operation in non-destructive mode without dry-run",
+			nonDestructiveMode: true,
+			dryRun:             false,
+			operation:          "delete",
+			expectError:        true,
+			errorContains:      "destructive operation",
+		},
+		{
+			name:               "destructive operation in non-destructive mode with dry-run",
+			nonDestructiveMode: true,
+			dryRun:             true,
+			operation:          "delete",
+			expectError:        false,
+		},
+		{
+			name:                 "restricted namespace",
+			restrictedNamespaces: []string{"kube-system"},
+			namespace:            "kube-system",
+			expectError:          true,
+			errorContains:        "is restricted",
+		},
+		{
+			name:                 "allowed namespace",
+			restrictedNamespaces: []string{"kube-system"},
+			namespace:            "default",
+			expectError:          false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &kubernetesClient{
+				nonDestructiveMode:   tt.nonDestructiveMode,
+				dryRun:               tt.dryRun,
+				allowedOperations:    tt.allowedOperations,
+				restrictedNamespaces: tt.restrictedNamespaces,
+			}
+
+			// Test operation check
+			if tt.operation != "" {
+				err := client.isOperationAllowed(tt.operation)
+				if tt.expectError && tt.errorContains != "is restricted" {
+					assert.Error(t, err)
+					assert.Contains(t, err.Error(), tt.errorContains)
+				} else if !tt.expectError {
+					assert.NoError(t, err)
+				}
+			}
+
+			// Test namespace check
+			if tt.namespace != "" {
+				err := client.isNamespaceRestricted(tt.namespace)
+				if tt.expectError && tt.errorContains == "is restricted" {
+					assert.Error(t, err)
+					assert.Contains(t, err.Error(), tt.errorContains)
+				} else if tt.namespace != "" {
+					assert.NoError(t, err)
+				}
+			}
+		})
+	}
+}
+
+func TestKubernetesClient_LogOperation(t *testing.T) {
+	mockLogger := &MockLogger{}
+	client := &kubernetesClient{
+		config: &ClientConfig{
+			Logger: mockLogger,
+		},
+	}
+
+	// Expect debug log call
+	mockLogger.On("Debug", "kubernetes operation", mock.AnythingOfType("[]interface {}")).Return()
+
+	client.logOperation("get", "test-context", "default", "pods", "test-pod")
+
+	mockLogger.AssertExpectations(t)
+}
+
+// Helper function to create minimal kubeconfig for testing
+func createMinimalKubeconfig(t testing.TB, path string) {
+	t.Helper()
+	kubeconfig := `
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://test.example.com
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+  name: test-context
+current-context: test-context
+users:
+- name: test-user
+  user:
+    token: test-token
+`
+	err := os.WriteFile(path, []byte(kubeconfig), 0644)
+	require.NoError(t, err)
+}
+
+// Benchmark tests
+func BenchmarkNewClient(b *testing.B) {
+	tmpDir := b.TempDir()
+	kubeconfigPath := filepath.Join(tmpDir, "kubeconfig")
+	createMinimalKubeconfig(b, kubeconfigPath)
+
+	config := &ClientConfig{
+		KubeconfigPath: kubeconfigPath,
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		client, err := NewClient(config)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = client
+	}
+}

--- a/internal/k8s/cluster_test.go
+++ b/internal/k8s/cluster_test.go
@@ -1,0 +1,326 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestAPIResourceInfo_Structure(t *testing.T) {
+	// Test APIResourceInfo struct
+
+	t.Run("complete resource info", func(t *testing.T) {
+		resource := APIResourceInfo{
+			Name:         "pods",
+			SingularName: "pod",
+			Namespaced:   true,
+			Kind:         "Pod",
+			Verbs:        []string{"get", "list", "create", "update", "delete"},
+			Group:        "",
+			Version:      "v1",
+		}
+
+		assert.Equal(t, "pods", resource.Name)
+		assert.Equal(t, "pod", resource.SingularName)
+		assert.True(t, resource.Namespaced)
+		assert.Equal(t, "Pod", resource.Kind)
+		assert.Len(t, resource.Verbs, 5)
+		assert.Contains(t, resource.Verbs, "get")
+		assert.Contains(t, resource.Verbs, "delete")
+		assert.Empty(t, resource.Group) // Core group
+		assert.Equal(t, "v1", resource.Version)
+	})
+
+	t.Run("cluster-scoped resource", func(t *testing.T) {
+		resource := APIResourceInfo{
+			Name:         "nodes",
+			SingularName: "node",
+			Namespaced:   false,
+			Kind:         "Node",
+			Verbs:        []string{"get", "list"},
+			Group:        "",
+			Version:      "v1",
+		}
+
+		assert.Equal(t, "nodes", resource.Name)
+		assert.False(t, resource.Namespaced)
+		assert.Equal(t, "Node", resource.Kind)
+	})
+
+	t.Run("custom resource", func(t *testing.T) {
+		resource := APIResourceInfo{
+			Name:         "customresources",
+			SingularName: "customresource",
+			Namespaced:   true,
+			Kind:         "CustomResource",
+			Verbs:        []string{"get", "list", "create", "update", "delete"},
+			Group:        "example.com",
+			Version:      "v1beta1",
+		}
+
+		assert.Equal(t, "customresources", resource.Name)
+		assert.Equal(t, "example.com", resource.Group)
+		assert.Equal(t, "v1beta1", resource.Version)
+	})
+}
+
+func TestClusterHealth_Structure(t *testing.T) {
+	// Test ClusterHealth struct
+
+	t.Run("healthy cluster", func(t *testing.T) {
+		health := ClusterHealth{
+			Status: "Healthy",
+			Components: []ComponentHealth{
+				{
+					Name:    "kube-apiserver",
+					Status:  "Healthy",
+					Message: "",
+				},
+				{
+					Name:    "etcd",
+					Status:  "Healthy",
+					Message: "",
+				},
+			},
+			Nodes: []NodeHealth{
+				{
+					Name:  "node-1",
+					Ready: true,
+					Conditions: []corev1.NodeCondition{
+						{
+							Type:   corev1.NodeReady,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+		}
+
+		assert.Equal(t, "Healthy", health.Status)
+		assert.Len(t, health.Components, 2)
+		assert.Len(t, health.Nodes, 1)
+
+		// Check component health
+		apiserver := health.Components[0]
+		assert.Equal(t, "kube-apiserver", apiserver.Name)
+		assert.Equal(t, "Healthy", apiserver.Status)
+		assert.Empty(t, apiserver.Message)
+
+		// Check node health
+		node := health.Nodes[0]
+		assert.Equal(t, "node-1", node.Name)
+		assert.True(t, node.Ready)
+		assert.Len(t, node.Conditions, 1)
+		assert.Equal(t, corev1.NodeReady, node.Conditions[0].Type)
+		assert.Equal(t, corev1.ConditionTrue, node.Conditions[0].Status)
+	})
+
+	t.Run("unhealthy cluster", func(t *testing.T) {
+		health := ClusterHealth{
+			Status: "Unhealthy",
+			Components: []ComponentHealth{
+				{
+					Name:    "kube-apiserver",
+					Status:  "Healthy",
+					Message: "",
+				},
+				{
+					Name:    "etcd",
+					Status:  "Unhealthy",
+					Message: "Connection timeout",
+				},
+			},
+			Nodes: []NodeHealth{
+				{
+					Name:  "node-1",
+					Ready: false,
+					Conditions: []corev1.NodeCondition{
+						{
+							Type:   corev1.NodeReady,
+							Status: corev1.ConditionFalse,
+							Reason: "NetworkUnavailable",
+						},
+					},
+				},
+			},
+		}
+
+		assert.Equal(t, "Unhealthy", health.Status)
+
+		// Check unhealthy component
+		etcd := health.Components[1]
+		assert.Equal(t, "etcd", etcd.Name)
+		assert.Equal(t, "Unhealthy", etcd.Status)
+		assert.Equal(t, "Connection timeout", etcd.Message)
+
+		// Check unhealthy node
+		node := health.Nodes[0]
+		assert.Equal(t, "node-1", node.Name)
+		assert.False(t, node.Ready)
+		assert.Equal(t, corev1.ConditionFalse, node.Conditions[0].Status)
+		assert.Equal(t, "NetworkUnavailable", node.Conditions[0].Reason)
+	})
+}
+
+func TestComponentHealth_Structure(t *testing.T) {
+	// Test ComponentHealth struct
+
+	t.Run("healthy component", func(t *testing.T) {
+		component := ComponentHealth{
+			Name:    "kube-scheduler",
+			Status:  "Healthy",
+			Message: "",
+		}
+
+		assert.Equal(t, "kube-scheduler", component.Name)
+		assert.Equal(t, "Healthy", component.Status)
+		assert.Empty(t, component.Message)
+	})
+
+	t.Run("unhealthy component with message", func(t *testing.T) {
+		component := ComponentHealth{
+			Name:    "kube-controller-manager",
+			Status:  "Unhealthy",
+			Message: "Failed to connect to etcd",
+		}
+
+		assert.Equal(t, "kube-controller-manager", component.Name)
+		assert.Equal(t, "Unhealthy", component.Status)
+		assert.Equal(t, "Failed to connect to etcd", component.Message)
+	})
+}
+
+func TestNodeHealth_Structure(t *testing.T) {
+	// Test NodeHealth struct
+
+	t.Run("ready node with multiple conditions", func(t *testing.T) {
+		now := metav1.Now()
+		node := NodeHealth{
+			Name:  "master-node",
+			Ready: true,
+			Conditions: []corev1.NodeCondition{
+				{
+					Type:               corev1.NodeReady,
+					Status:             corev1.ConditionTrue,
+					LastHeartbeatTime:  now,
+					LastTransitionTime: now,
+					Reason:             "KubeletReady",
+					Message:            "kubelet is posting ready status",
+				},
+				{
+					Type:               corev1.NodeMemoryPressure,
+					Status:             corev1.ConditionFalse,
+					LastHeartbeatTime:  now,
+					LastTransitionTime: now,
+					Reason:             "KubeletHasSufficientMemory",
+					Message:            "kubelet has sufficient memory available",
+				},
+				{
+					Type:               corev1.NodeDiskPressure,
+					Status:             corev1.ConditionFalse,
+					LastHeartbeatTime:  now,
+					LastTransitionTime: now,
+					Reason:             "KubeletHasNoDiskPressure",
+					Message:            "kubelet has no disk pressure",
+				},
+			},
+		}
+
+		assert.Equal(t, "master-node", node.Name)
+		assert.True(t, node.Ready)
+		assert.Len(t, node.Conditions, 3)
+
+		// Check Ready condition
+		readyCondition := node.Conditions[0]
+		assert.Equal(t, corev1.NodeReady, readyCondition.Type)
+		assert.Equal(t, corev1.ConditionTrue, readyCondition.Status)
+		assert.Equal(t, "KubeletReady", readyCondition.Reason)
+
+		// Check MemoryPressure condition (should be False for healthy)
+		memoryCondition := node.Conditions[1]
+		assert.Equal(t, corev1.NodeMemoryPressure, memoryCondition.Type)
+		assert.Equal(t, corev1.ConditionFalse, memoryCondition.Status)
+
+		// Check DiskPressure condition (should be False for healthy)
+		diskCondition := node.Conditions[2]
+		assert.Equal(t, corev1.NodeDiskPressure, diskCondition.Type)
+		assert.Equal(t, corev1.ConditionFalse, diskCondition.Status)
+	})
+
+	t.Run("not ready node", func(t *testing.T) {
+		node := NodeHealth{
+			Name:  "worker-node",
+			Ready: false,
+			Conditions: []corev1.NodeCondition{
+				{
+					Type:    corev1.NodeReady,
+					Status:  corev1.ConditionFalse,
+					Reason:  "KubeletNotReady",
+					Message: "kubelet stopped posting node status",
+				},
+			},
+		}
+
+		assert.Equal(t, "worker-node", node.Name)
+		assert.False(t, node.Ready)
+		assert.Len(t, node.Conditions, 1)
+
+		condition := node.Conditions[0]
+		assert.Equal(t, corev1.NodeReady, condition.Type)
+		assert.Equal(t, corev1.ConditionFalse, condition.Status)
+		assert.Equal(t, "KubeletNotReady", condition.Reason)
+	})
+}
+
+func TestKubernetesClient_ClusterOperationsValidation(t *testing.T) {
+	// Test validation logic for cluster operations without calling methods that can deadlock
+
+	t.Run("API resources operation validation", func(t *testing.T) {
+		client := createTestClientForResources()
+		client.allowedOperations = []string{"get", "list"}
+
+		// API resources operation would typically be covered by "get" or "list"
+		assert.NoError(t, client.isOperationAllowed("get"))
+		assert.NoError(t, client.isOperationAllowed("list"))
+
+		// Test disallowed operations
+		client.allowedOperations = []string{"delete"}
+		assert.Error(t, client.isOperationAllowed("get"))
+		assert.Error(t, client.isOperationAllowed("list"))
+	})
+
+	t.Run("cluster health operation validation", func(t *testing.T) {
+		client := createTestClientForResources()
+		client.nonDestructiveMode = true
+		client.dryRun = false
+
+		// Cluster health checks should be allowed in non-destructive mode
+		assert.NoError(t, client.isOperationAllowed("get"))
+		assert.NoError(t, client.isOperationAllowed("list"))
+		assert.NoError(t, client.isOperationAllowed("describe"))
+	})
+}
+
+func TestKubernetesClient_ClusterOperationsLogging(t *testing.T) {
+	// Test logging for cluster operations
+
+	mockLogger := &MockLogger{}
+
+	// Expect debug log calls for each operation
+	mockLogger.On("Debug", "kubernetes operation", mock.AnythingOfType("[]interface {}")).Return().Times(2)
+
+	client := &kubernetesClient{
+		config: &ClientConfig{
+			Logger: mockLogger,
+		},
+	}
+
+	// Test logging for cluster operations
+	client.logOperation("api-resources", "test-context", "", "", "")
+	client.logOperation("cluster-health", "test-context", "", "", "")
+
+	mockLogger.AssertExpectations(t)
+}

--- a/internal/k8s/helm_test.go
+++ b/internal/k8s/helm_test.go
@@ -1,0 +1,313 @@
+package k8s
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestHelmInstallOptions_Structure(t *testing.T) {
+	// Test HelmInstallOptions struct
+
+	t.Run("complete install options", func(t *testing.T) {
+		opts := HelmInstallOptions{
+			Values: map[string]interface{}{
+				"replicaCount": 3,
+				"image": map[string]interface{}{
+					"tag": "latest",
+				},
+			},
+			ValuesFiles:     []string{"values.yaml", "production.yaml"},
+			Wait:            true,
+			Timeout:         10 * time.Minute,
+			CreateNamespace: true,
+			Version:         "1.2.3",
+			Repository:      "https://charts.example.com",
+		}
+
+		assert.NotNil(t, opts.Values)
+		assert.Equal(t, 3, opts.Values["replicaCount"])
+		assert.Len(t, opts.ValuesFiles, 2)
+		assert.Contains(t, opts.ValuesFiles, "values.yaml")
+		assert.True(t, opts.Wait)
+		assert.Equal(t, 10*time.Minute, opts.Timeout)
+		assert.True(t, opts.CreateNamespace)
+		assert.Equal(t, "1.2.3", opts.Version)
+		assert.Equal(t, "https://charts.example.com", opts.Repository)
+	})
+
+	t.Run("minimal install options", func(t *testing.T) {
+		opts := HelmInstallOptions{}
+
+		assert.Nil(t, opts.Values)
+		assert.Nil(t, opts.ValuesFiles)
+		assert.False(t, opts.Wait)
+		assert.Equal(t, time.Duration(0), opts.Timeout)
+		assert.False(t, opts.CreateNamespace)
+		assert.Empty(t, opts.Version)
+		assert.Empty(t, opts.Repository)
+	})
+}
+
+func TestHelmUpgradeOptions_Structure(t *testing.T) {
+	// Test HelmUpgradeOptions struct
+
+	t.Run("complete upgrade options", func(t *testing.T) {
+		opts := HelmUpgradeOptions{
+			Values: map[string]interface{}{
+				"service": map[string]interface{}{
+					"type": "LoadBalancer",
+				},
+			},
+			ValuesFiles: []string{"values.yaml"},
+			Wait:        true,
+			Timeout:     5 * time.Minute,
+			Version:     "2.0.0",
+			Repository:  "https://charts.example.com",
+			ResetValues: true,
+		}
+
+		assert.NotNil(t, opts.Values)
+		service, exists := opts.Values["service"].(map[string]interface{})
+		assert.True(t, exists)
+		assert.Equal(t, "LoadBalancer", service["type"])
+		assert.Len(t, opts.ValuesFiles, 1)
+		assert.True(t, opts.Wait)
+		assert.Equal(t, 5*time.Minute, opts.Timeout)
+		assert.Equal(t, "2.0.0", opts.Version)
+		assert.Equal(t, "https://charts.example.com", opts.Repository)
+		assert.True(t, opts.ResetValues)
+	})
+
+	t.Run("upgrade with reset values", func(t *testing.T) {
+		opts := HelmUpgradeOptions{
+			ResetValues: true,
+		}
+
+		assert.True(t, opts.ResetValues)
+		assert.Nil(t, opts.Values)
+	})
+}
+
+func TestHelmUninstallOptions_Structure(t *testing.T) {
+	// Test HelmUninstallOptions struct
+
+	t.Run("complete uninstall options", func(t *testing.T) {
+		opts := HelmUninstallOptions{
+			Wait:    true,
+			Timeout: 2 * time.Minute,
+		}
+
+		assert.True(t, opts.Wait)
+		assert.Equal(t, 2*time.Minute, opts.Timeout)
+	})
+
+	t.Run("minimal uninstall options", func(t *testing.T) {
+		opts := HelmUninstallOptions{}
+
+		assert.False(t, opts.Wait)
+		assert.Equal(t, time.Duration(0), opts.Timeout)
+	})
+}
+
+func TestHelmListOptions_Structure(t *testing.T) {
+	// Test HelmListOptions struct
+
+	t.Run("complete list options", func(t *testing.T) {
+		opts := HelmListOptions{
+			AllNamespaces: true,
+			Filter:        "nginx",
+			Deployed:      true,
+			Failed:        false,
+			Pending:       false,
+		}
+
+		assert.True(t, opts.AllNamespaces)
+		assert.Equal(t, "nginx", opts.Filter)
+		assert.True(t, opts.Deployed)
+		assert.False(t, opts.Failed)
+		assert.False(t, opts.Pending)
+	})
+
+	t.Run("list failed releases", func(t *testing.T) {
+		opts := HelmListOptions{
+			Failed: true,
+		}
+
+		assert.True(t, opts.Failed)
+		assert.False(t, opts.Deployed)
+		assert.False(t, opts.Pending)
+	})
+
+	t.Run("list all states", func(t *testing.T) {
+		opts := HelmListOptions{
+			Deployed: true,
+			Failed:   true,
+			Pending:  true,
+		}
+
+		assert.True(t, opts.Deployed)
+		assert.True(t, opts.Failed)
+		assert.True(t, opts.Pending)
+	})
+}
+
+func TestHelmRelease_Structure(t *testing.T) {
+	// Test HelmRelease struct
+
+	t.Run("complete release info", func(t *testing.T) {
+		updated := time.Now()
+		release := HelmRelease{
+			Name:       "my-app",
+			Namespace:  "production",
+			Revision:   3,
+			Status:     "deployed",
+			Chart:      "nginx-1.2.3",
+			AppVersion: "1.19.0",
+			Updated:    updated,
+			Values: map[string]interface{}{
+				"replicaCount": 2,
+				"service": map[string]interface{}{
+					"type": "ClusterIP",
+				},
+			},
+		}
+
+		assert.Equal(t, "my-app", release.Name)
+		assert.Equal(t, "production", release.Namespace)
+		assert.Equal(t, 3, release.Revision)
+		assert.Equal(t, "deployed", release.Status)
+		assert.Equal(t, "nginx-1.2.3", release.Chart)
+		assert.Equal(t, "1.19.0", release.AppVersion)
+		assert.Equal(t, updated, release.Updated)
+		assert.NotNil(t, release.Values)
+		assert.Equal(t, 2, release.Values["replicaCount"])
+	})
+
+	t.Run("failed release", func(t *testing.T) {
+		release := HelmRelease{
+			Name:       "failed-app",
+			Namespace:  "default",
+			Revision:   1,
+			Status:     "failed",
+			Chart:      "broken-chart-1.0.0",
+			AppVersion: "unknown",
+			Updated:    time.Now(),
+		}
+
+		assert.Equal(t, "failed-app", release.Name)
+		assert.Equal(t, "failed", release.Status)
+		assert.Equal(t, 1, release.Revision)
+		assert.Equal(t, "broken-chart-1.0.0", release.Chart)
+		assert.Nil(t, release.Values)
+	})
+}
+
+func TestKubernetesClient_HelmOperationsValidation(t *testing.T) {
+	// Test validation logic for Helm operations without calling methods that can deadlock
+
+	t.Run("helm install validation", func(t *testing.T) {
+		client := createTestClientForResources()
+		client.allowedOperations = []string{"create", "get", "list"}
+		client.restrictedNamespaces = []string{"kube-system"}
+
+		// Helm install would require create permissions
+		assert.NoError(t, client.isOperationAllowed("create"))
+
+		// Test restricted namespace
+		assert.Error(t, client.isNamespaceRestricted("kube-system"))
+		assert.Contains(t, client.isNamespaceRestricted("kube-system").Error(), "is restricted")
+
+		// Test allowed namespace
+		assert.NoError(t, client.isNamespaceRestricted("default"))
+	})
+
+	t.Run("helm upgrade validation", func(t *testing.T) {
+		client := createTestClientForResources()
+		client.allowedOperations = []string{"patch", "update"}
+
+		// Helm upgrade would require update/patch permissions
+		assert.NoError(t, client.isOperationAllowed("patch"))
+		assert.NoError(t, client.isOperationAllowed("update"))
+
+		// Test disallowed operations
+		assert.Error(t, client.isOperationAllowed("delete"))
+	})
+
+	t.Run("helm uninstall validation", func(t *testing.T) {
+		client := createTestClientForResources()
+		client.nonDestructiveMode = true
+		client.dryRun = false
+
+		// Helm uninstall is destructive and should be blocked
+		assert.Error(t, client.isOperationAllowed("delete"))
+		assert.Contains(t, client.isOperationAllowed("delete").Error(), "destructive operation")
+
+		// But allowed with dry-run
+		client.dryRun = true
+		assert.NoError(t, client.isOperationAllowed("delete"))
+	})
+
+	t.Run("helm list validation", func(t *testing.T) {
+		client := createTestClientForResources()
+		client.allowedOperations = []string{"get", "list"}
+
+		// Helm list would require list permissions
+		assert.NoError(t, client.isOperationAllowed("list"))
+		assert.NoError(t, client.isOperationAllowed("get"))
+	})
+}
+
+func TestKubernetesClient_HelmOperationsLogging(t *testing.T) {
+	// Test logging for Helm operations
+
+	mockLogger := &MockLogger{}
+
+	// Expect debug log calls for each operation
+	mockLogger.On("Debug", "kubernetes operation", mock.AnythingOfType("[]interface {}")).Return().Times(4)
+
+	client := &kubernetesClient{
+		config: &ClientConfig{
+			Logger: mockLogger,
+		},
+	}
+
+	// Test logging for Helm operations
+	client.logOperation("helm-install", "test-context", "default", "release", "my-app")
+	client.logOperation("helm-upgrade", "test-context", "default", "release", "my-app")
+	client.logOperation("helm-uninstall", "test-context", "default", "release", "my-app")
+	client.logOperation("helm-list", "test-context", "default", "releases", "")
+
+	mockLogger.AssertExpectations(t)
+}
+
+func TestHelmOptions_TimeoutValidation(t *testing.T) {
+	// Test timeout validation logic
+
+	t.Run("reasonable timeouts", func(t *testing.T) {
+		installOpts := HelmInstallOptions{
+			Timeout: 5 * time.Minute,
+		}
+		upgradeOpts := HelmUpgradeOptions{
+			Timeout: 10 * time.Minute,
+		}
+		uninstallOpts := HelmUninstallOptions{
+			Timeout: 2 * time.Minute,
+		}
+
+		assert.Equal(t, 5*time.Minute, installOpts.Timeout)
+		assert.Equal(t, 10*time.Minute, upgradeOpts.Timeout)
+		assert.Equal(t, 2*time.Minute, uninstallOpts.Timeout)
+	})
+
+	t.Run("zero timeout", func(t *testing.T) {
+		opts := HelmInstallOptions{
+			Timeout: 0,
+		}
+
+		// Zero timeout means no timeout (wait indefinitely)
+		assert.Equal(t, time.Duration(0), opts.Timeout)
+	})
+}

--- a/internal/k8s/pods_test.go
+++ b/internal/k8s/pods_test.go
@@ -1,0 +1,207 @@
+package k8s
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestKubernetesClient_PodOperationsValidation(t *testing.T) {
+	// Test validation logic for pod operations without calling methods that can deadlock
+
+	t.Run("GetLogs validation", func(t *testing.T) {
+		client := createTestClientForResources()
+		client.allowedOperations = []string{"get"}
+		client.restrictedNamespaces = []string{"kube-system"}
+
+		// Test allowed operation
+		assert.NoError(t, client.isOperationAllowed("get"))
+
+		// Test restricted namespace
+		assert.Error(t, client.isNamespaceRestricted("kube-system"))
+		assert.Contains(t, client.isNamespaceRestricted("kube-system").Error(), "is restricted")
+
+		// Test allowed namespace
+		assert.NoError(t, client.isNamespaceRestricted("default"))
+	})
+
+	t.Run("Exec validation", func(t *testing.T) {
+		client := createTestClientForResources()
+		client.allowedOperations = []string{"get", "list"}
+
+		// Test that exec operation would be covered by "get" permission
+		assert.NoError(t, client.isOperationAllowed("get"))
+
+		// Test disallowed operations
+		client.allowedOperations = []string{"list"}
+		assert.Error(t, client.isOperationAllowed("get"))
+	})
+
+	t.Run("PortForward validation", func(t *testing.T) {
+		client := createTestClientForResources()
+		client.nonDestructiveMode = true
+		client.dryRun = false
+
+		// Port forwarding should be allowed even in non-destructive mode as it's not destructive
+		assert.NoError(t, client.isOperationAllowed("get"))
+	})
+}
+
+func TestLogOptions_Validation(t *testing.T) {
+	// Test LogOptions struct validation
+
+	t.Run("valid log options", func(t *testing.T) {
+		tailLines := int64(100)
+		sinceTime := time.Now().Add(-1 * time.Hour)
+
+		opts := LogOptions{
+			Follow:     true,
+			Previous:   false,
+			Timestamps: true,
+			SinceTime:  &sinceTime,
+			TailLines:  &tailLines,
+		}
+
+		// Validate the options make sense
+		assert.True(t, opts.Follow)
+		assert.False(t, opts.Previous)
+		assert.True(t, opts.Timestamps)
+		assert.NotNil(t, opts.SinceTime)
+		assert.NotNil(t, opts.TailLines)
+		assert.Equal(t, int64(100), *opts.TailLines)
+	})
+
+	t.Run("conflicting options", func(t *testing.T) {
+		// Test that we can create options with potentially conflicting settings
+		// (actual validation would happen in the Kubernetes API)
+		opts := LogOptions{
+			Follow:   true,
+			Previous: true, // This combination might not be valid in K8s API
+		}
+
+		// Our struct allows this, but Kubernetes API would reject it
+		assert.True(t, opts.Follow)
+		assert.True(t, opts.Previous)
+	})
+}
+
+func TestExecOptions_Validation(t *testing.T) {
+	// Test ExecOptions struct validation
+
+	t.Run("valid exec options", func(t *testing.T) {
+		opts := ExecOptions{
+			Stdin:  strings.NewReader("test input"),
+			Stdout: &strings.Builder{},
+			Stderr: &strings.Builder{},
+			TTY:    true,
+		}
+
+		assert.NotNil(t, opts.Stdin)
+		assert.NotNil(t, opts.Stdout)
+		assert.NotNil(t, opts.Stderr)
+		assert.True(t, opts.TTY)
+	})
+
+	t.Run("minimal exec options", func(t *testing.T) {
+		opts := ExecOptions{
+			TTY: false,
+		}
+
+		// Can have minimal options
+		assert.Nil(t, opts.Stdin)
+		assert.Nil(t, opts.Stdout)
+		assert.Nil(t, opts.Stderr)
+		assert.False(t, opts.TTY)
+	})
+}
+
+func TestExecResult_Structure(t *testing.T) {
+	// Test ExecResult struct
+
+	t.Run("successful execution", func(t *testing.T) {
+		result := ExecResult{
+			ExitCode: 0,
+			Stdout:   "command output",
+			Stderr:   "",
+		}
+
+		assert.Equal(t, 0, result.ExitCode)
+		assert.Equal(t, "command output", result.Stdout)
+		assert.Empty(t, result.Stderr)
+	})
+
+	t.Run("failed execution", func(t *testing.T) {
+		result := ExecResult{
+			ExitCode: 1,
+			Stdout:   "",
+			Stderr:   "error message",
+		}
+
+		assert.Equal(t, 1, result.ExitCode)
+		assert.Empty(t, result.Stdout)
+		assert.Equal(t, "error message", result.Stderr)
+	})
+}
+
+func TestPortForwardOptions_Structure(t *testing.T) {
+	// Test PortForwardOptions struct
+
+	t.Run("valid port forward options", func(t *testing.T) {
+		stdout := &strings.Builder{}
+		stderr := &strings.Builder{}
+
+		opts := PortForwardOptions{
+			Stdout: stdout,
+			Stderr: stderr,
+		}
+
+		assert.NotNil(t, opts.Stdout)
+		assert.NotNil(t, opts.Stderr)
+	})
+}
+
+func TestPortForwardSession_Structure(t *testing.T) {
+	// Test PortForwardSession struct
+
+	t.Run("valid session", func(t *testing.T) {
+		session := PortForwardSession{
+			LocalPorts:  []int{8080, 9090},
+			RemotePorts: []int{80, 90},
+			StopChan:    make(chan struct{}),
+			ReadyChan:   make(chan struct{}),
+			Forwarder:   nil, // Would be set by actual implementation
+		}
+
+		assert.Len(t, session.LocalPorts, 2)
+		assert.Len(t, session.RemotePorts, 2)
+		assert.Equal(t, 8080, session.LocalPorts[0])
+		assert.Equal(t, 80, session.RemotePorts[0])
+		assert.NotNil(t, session.StopChan)
+		assert.NotNil(t, session.ReadyChan)
+	})
+}
+
+func TestKubernetesClient_PodOperationsLogging(t *testing.T) {
+	// Test logging for pod operations
+
+	mockLogger := &MockLogger{}
+
+	// Expect debug log calls for each operation
+	mockLogger.On("Debug", "kubernetes operation", mock.AnythingOfType("[]interface {}")).Return().Times(3)
+
+	client := &kubernetesClient{
+		config: &ClientConfig{
+			Logger: mockLogger,
+		},
+	}
+
+	// Test logging for pod operations
+	client.logOperation("logs", "test-context", "default", "pods", "test-pod")
+	client.logOperation("exec", "test-context", "default", "pods", "test-pod")
+	client.logOperation("port-forward", "test-context", "default", "pods", "test-pod")
+
+	mockLogger.AssertExpectations(t)
+}

--- a/internal/k8s/resources_test.go
+++ b/internal/k8s/resources_test.go
@@ -1,0 +1,282 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+)
+
+// Create simplified test client for validation tests only
+func createTestClientForResources() *kubernetesClient {
+	mockLogger := &MockLogger{}
+	// Setup the mock to accept any calls
+	mockLogger.On("Debug", mock.Anything, mock.Anything).Return()
+	mockLogger.On("Info", mock.Anything, mock.Anything).Return()
+	mockLogger.On("Warn", mock.Anything, mock.Anything).Return()
+	mockLogger.On("Error", mock.Anything, mock.Anything).Return()
+
+	return &kubernetesClient{
+		config: &ClientConfig{
+			Logger: mockLogger,
+		},
+		clientsets:         make(map[string]kubernetes.Interface),
+		dynamicClients:     make(map[string]dynamic.Interface),
+		discoveryClients:   make(map[string]discovery.DiscoveryInterface),
+		nonDestructiveMode: false,
+		dryRun:             false,
+		kubeconfigData:     createTestKubeconfig(),
+		currentContext:     "test-context",
+	}
+}
+
+func TestKubernetesClient_ResourceSecurityChecks(t *testing.T) {
+	tests := []struct {
+		name                 string
+		operation            string
+		namespace            string
+		allowedOperations    []string
+		restrictedNamespaces []string
+		nonDestructiveMode   bool
+		dryRun               bool
+		expectError          bool
+		errorContains        string
+	}{
+		{
+			name:              "get operation allowed",
+			operation:         "get",
+			allowedOperations: []string{"get", "list"},
+			expectError:       false,
+		},
+		{
+			name:              "get operation not allowed",
+			operation:         "get",
+			allowedOperations: []string{"list"},
+			expectError:       true,
+			errorContains:     "is not allowed",
+		},
+		{
+			name:               "destructive operation in non-destructive mode without dry-run",
+			operation:          "delete",
+			nonDestructiveMode: true,
+			dryRun:             false,
+			expectError:        true,
+			errorContains:      "destructive operation",
+		},
+		{
+			name:               "destructive operation in non-destructive mode with dry-run",
+			operation:          "delete",
+			nonDestructiveMode: true,
+			dryRun:             true,
+			expectError:        false,
+		},
+		{
+			name:                 "access to restricted namespace",
+			namespace:            "kube-system",
+			restrictedNamespaces: []string{"kube-system"},
+			expectError:          true,
+			errorContains:        "is restricted",
+		},
+		{
+			name:                 "access to allowed namespace",
+			namespace:            "default",
+			restrictedNamespaces: []string{"kube-system"},
+			expectError:          false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := createTestClientForResources()
+			client.allowedOperations = tt.allowedOperations
+			client.restrictedNamespaces = tt.restrictedNamespaces
+			client.nonDestructiveMode = tt.nonDestructiveMode
+			client.dryRun = tt.dryRun
+
+			// Test operation validation
+			if tt.operation != "" {
+				err := client.isOperationAllowed(tt.operation)
+				if tt.expectError && tt.errorContains != "is restricted" {
+					assert.Error(t, err)
+					assert.Contains(t, err.Error(), tt.errorContains)
+				} else if !tt.expectError {
+					assert.NoError(t, err)
+				}
+			}
+
+			// Test namespace validation
+			if tt.namespace != "" {
+				err := client.isNamespaceRestricted(tt.namespace)
+				if tt.expectError && tt.errorContains == "is restricted" {
+					assert.Error(t, err)
+					assert.Contains(t, err.Error(), tt.errorContains)
+				} else if !tt.expectError {
+					assert.NoError(t, err)
+				}
+			}
+		})
+	}
+}
+
+func TestKubernetesClient_ScaleValidation(t *testing.T) {
+	// Test the scale validation logic directly without calling the Scale method
+	// to avoid mutex deadlocks in testing
+
+	t.Run("unsupported resource type validation", func(t *testing.T) {
+		// This tests the logic from the Scale method that checks resource types
+		resourceType := "pods"
+
+		// This is the validation logic from the Scale method
+		isScalable := false
+		switch resourceType {
+		case "deployment", "deployments":
+			isScalable = true
+		case "replicaset", "replicasets":
+			isScalable = true
+		case "statefulset", "statefulsets":
+			isScalable = true
+		}
+
+		assert.False(t, isScalable, "pods should not be scalable")
+	})
+
+	t.Run("supported resource types validation", func(t *testing.T) {
+		supportedTypes := []string{"deployment", "deployments", "replicaset", "replicasets", "statefulset", "statefulsets"}
+
+		for _, resourceType := range supportedTypes {
+			t.Run(resourceType, func(t *testing.T) {
+				// This is the validation logic from the Scale method
+				isScalable := false
+				switch resourceType {
+				case "deployment", "deployments":
+					isScalable = true
+				case "replicaset", "replicasets":
+					isScalable = true
+				case "statefulset", "statefulsets":
+					isScalable = true
+				}
+
+				assert.True(t, isScalable, "%s should be scalable", resourceType)
+			})
+		}
+	})
+}
+
+func TestKubernetesClient_BasicOperationsValidation(t *testing.T) {
+	// Test basic validation logic without calling methods that can deadlock
+
+	t.Run("Operation validation logic", func(t *testing.T) {
+		client := createTestClientForResources()
+
+		// Test allowed operations
+		client.allowedOperations = []string{"get", "list", "create"}
+
+		assert.NoError(t, client.isOperationAllowed("get"))
+		assert.NoError(t, client.isOperationAllowed("list"))
+		assert.NoError(t, client.isOperationAllowed("create"))
+
+		assert.Error(t, client.isOperationAllowed("delete"))
+		assert.Error(t, client.isOperationAllowed("patch"))
+	})
+
+	t.Run("Namespace restriction logic", func(t *testing.T) {
+		client := createTestClientForResources()
+		client.restrictedNamespaces = []string{"kube-system", "kube-public"}
+
+		assert.NoError(t, client.isNamespaceRestricted("default"))
+		assert.NoError(t, client.isNamespaceRestricted("my-namespace"))
+
+		assert.Error(t, client.isNamespaceRestricted("kube-system"))
+		assert.Error(t, client.isNamespaceRestricted("kube-public"))
+	})
+
+	t.Run("Non-destructive mode logic", func(t *testing.T) {
+		client := createTestClientForResources()
+		client.nonDestructiveMode = true
+		client.dryRun = false
+
+		// Safe operations should be allowed
+		assert.NoError(t, client.isOperationAllowed("get"))
+		assert.NoError(t, client.isOperationAllowed("list"))
+		assert.NoError(t, client.isOperationAllowed("describe"))
+
+		// Destructive operations should be blocked without dry-run
+		assert.Error(t, client.isOperationAllowed("delete"))
+		assert.Error(t, client.isOperationAllowed("create"))
+		assert.Error(t, client.isOperationAllowed("patch"))
+
+		// But allowed with dry-run
+		client.dryRun = true
+		assert.NoError(t, client.isOperationAllowed("delete"))
+		assert.NoError(t, client.isOperationAllowed("create"))
+		assert.NoError(t, client.isOperationAllowed("patch"))
+	})
+}
+
+func TestKubernetesClient_CombinedValidationLogic(t *testing.T) {
+	// Test the combined validation logic without calling methods that can deadlock
+
+	t.Run("operation and namespace validation combined", func(t *testing.T) {
+		client := createTestClientForResources()
+		client.allowedOperations = []string{"get", "list"}
+		client.restrictedNamespaces = []string{"kube-system"}
+
+		// Test allowed operation in allowed namespace
+		assert.NoError(t, client.isOperationAllowed("get"))
+		assert.NoError(t, client.isNamespaceRestricted("default"))
+
+		// Test disallowed operation
+		assert.Error(t, client.isOperationAllowed("delete"))
+		assert.Contains(t, client.isOperationAllowed("delete").Error(), "is not allowed")
+
+		// Test restricted namespace
+		assert.Error(t, client.isNamespaceRestricted("kube-system"))
+		assert.Contains(t, client.isNamespaceRestricted("kube-system").Error(), "is restricted")
+	})
+
+	t.Run("destructive operations with non-destructive mode", func(t *testing.T) {
+		client := createTestClientForResources()
+		client.nonDestructiveMode = true
+		client.dryRun = false
+
+		// Test that destructive operations are blocked
+		destructiveOps := []string{"delete", "create", "apply", "patch", "scale"}
+		for _, op := range destructiveOps {
+			err := client.isOperationAllowed(op)
+			assert.Error(t, err, "operation %s should be blocked in non-destructive mode", op)
+			assert.Contains(t, err.Error(), "destructive operation")
+		}
+
+		// Test that safe operations are allowed
+		safeOps := []string{"get", "list", "describe"}
+		for _, op := range safeOps {
+			assert.NoError(t, client.isOperationAllowed(op), "operation %s should be allowed", op)
+		}
+	})
+}
+
+// Test logging operations
+func TestKubernetesClient_LogResourceOperations(t *testing.T) {
+	mockLogger := &MockLogger{}
+
+	// Expect debug log calls for each operation
+	mockLogger.On("Debug", "kubernetes operation", mock.AnythingOfType("[]interface {}")).Return().Times(5)
+
+	client := &kubernetesClient{
+		config: &ClientConfig{
+			Logger: mockLogger,
+		},
+	}
+
+	// Test logging for different operations
+	client.logOperation("get", "test-context", "default", "pods", "test-pod")
+	client.logOperation("list", "test-context", "default", "pods", "")
+	client.logOperation("create", "test-context", "default", "pods", "new-pod")
+	client.logOperation("delete", "test-context", "default", "pods", "old-pod")
+	client.logOperation("scale", "test-context", "default", "deployment", "test-deployment")
+
+	mockLogger.AssertExpectations(t)
+}

--- a/internal/tools/cluster/handlers.go
+++ b/internal/tools/cluster/handlers.go
@@ -12,7 +12,7 @@ import (
 // handleGetAPIResources handles kubectl api-resources operations
 func handleGetAPIResources(ctx context.Context, request mcp.CallToolRequest, sc *server.ServerContext) (*mcp.CallToolResult, error) {
 	args := request.GetArguments()
-	
+
 	kubeContext, _ := args["kubeContext"].(string)
 
 	resources, err := sc.K8sClient().GetAPIResources(ctx, kubeContext)
@@ -32,7 +32,7 @@ func handleGetAPIResources(ctx context.Context, request mcp.CallToolRequest, sc 
 // handleGetClusterHealth handles kubectl cluster health operations
 func handleGetClusterHealth(ctx context.Context, request mcp.CallToolRequest, sc *server.ServerContext) (*mcp.CallToolResult, error) {
 	args := request.GetArguments()
-	
+
 	kubeContext, _ := args["kubeContext"].(string)
 
 	health, err := sc.K8sClient().GetClusterHealth(ctx, kubeContext)
@@ -47,4 +47,4 @@ func handleGetClusterHealth(ctx context.Context, request mcp.CallToolRequest, sc
 	}
 
 	return mcp.NewToolResultText(string(jsonData)), nil
-} 
+}

--- a/internal/tools/cluster/tools.go
+++ b/internal/tools/cluster/tools.go
@@ -10,8 +10,8 @@ import (
 
 // RegisterClusterTools registers all cluster management tools with the MCP server
 func RegisterClusterTools(s *mcpserver.MCPServer, sc *server.ServerContext) error {
-	// kubectl_api_resources tool
-	apiResourcesTool := mcp.NewTool("kubectl_api_resources",
+	// kubernetes_api_resources tool
+	apiResourcesTool := mcp.NewTool("kubernetes_api_resources",
 		mcp.WithDescription("List available API resources in the cluster"),
 		mcp.WithString("kubeContext",
 			mcp.Description("Kubernetes context to use (optional, uses current context if not specified)"),
@@ -31,8 +31,8 @@ func RegisterClusterTools(s *mcpserver.MCPServer, sc *server.ServerContext) erro
 		return handleGetAPIResources(ctx, request, sc)
 	})
 
-	// kubectl_cluster_health tool
-	clusterHealthTool := mcp.NewTool("kubectl_cluster_health",
+	// kubernetes_cluster_health tool
+	clusterHealthTool := mcp.NewTool("kubernetes_cluster_health",
 		mcp.WithDescription("Check the health status of cluster components"),
 		mcp.WithString("kubeContext",
 			mcp.Description("Kubernetes context to use (optional, uses current context if not specified)"),
@@ -44,4 +44,4 @@ func RegisterClusterTools(s *mcpserver.MCPServer, sc *server.ServerContext) erro
 	})
 
 	return nil
-} 
+}

--- a/internal/tools/context/handlers.go
+++ b/internal/tools/context/handlers.go
@@ -44,7 +44,7 @@ func handleGetCurrentContext(ctx context.Context, request mcp.CallToolRequest, s
 // handleUseContext handles kubectl context use operations
 func handleUseContext(ctx context.Context, request mcp.CallToolRequest, sc *server.ServerContext) (*mcp.CallToolResult, error) {
 	args := request.GetArguments()
-	
+
 	contextName, ok := args["contextName"].(string)
 	if !ok || contextName == "" {
 		return mcp.NewToolResultError("contextName is required"), nil
@@ -56,4 +56,4 @@ func handleUseContext(ctx context.Context, request mcp.CallToolRequest, sc *serv
 	}
 
 	return mcp.NewToolResultText(fmt.Sprintf("Successfully switched to context: %s", contextName)), nil
-} 
+}

--- a/internal/tools/context/tools.go
+++ b/internal/tools/context/tools.go
@@ -10,8 +10,8 @@ import (
 
 // RegisterContextTools registers all context management tools with the MCP server
 func RegisterContextTools(s *mcpserver.MCPServer, sc *server.ServerContext) error {
-	// kubectl_context_list tool
-	listContextsTool := mcp.NewTool("kubectl_context_list",
+	// kubernetes_context_list tool
+	listContextsTool := mcp.NewTool("kubernetes_context_list",
 		mcp.WithDescription("List all available Kubernetes contexts"),
 	)
 
@@ -19,8 +19,8 @@ func RegisterContextTools(s *mcpserver.MCPServer, sc *server.ServerContext) erro
 		return handleListContexts(ctx, request, sc)
 	})
 
-	// kubectl_context_get_current tool
-	getCurrentContextTool := mcp.NewTool("kubectl_context_get_current",
+	// kubernetes_context_get_current tool
+	getCurrentContextTool := mcp.NewTool("kubernetes_context_get_current",
 		mcp.WithDescription("Get the current Kubernetes context"),
 	)
 
@@ -28,8 +28,8 @@ func RegisterContextTools(s *mcpserver.MCPServer, sc *server.ServerContext) erro
 		return handleGetCurrentContext(ctx, request, sc)
 	})
 
-	// kubectl_context_use tool
-	useContextTool := mcp.NewTool("kubectl_context_use",
+	// kubernetes_context_use tool
+	useContextTool := mcp.NewTool("kubernetes_context_use",
 		mcp.WithDescription("Switch to a different Kubernetes context"),
 		mcp.WithString("contextName",
 			mcp.Required(),
@@ -42,4 +42,4 @@ func RegisterContextTools(s *mcpserver.MCPServer, sc *server.ServerContext) erro
 	})
 
 	return nil
-} 
+}

--- a/internal/tools/helm/handlers.go
+++ b/internal/tools/helm/handlers.go
@@ -30,19 +30,19 @@ func handleHelmInstall(ctx context.Context, request mcp.CallToolRequest, sc *ser
 	}
 
 	args := request.GetArguments()
-	
+
 	kubeContext, _ := args["kubeContext"].(string)
-	
+
 	namespace, ok := args["namespace"].(string)
 	if !ok || namespace == "" {
 		return mcp.NewToolResultError("namespace is required"), nil
 	}
-	
+
 	releaseName, ok := args["releaseName"].(string)
 	if !ok || releaseName == "" {
 		return mcp.NewToolResultError("releaseName is required"), nil
 	}
-	
+
 	chart, ok := args["chart"].(string)
 	if !ok || chart == "" {
 		return mcp.NewToolResultError("chart is required"), nil
@@ -52,12 +52,12 @@ func handleHelmInstall(ctx context.Context, request mcp.CallToolRequest, sc *ser
 	version, _ := args["version"].(string)
 	wait, _ := args["wait"].(bool)
 	createNamespace, _ := args["createNamespace"].(bool)
-	
+
 	var values map[string]interface{}
 	if valuesInterface, ok := args["values"]; ok && valuesInterface != nil {
 		values, _ = valuesInterface.(map[string]interface{})
 	}
-	
+
 	var timeout time.Duration = 300 * time.Second
 	if timeoutFloat, ok := args["timeout"].(float64); ok {
 		timeout = time.Duration(timeoutFloat) * time.Second
@@ -105,19 +105,19 @@ func handleHelmUpgrade(ctx context.Context, request mcp.CallToolRequest, sc *ser
 	}
 
 	args := request.GetArguments()
-	
+
 	kubeContext, _ := args["kubeContext"].(string)
-	
+
 	namespace, ok := args["namespace"].(string)
 	if !ok || namespace == "" {
 		return mcp.NewToolResultError("namespace is required"), nil
 	}
-	
+
 	releaseName, ok := args["releaseName"].(string)
 	if !ok || releaseName == "" {
 		return mcp.NewToolResultError("releaseName is required"), nil
 	}
-	
+
 	chart, ok := args["chart"].(string)
 	if !ok || chart == "" {
 		return mcp.NewToolResultError("chart is required"), nil
@@ -127,12 +127,12 @@ func handleHelmUpgrade(ctx context.Context, request mcp.CallToolRequest, sc *ser
 	version, _ := args["version"].(string)
 	wait, _ := args["wait"].(bool)
 	resetValues, _ := args["resetValues"].(bool)
-	
+
 	var values map[string]interface{}
 	if valuesInterface, ok := args["values"]; ok && valuesInterface != nil {
 		values, _ = valuesInterface.(map[string]interface{})
 	}
-	
+
 	var timeout time.Duration = 300 * time.Second
 	if timeoutFloat, ok := args["timeout"].(float64); ok {
 		timeout = time.Duration(timeoutFloat) * time.Second
@@ -180,21 +180,21 @@ func handleHelmUninstall(ctx context.Context, request mcp.CallToolRequest, sc *s
 	}
 
 	args := request.GetArguments()
-	
+
 	kubeContext, _ := args["kubeContext"].(string)
-	
+
 	namespace, ok := args["namespace"].(string)
 	if !ok || namespace == "" {
 		return mcp.NewToolResultError("namespace is required"), nil
 	}
-	
+
 	releaseName, ok := args["releaseName"].(string)
 	if !ok || releaseName == "" {
 		return mcp.NewToolResultError("releaseName is required"), nil
 	}
 
 	wait, _ := args["wait"].(bool)
-	
+
 	var timeout time.Duration = 300 * time.Second
 	if timeoutFloat, ok := args["timeout"].(float64); ok {
 		timeout = time.Duration(timeoutFloat) * time.Second
@@ -216,9 +216,9 @@ func handleHelmUninstall(ctx context.Context, request mcp.CallToolRequest, sc *s
 // handleHelmList handles helm list operations
 func handleHelmList(ctx context.Context, request mcp.CallToolRequest, sc *server.ServerContext) (*mcp.CallToolResult, error) {
 	args := request.GetArguments()
-	
+
 	kubeContext, _ := args["kubeContext"].(string)
-	
+
 	namespace, ok := args["namespace"].(string)
 	if !ok || namespace == "" {
 		return mcp.NewToolResultError("namespace is required"), nil
@@ -255,4 +255,4 @@ func handleHelmList(ctx context.Context, request mcp.CallToolRequest, sc *server
 	}
 
 	return mcp.NewToolResultText(string(jsonData)), nil
-} 
+}

--- a/internal/tools/helm/tools.go
+++ b/internal/tools/helm/tools.go
@@ -136,4 +136,4 @@ func RegisterHelmTools(s *mcpserver.MCPServer, sc *server.ServerContext) error {
 	})
 
 	return nil
-} 
+}

--- a/internal/tools/pod/handlers.go
+++ b/internal/tools/pod/handlers.go
@@ -15,25 +15,25 @@ import (
 // handleGetLogs handles kubectl logs operations
 func handleGetLogs(ctx context.Context, request mcp.CallToolRequest, sc *server.ServerContext) (*mcp.CallToolResult, error) {
 	args := request.GetArguments()
-	
+
 	kubeContext, _ := args["kubeContext"].(string)
-	
+
 	namespace, ok := args["namespace"].(string)
 	if !ok || namespace == "" {
 		return mcp.NewToolResultError("namespace is required"), nil
 	}
-	
+
 	podName, ok := args["podName"].(string)
 	if !ok || podName == "" {
 		return mcp.NewToolResultError("podName is required"), nil
 	}
-	
+
 	containerName, _ := args["containerName"].(string)
-	
+
 	follow, _ := args["follow"].(bool)
 	previous, _ := args["previous"].(bool)
 	timestamps, _ := args["timestamps"].(bool)
-	
+
 	var tailLines *int64
 	if tailLinesFloat, ok := args["tailLines"].(float64); ok {
 		tailLinesInt := int64(tailLinesFloat)
@@ -65,26 +65,26 @@ func handleGetLogs(ctx context.Context, request mcp.CallToolRequest, sc *server.
 // handleExec handles kubectl exec operations
 func handleExec(ctx context.Context, request mcp.CallToolRequest, sc *server.ServerContext) (*mcp.CallToolResult, error) {
 	args := request.GetArguments()
-	
+
 	kubeContext, _ := args["kubeContext"].(string)
-	
+
 	namespace, ok := args["namespace"].(string)
 	if !ok || namespace == "" {
 		return mcp.NewToolResultError("namespace is required"), nil
 	}
-	
+
 	podName, ok := args["podName"].(string)
 	if !ok || podName == "" {
 		return mcp.NewToolResultError("podName is required"), nil
 	}
-	
+
 	containerName, _ := args["containerName"].(string)
-	
+
 	commandInterface, ok := args["command"]
 	if !ok || commandInterface == nil {
 		return mcp.NewToolResultError("command is required"), nil
 	}
-	
+
 	// Convert command interface to []string
 	var command []string
 	if commandSlice, ok := commandInterface.([]interface{}); ok {
@@ -96,11 +96,11 @@ func handleExec(ctx context.Context, request mcp.CallToolRequest, sc *server.Ser
 	} else {
 		return mcp.NewToolResultError("command must be an array of strings"), nil
 	}
-	
+
 	if len(command) == 0 {
 		return mcp.NewToolResultError("command cannot be empty"), nil
 	}
-	
+
 	tty, _ := args["tty"].(bool)
 
 	opts := k8s.ExecOptions{
@@ -128,24 +128,37 @@ func handleExec(ctx context.Context, request mcp.CallToolRequest, sc *server.Ser
 // handlePortForward handles kubectl port-forward operations
 func handlePortForward(ctx context.Context, request mcp.CallToolRequest, sc *server.ServerContext) (*mcp.CallToolResult, error) {
 	args := request.GetArguments()
-	
+
 	kubeContext, _ := args["kubeContext"].(string)
-	
+
 	namespace, ok := args["namespace"].(string)
 	if !ok || namespace == "" {
 		return mcp.NewToolResultError("namespace is required"), nil
 	}
-	
-	podName, ok := args["podName"].(string)
-	if !ok || podName == "" {
-		return mcp.NewToolResultError("podName is required"), nil
+
+	// Get resource type (default to "pod" for backward compatibility)
+	resourceType, _ := args["resourceType"].(string)
+	if resourceType == "" {
+		resourceType = "pod"
 	}
-	
+
+	// Get resource name (support both old "podName" and new "resourceName" for backward compatibility)
+	resourceName, ok := args["resourceName"].(string)
+	if !ok || resourceName == "" {
+		// Fall back to "podName" for backward compatibility
+		if podName, exists := args["podName"].(string); exists && podName != "" {
+			resourceName = podName
+			resourceType = "pod" // Ensure it's treated as a pod
+		} else {
+			return mcp.NewToolResultError("resourceName is required"), nil
+		}
+	}
+
 	portsInterface, ok := args["ports"]
 	if !ok || portsInterface == nil {
 		return mcp.NewToolResultError("ports is required"), nil
 	}
-	
+
 	// Convert ports interface to []string
 	var ports []string
 	if portsSlice, ok := portsInterface.([]interface{}); ok {
@@ -157,35 +170,107 @@ func handlePortForward(ctx context.Context, request mcp.CallToolRequest, sc *ser
 	} else {
 		return mcp.NewToolResultError("ports must be an array of strings"), nil
 	}
-	
+
 	if len(ports) == 0 {
 		return mcp.NewToolResultError("ports cannot be empty"), nil
 	}
 
 	opts := k8s.PortForwardOptions{}
 
-	session, err := sc.K8sClient().PortForward(ctx, kubeContext, namespace, podName, ports, opts)
-	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("Failed to setup port forwarding: %v", err)), nil
+	var session *k8s.PortForwardSession
+	var err error
+	var sessionID string
+
+	// Create a context with a shorter timeout for the initial setup
+	setupCtx, setupCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer setupCancel()
+
+	// Handle port forwarding based on resource type
+	switch resourceType {
+	case "pod":
+		session, err = sc.K8sClient().PortForward(setupCtx, kubeContext, namespace, resourceName, ports, opts)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("Failed to setup port forwarding to pod: %v", err)), nil
+		}
+		sessionID = fmt.Sprintf("%s/%s:%s", namespace, resourceName, strings.Join(ports, ","))
+
+	case "service":
+		session, err = sc.K8sClient().PortForwardToService(setupCtx, kubeContext, namespace, resourceName, ports, opts)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("Failed to setup port forwarding to service: %v", err)), nil
+		}
+		sessionID = fmt.Sprintf("%s/service/%s:%s", namespace, resourceName, strings.Join(ports, ","))
+
+	default:
+		return mcp.NewToolResultError(fmt.Sprintf("Invalid resource type: %s. Must be 'pod' or 'service'", resourceType)), nil
 	}
 
-	// Wait a moment for the port forward to be ready
-	select {
-	case <-session.ReadyChan:
-		// Port forward is ready
-	case <-time.After(5 * time.Second):
-		return mcp.NewToolResultError("Port forward setup timed out"), nil
-	}
+	// Register the session for cleanup during shutdown
+	sc.RegisterPortForwardSession(sessionID, session)
 
 	// Format the result
 	var output strings.Builder
-	output.WriteString("Port forwarding session established:\n")
+	output.WriteString(fmt.Sprintf("Port forwarding session established to %s %s:\n", resourceType, resourceName))
 	for i, localPort := range session.LocalPorts {
 		if i < len(session.RemotePorts) {
 			output.WriteString(fmt.Sprintf("Local port %d -> Remote port %d\n", localPort, session.RemotePorts[i]))
 		}
 	}
-	output.WriteString("\nNote: This is a long-running session. Use Ctrl+C or close the connection to stop port forwarding.")
+	output.WriteString(fmt.Sprintf("\nSession ID: %s\n", sessionID))
+	output.WriteString("Note: This is a long-running session. Use 'list_port_forward_sessions' to view active sessions and 'stop_port_forward_session' to stop this session.")
 
 	return mcp.NewToolResultText(output.String()), nil
-} 
+}
+
+// handleListPortForwardSessions handles listing all active port forwarding sessions
+func handleListPortForwardSessions(ctx context.Context, request mcp.CallToolRequest, sc *server.ServerContext) (*mcp.CallToolResult, error) {
+	sessions := sc.GetActiveSessions()
+
+	if len(sessions) == 0 {
+		return mcp.NewToolResultText("No active port forwarding sessions."), nil
+	}
+
+	var output strings.Builder
+	output.WriteString(fmt.Sprintf("Active port forwarding sessions (%d):\n\n", len(sessions)))
+
+	for sessionID, session := range sessions {
+		output.WriteString(fmt.Sprintf("Session ID: %s\n", sessionID))
+		output.WriteString("Port mappings:\n")
+		for i, localPort := range session.LocalPorts {
+			if i < len(session.RemotePorts) {
+				output.WriteString(fmt.Sprintf("  Local port %d -> Remote port %d\n", localPort, session.RemotePorts[i]))
+			}
+		}
+		output.WriteString("\n")
+	}
+
+	return mcp.NewToolResultText(output.String()), nil
+}
+
+// handleStopPortForwardSession handles stopping a specific port forwarding session
+func handleStopPortForwardSession(ctx context.Context, request mcp.CallToolRequest, sc *server.ServerContext) (*mcp.CallToolResult, error) {
+	args := request.GetArguments()
+
+	sessionID, ok := args["sessionID"].(string)
+	if !ok || sessionID == "" {
+		return mcp.NewToolResultError("sessionID is required"), nil
+	}
+
+	err := sc.StopPortForwardSession(sessionID)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to stop session: %v", err)), nil
+	}
+
+	return mcp.NewToolResultText(fmt.Sprintf("Port forwarding session %s stopped successfully.", sessionID)), nil
+}
+
+// handleStopAllPortForwardSessions handles stopping all active port forwarding sessions
+func handleStopAllPortForwardSessions(ctx context.Context, request mcp.CallToolRequest, sc *server.ServerContext) (*mcp.CallToolResult, error) {
+	count := sc.StopAllPortForwardSessions()
+
+	if count == 0 {
+		return mcp.NewToolResultText("No active port forwarding sessions to stop."), nil
+	}
+
+	return mcp.NewToolResultText(fmt.Sprintf("Stopped %d port forwarding session(s) successfully.", count)), nil
+}

--- a/internal/tools/pod/tools.go
+++ b/internal/tools/pod/tools.go
@@ -10,8 +10,8 @@ import (
 
 // RegisterPodTools registers all pod management tools with the MCP server
 func RegisterPodTools(s *mcpserver.MCPServer, sc *server.ServerContext) error {
-	// kubectl_logs tool
-	logsTool := mcp.NewTool("kubectl_logs",
+	// kubernetes_logs tool
+	logsTool := mcp.NewTool("kubernetes_logs",
 		mcp.WithDescription("Get logs from a pod container"),
 		mcp.WithString("kubeContext",
 			mcp.Description("Kubernetes context to use (optional, uses current context if not specified)"),
@@ -45,8 +45,8 @@ func RegisterPodTools(s *mcpserver.MCPServer, sc *server.ServerContext) error {
 		return handleGetLogs(ctx, request, sc)
 	})
 
-	// kubectl_exec tool
-	execTool := mcp.NewTool("kubectl_exec",
+	// kubernetes_exec tool
+	execTool := mcp.NewTool("kubernetes_exec",
 		mcp.WithDescription("Execute a command inside a pod container"),
 		mcp.WithString("kubeContext",
 			mcp.Description("Kubernetes context to use (optional, uses current context if not specified)"),
@@ -75,19 +75,23 @@ func RegisterPodTools(s *mcpserver.MCPServer, sc *server.ServerContext) error {
 		return handleExec(ctx, request, sc)
 	})
 
-	// kubectl_port_forward tool
-	portForwardTool := mcp.NewTool("kubectl_port_forward",
-		mcp.WithDescription("Port-forward to a pod"),
+	// port_forward tool
+	portForwardTool := mcp.NewTool("port_forward",
+		mcp.WithDescription("Port-forward to a pod or service"),
 		mcp.WithString("kubeContext",
 			mcp.Description("Kubernetes context to use (optional, uses current context if not specified)"),
 		),
 		mcp.WithString("namespace",
 			mcp.Required(),
-			mcp.Description("Namespace where the pod is located"),
+			mcp.Description("Namespace where the resource is located"),
 		),
-		mcp.WithString("podName",
+		mcp.WithString("resourceType",
+			mcp.Description("Type of resource to port-forward to: 'pod' or 'service' (default: 'pod')"),
+			mcp.Enum("pod", "service"),
+		),
+		mcp.WithString("resourceName",
 			mcp.Required(),
-			mcp.Description("Name of the pod to port-forward to"),
+			mcp.Description("Name of the pod or service to port-forward to"),
 		),
 		mcp.WithArray("ports",
 			mcp.Required(),
@@ -99,5 +103,36 @@ func RegisterPodTools(s *mcpserver.MCPServer, sc *server.ServerContext) error {
 		return handlePortForward(ctx, request, sc)
 	})
 
+	// list_port_forward_sessions tool
+	listSessionsTool := mcp.NewTool("list_port_forward_sessions",
+		mcp.WithDescription("List all active port forwarding sessions"),
+	)
+
+	s.AddTool(listSessionsTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return handleListPortForwardSessions(ctx, request, sc)
+	})
+
+	// stop_port_forward_session tool
+	stopSessionTool := mcp.NewTool("stop_port_forward_session",
+		mcp.WithDescription("Stop a specific port forwarding session by ID"),
+		mcp.WithString("sessionID",
+			mcp.Required(),
+			mcp.Description("ID of the port forwarding session to stop"),
+		),
+	)
+
+	s.AddTool(stopSessionTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return handleStopPortForwardSession(ctx, request, sc)
+	})
+
+	// stop_all_port_forward_sessions tool
+	stopAllSessionsTool := mcp.NewTool("stop_all_port_forward_sessions",
+		mcp.WithDescription("Stop all active port forwarding sessions"),
+	)
+
+	s.AddTool(stopAllSessionsTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return handleStopAllPortForwardSessions(ctx, request, sc)
+	})
+
 	return nil
-} 
+}

--- a/internal/tools/resource/handlers.go
+++ b/internal/tools/resource/handlers.go
@@ -15,19 +15,19 @@ import (
 // handleGetResource handles kubectl get operations
 func handleGetResource(ctx context.Context, request mcp.CallToolRequest, sc *server.ServerContext) (*mcp.CallToolResult, error) {
 	args := request.GetArguments()
-	
+
 	kubeContext, _ := args["kubeContext"].(string)
-	
+
 	namespace, ok := args["namespace"].(string)
 	if !ok || namespace == "" {
 		return mcp.NewToolResultError("namespace is required"), nil
 	}
-	
+
 	resourceType, ok := args["resourceType"].(string)
 	if !ok || resourceType == "" {
 		return mcp.NewToolResultError("resourceType is required"), nil
 	}
-	
+
 	name, ok := args["name"].(string)
 	if !ok || name == "" {
 		return mcp.NewToolResultError("name is required"), nil
@@ -51,14 +51,14 @@ func handleGetResource(ctx context.Context, request mcp.CallToolRequest, sc *ser
 // handleListResources handles kubectl list operations
 func handleListResources(ctx context.Context, request mcp.CallToolRequest, sc *server.ServerContext) (*mcp.CallToolResult, error) {
 	args := request.GetArguments()
-	
+
 	kubeContext, _ := args["kubeContext"].(string)
-	
+
 	namespace, ok := args["namespace"].(string)
 	if !ok || namespace == "" {
 		return mcp.NewToolResultError("namespace is required"), nil
 	}
-	
+
 	resourceType, ok := args["resourceType"].(string)
 	if !ok || resourceType == "" {
 		return mcp.NewToolResultError("resourceType is required"), nil
@@ -96,19 +96,19 @@ func handleListResources(ctx context.Context, request mcp.CallToolRequest, sc *s
 // handleDescribeResource handles kubectl describe operations
 func handleDescribeResource(ctx context.Context, request mcp.CallToolRequest, sc *server.ServerContext) (*mcp.CallToolResult, error) {
 	args := request.GetArguments()
-	
+
 	kubeContext, _ := args["kubeContext"].(string)
-	
+
 	namespace, ok := args["namespace"].(string)
 	if !ok || namespace == "" {
 		return mcp.NewToolResultError("namespace is required"), nil
 	}
-	
+
 	resourceType, ok := args["resourceType"].(string)
 	if !ok || resourceType == "" {
 		return mcp.NewToolResultError("resourceType is required"), nil
 	}
-	
+
 	name, ok := args["name"].(string)
 	if !ok || name == "" {
 		return mcp.NewToolResultError("name is required"), nil
@@ -151,7 +151,7 @@ func handleCreateResource(ctx context.Context, request mcp.CallToolRequest, sc *
 	if err != nil {
 		return mcp.NewToolResultError("namespace is required"), nil
 	}
-	
+
 	manifestData, ok := request.GetArguments()["manifest"]
 	if !ok || manifestData == nil {
 		return mcp.NewToolResultError("manifest is required"), nil
@@ -205,7 +205,7 @@ func handleApplyResource(ctx context.Context, request mcp.CallToolRequest, sc *s
 	if err != nil {
 		return mcp.NewToolResultError("namespace is required"), nil
 	}
-	
+
 	manifestData, ok := request.GetArguments()["manifest"]
 	if !ok || manifestData == nil {
 		return mcp.NewToolResultError("manifest is required"), nil
@@ -259,12 +259,12 @@ func handleDeleteResource(ctx context.Context, request mcp.CallToolRequest, sc *
 	if err != nil {
 		return mcp.NewToolResultError("namespace is required"), nil
 	}
-	
+
 	resourceType, err := request.RequireString("resourceType")
 	if err != nil {
 		return mcp.NewToolResultError("resourceType is required"), nil
 	}
-	
+
 	name, err := request.RequireString("name")
 	if err != nil {
 		return mcp.NewToolResultError("name is required"), nil
@@ -301,12 +301,12 @@ func handlePatchResource(ctx context.Context, request mcp.CallToolRequest, sc *s
 	if err != nil {
 		return mcp.NewToolResultError("namespace is required"), nil
 	}
-	
+
 	resourceType, err := request.RequireString("resourceType")
 	if err != nil {
 		return mcp.NewToolResultError("resourceType is required"), nil
 	}
-	
+
 	name, err := request.RequireString("name")
 	if err != nil {
 		return mcp.NewToolResultError("name is required"), nil
@@ -378,12 +378,12 @@ func handleScaleResource(ctx context.Context, request mcp.CallToolRequest, sc *s
 	if err != nil {
 		return mcp.NewToolResultError("namespace is required"), nil
 	}
-	
+
 	resourceType, err := request.RequireString("resourceType")
 	if err != nil {
 		return mcp.NewToolResultError("resourceType is required"), nil
 	}
-	
+
 	name, err := request.RequireString("name")
 	if err != nil {
 		return mcp.NewToolResultError("name is required"), nil
@@ -400,4 +400,4 @@ func handleScaleResource(ctx context.Context, request mcp.CallToolRequest, sc *s
 	}
 
 	return mcp.NewToolResultText(fmt.Sprintf("Resource %s/%s scaled to %d replicas successfully", resourceType, name, int32(replicas))), nil
-} 
+}

--- a/internal/tools/resource/tools.go
+++ b/internal/tools/resource/tools.go
@@ -77,8 +77,8 @@ type ScaleResourceArgs struct {
 
 // RegisterResourceTools registers all resource management tools with the MCP server
 func RegisterResourceTools(s *mcpserver.MCPServer, sc *server.ServerContext) error {
-	// kubectl_get tool
-	getResourceTool := mcp.NewTool("kubectl_get",
+	// kubernetes_get tool
+	getResourceTool := mcp.NewTool("kubernetes_get",
 		mcp.WithDescription("Get a specific Kubernetes resource by name and namespace"),
 		mcp.WithString("kubeContext",
 			mcp.Description("Kubernetes context to use (optional, uses current context if not specified)"),
@@ -101,8 +101,8 @@ func RegisterResourceTools(s *mcpserver.MCPServer, sc *server.ServerContext) err
 		return handleGetResource(ctx, request, sc)
 	})
 
-	// kubectl_list tool
-	listResourceTool := mcp.NewTool("kubectl_list",
+	// kubernetes_list tool
+	listResourceTool := mcp.NewTool("kubernetes_list",
 		mcp.WithDescription("List Kubernetes resources of a specific type"),
 		mcp.WithString("kubeContext",
 			mcp.Description("Kubernetes context to use (optional, uses current context if not specified)"),
@@ -130,8 +130,8 @@ func RegisterResourceTools(s *mcpserver.MCPServer, sc *server.ServerContext) err
 		return handleListResources(ctx, request, sc)
 	})
 
-	// kubectl_describe tool
-	describeResourceTool := mcp.NewTool("kubectl_describe",
+	// kubernetes_describe tool
+	describeResourceTool := mcp.NewTool("kubernetes_describe",
 		mcp.WithDescription("Get detailed information about a Kubernetes resource including events"),
 		mcp.WithString("kubeContext",
 			mcp.Description("Kubernetes context to use (optional, uses current context if not specified)"),
@@ -154,8 +154,8 @@ func RegisterResourceTools(s *mcpserver.MCPServer, sc *server.ServerContext) err
 		return handleDescribeResource(ctx, request, sc)
 	})
 
-	// kubectl_create tool
-	createResourceTool := mcp.NewTool("kubectl_create",
+	// kubernetes_create tool
+	createResourceTool := mcp.NewTool("kubernetes_create",
 		mcp.WithDescription("Create a new Kubernetes resource from a manifest"),
 		mcp.WithString("kubeContext",
 			mcp.Description("Kubernetes context to use (optional, uses current context if not specified)"),
@@ -174,8 +174,8 @@ func RegisterResourceTools(s *mcpserver.MCPServer, sc *server.ServerContext) err
 		return handleCreateResource(ctx, request, sc)
 	})
 
-	// kubectl_apply tool
-	applyResourceTool := mcp.NewTool("kubectl_apply",
+	// kubernetes_apply tool
+	applyResourceTool := mcp.NewTool("kubernetes_apply",
 		mcp.WithDescription("Apply a Kubernetes manifest (create or update)"),
 		mcp.WithString("kubeContext",
 			mcp.Description("Kubernetes context to use (optional, uses current context if not specified)"),
@@ -194,8 +194,8 @@ func RegisterResourceTools(s *mcpserver.MCPServer, sc *server.ServerContext) err
 		return handleApplyResource(ctx, request, sc)
 	})
 
-	// kubectl_delete tool
-	deleteResourceTool := mcp.NewTool("kubectl_delete",
+	// kubernetes_delete tool
+	deleteResourceTool := mcp.NewTool("kubernetes_delete",
 		mcp.WithDescription("Delete a Kubernetes resource"),
 		mcp.WithString("kubeContext",
 			mcp.Description("Kubernetes context to use (optional, uses current context if not specified)"),
@@ -218,8 +218,8 @@ func RegisterResourceTools(s *mcpserver.MCPServer, sc *server.ServerContext) err
 		return handleDeleteResource(ctx, request, sc)
 	})
 
-	// kubectl_patch tool
-	patchResourceTool := mcp.NewTool("kubectl_patch",
+	// kubernetes_patch tool
+	patchResourceTool := mcp.NewTool("kubernetes_patch",
 		mcp.WithDescription("Patch a Kubernetes resource with specific changes"),
 		mcp.WithString("kubeContext",
 			mcp.Description("Kubernetes context to use (optional, uses current context if not specified)"),
@@ -251,8 +251,8 @@ func RegisterResourceTools(s *mcpserver.MCPServer, sc *server.ServerContext) err
 		return handlePatchResource(ctx, request, sc)
 	})
 
-	// kubectl_scale tool
-	scaleResourceTool := mcp.NewTool("kubectl_scale",
+	// kubernetes_scale tool
+	scaleResourceTool := mcp.NewTool("kubernetes_scale",
 		mcp.WithDescription("Scale a Kubernetes resource (deployment, replicaset, etc.)"),
 		mcp.WithString("kubeContext",
 			mcp.Description("Kubernetes context to use (optional, uses current context if not specified)"),
@@ -280,4 +280,4 @@ func RegisterResourceTools(s *mcpserver.MCPServer, sc *server.ServerContext) err
 	})
 
 	return nil
-} 
+}

--- a/main.go
+++ b/main.go
@@ -1,73 +1,16 @@
 package main
 
 import (
-	"context"
-	"fmt"
-	"log"
-	"os"
-	"os/signal"
-
-	"github.com/giantswarm/mcp-kubernetes/internal/server"
-	"github.com/giantswarm/mcp-kubernetes/internal/tools/cluster"
-	contexttools "github.com/giantswarm/mcp-kubernetes/internal/tools/context"
-	"github.com/giantswarm/mcp-kubernetes/internal/tools/helm"
-	"github.com/giantswarm/mcp-kubernetes/internal/tools/pod"
-	"github.com/giantswarm/mcp-kubernetes/internal/tools/resource"
-	mcpserver "github.com/mark3labs/mcp-go/server"
+	"github.com/giantswarm/mcp-kubernetes/cmd"
 )
 
+// version will be set by goreleaser during build
+var version = "dev"
+
 func main() {
-	// Setup context for server
-	ctx := context.Background()
+	// Set the version from build-time variable
+	cmd.SetVersion(version)
 
-	// Create server context with kubernetes client
-	serverContext, err := server.NewServerContext(ctx)
-	if err != nil {
-		log.Fatalf("Failed to create server context: %v", err)
-	}
-	defer func() {
-		if err := serverContext.Shutdown(); err != nil {
-			log.Printf("Error during server context shutdown: %v", err)
-		}
-	}()
-
-	// Create MCP server
-	mcpSrv := mcpserver.NewMCPServer("mcp-kubernetes", "1.0.0",
-		mcpserver.WithToolCapabilities(true),
-	)
-
-	// Register all tool categories
-	if err := resource.RegisterResourceTools(mcpSrv, serverContext); err != nil {
-		log.Fatalf("Failed to register resource tools: %v", err)
-	}
-
-	if err := pod.RegisterPodTools(mcpSrv, serverContext); err != nil {
-		log.Fatalf("Failed to register pod tools: %v", err)
-	}
-
-	if err := contexttools.RegisterContextTools(mcpSrv, serverContext); err != nil {
-		log.Fatalf("Failed to register context tools: %v", err)
-	}
-
-	if err := cluster.RegisterClusterTools(mcpSrv, serverContext); err != nil {
-		log.Fatalf("Failed to register cluster tools: %v", err)
-	}
-
-	if err := helm.RegisterHelmTools(mcpSrv, serverContext); err != nil {
-		log.Fatalf("Failed to register helm tools: %v", err)
-	}
-
-	fmt.Println("Starting MCP Kubernetes server...")
-
-	// Setup graceful shutdown
-	shutdownCtx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
-	defer cancel()
-
-	// Start stdio server
-	if err := mcpserver.ServeStdio(mcpSrv); err != nil {
-		log.Printf("Server stopped: %v", err)
-	}
-
-	<-shutdownCtx.Done()
-	fmt.Println("Server gracefully stopped")
+	// Execute the root command
+	cmd.Execute()
 }

--- a/test/integration/signal_handling_test.go
+++ b/test/integration/signal_handling_test.go
@@ -1,0 +1,105 @@
+package integration
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestServerGracefulShutdown(t *testing.T) {
+	// Skip if no kubectl is available (server depends on k8s config)
+	if _, err := exec.LookPath("kubectl"); err != nil {
+		t.Skip("kubectl not available, skipping integration test")
+	}
+
+	// Build the server binary for testing
+	buildCmd := exec.Command("go", "build", "-o", "/tmp/mcp-kubernetes-test", ".")
+	buildCmd.Dir = "../../" // Go back to project root
+	if err := buildCmd.Run(); err != nil {
+		t.Fatalf("Failed to build server: %v", err)
+	}
+	defer os.Remove("/tmp/mcp-kubernetes-test")
+
+	t.Run("SIGTERM handling", func(t *testing.T) {
+		testSignalHandling(t, syscall.SIGTERM)
+	})
+
+	t.Run("SIGINT handling", func(t *testing.T) {
+		testSignalHandling(t, syscall.SIGINT)
+	})
+}
+
+func testSignalHandling(t *testing.T, signal syscall.Signal) {
+	// Start the server process
+	cmd := exec.Command("/tmp/mcp-kubernetes-test")
+	cmd.Env = append(os.Environ(), "KUBECONFIG=/dev/null") // Prevent actual k8s connection
+
+	// Start the process
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Failed to start server: %v", err)
+	}
+
+	// Give the server a moment to start up
+	time.Sleep(100 * time.Millisecond)
+
+	// Send the signal
+	if err := cmd.Process.Signal(signal); err != nil {
+		t.Fatalf("Failed to send %s signal: %v", signal, err)
+	}
+
+	// Wait for the process to exit with a timeout
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+	}()
+
+	select {
+	case err := <-done:
+		// Process exited
+		if err != nil {
+			// Check if it's a normal exit or signal-related exit
+			if exitError, ok := err.(*exec.ExitError); ok {
+				// For signal handling, the process might exit with a non-zero code
+				// but that's expected when interrupted by a signal
+				t.Logf("Process exited with: %v", exitError)
+			} else {
+				t.Fatalf("Process exited with unexpected error: %v", err)
+			}
+		}
+		t.Logf("Server gracefully handled %s signal", signal)
+	case <-time.After(5 * time.Second):
+		// Force kill if it doesn't exit in time
+		if err := cmd.Process.Kill(); err != nil {
+			t.Logf("Failed to force kill process: %v", err)
+		}
+		t.Fatalf("Server did not exit within 5 seconds after %s signal", signal)
+	}
+}
+
+func TestServerContextCancellation(t *testing.T) {
+	// This test verifies that the server context propagates cancellation properly
+	// by checking that operations respect context cancellation
+
+	// Note: This is more of a unit test but placed here for integration context
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	// Simulate a long-running operation that should be cancelled
+	done := make(chan bool)
+	go func() {
+		select {
+		case <-ctx.Done():
+			done <- true
+		case <-time.After(1 * time.Second):
+			done <- false
+		}
+	}()
+
+	result := <-done
+	if !result {
+		t.Error("Context cancellation was not properly handled")
+	}
+}


### PR DESCRIPTION
This pull request introduces a new command-line interface (CLI) for the `mcp-kubernetes` application, built using the Cobra framework. The changes include the implementation of core commands (`serve`, `self-update`, and `version`), extensive transport options for the `serve` command, and associated unit tests to ensure functionality and robustness.

### Core CLI Implementation:
* [`cmd/root.go`](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR1-R64): Introduced the root command (`mcp-kubernetes`) as the entry point for the CLI. It defaults to the `serve` command when no subcommand is provided, ensuring backward compatibility. Added a `SetVersion` function to inject the application version dynamically.

### Subcommands:
* [`cmd/serve.go`](diffhunk://#diff-fb0c696bc104f613e5b601c77c2eba916dd636d5948c9b5c8e85ea92ee5b07e6R1-R322): Added the `serve` command to start the MCP Kubernetes server with multiple transport options (`stdio`, `sse`, `streamable-http`). Includes flags for Kubernetes client configuration (e.g., `non-destructive`, `dry-run`, `qps-limit`) and transport-specific settings (e.g., `http-addr`, `sse-endpoint`).
* [`cmd/selfupdate.go`](diffhunk://#diff-69a3d99c4d5a6fa28beb6a5bf56c328758de1a88c52df0ea6ee07146db3de10aR1-R82): Added the `self-update` command to update the binary to the latest GitHub release. Includes validation to prevent updates for development versions.

### Documentation and Testing:
* [`cmd/doc.go`](diffhunk://#diff-97903a98e2011083736a63bc1cf949deccbc07a31a5b965ddd8cb708c236c9dbR1-R33): Added comprehensive package-level documentation for the CLI, detailing command structure, transport options, and usage examples.
* Unit Tests:
  - [`cmd/root_test.go`](diffhunk://#diff-558a3da4e777c67907421d3d7da4d33b537fa8fba7c600b2938bb2d39fdb59faR1-R45): Verified root command properties and subcommand existence.
  - [`cmd/serve_test.go`](diffhunk://#diff-e5ffecbd89b883f1fcd7de6f84b6889a9128f0e4fa587f0c8bfe06cfa031e975R1-R153): Tested `serve` command properties, flags, default values, and transport validation.
  - [`cmd/selfupdate_test.go`](diffhunk://#diff-0ce505f5212a20e0e3f70b505810803e3b886d5a3ff677e5e7c13c9c9eccf62eR1-R71): Tested `self-update` command behavior and GitHub repository slug validation.