### PR TITLE
feat: implement comprehensive pagination for MCP tools

### DIFF
--- a/internal/tools/cluster/handlers.go
+++ b/internal/tools/cluster/handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/giantswarm/mcp-kubernetes/internal/server"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -15,13 +16,40 @@ func handleGetAPIResources(ctx context.Context, request mcp.CallToolRequest, sc 
 
 	kubeContext, _ := args["kubeContext"].(string)
 
-	resources, err := sc.K8sClient().GetAPIResources(ctx, kubeContext)
+	// Extract filter parameters
+	apiGroup, _ := args["apiGroup"].(string)
+	namespacedOnly, _ := args["namespaced"].(bool)
+	verbsStr, _ := args["verbs"].(string)
+
+	// Parse verbs
+	var verbs []string
+	if verbsStr != "" {
+		for _, verb := range strings.Split(verbsStr, ",") {
+			verbs = append(verbs, strings.TrimSpace(verb))
+		}
+	}
+
+	// Extract pagination parameters with sensible defaults
+	var limit, offset int = 20, 0 // Default page size for API resources
+	if limitVal, ok := args["limit"]; ok {
+		if limitFloat, ok := limitVal.(float64); ok {
+			limit = int(limitFloat)
+		}
+	}
+	if offsetVal, ok := args["offset"]; ok {
+		if offsetFloat, ok := offsetVal.(float64); ok {
+			offset = int(offsetFloat)
+		}
+	}
+
+	// Use paginated API (now the only API)
+	paginatedResponse, err := sc.K8sClient().GetAPIResources(ctx, kubeContext, limit, offset, apiGroup, namespacedOnly, verbs)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to get API resources: %v", err)), nil
 	}
 
-	// Convert resources to JSON for output
-	jsonData, err := json.MarshalIndent(resources, "", "  ")
+	// Convert paginated response to JSON
+	jsonData, err := json.MarshalIndent(paginatedResponse, "", "  ")
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to marshal API resources: %v", err)), nil
 	}

--- a/internal/tools/cluster/tools.go
+++ b/internal/tools/cluster/tools.go
@@ -25,6 +25,12 @@ func RegisterClusterTools(s *mcpserver.MCPServer, sc *server.ServerContext) erro
 		mcp.WithString("verbs",
 			mcp.Description("Filter by supported verbs (e.g., 'get,list,create') (optional)"),
 		),
+		mcp.WithNumber("limit",
+			mcp.Description("Maximum number of items to return per page (optional, default: 20, 0 = no limit)"),
+		),
+		mcp.WithNumber("offset",
+			mcp.Description("Number of items to skip (optional, for simple offset-based pagination)"),
+		),
 	)
 
 	s.AddTool(apiResourcesTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/internal/tools/pod/tools.go
+++ b/internal/tools/pod/tools.go
@@ -39,6 +39,12 @@ func RegisterPodTools(s *mcpserver.MCPServer, sc *server.ServerContext) error {
 		mcp.WithNumber("tailLines",
 			mcp.Description("Number of lines from the end of logs to show (optional)"),
 		),
+		mcp.WithNumber("sinceLines",
+			mcp.Description("Skip this many lines from the beginning (useful for pagination, optional)"),
+		),
+		mcp.WithNumber("maxLines",
+			mcp.Description("Maximum number of lines to return (useful for pagination, optional)"),
+		),
 	)
 
 	s.AddTool(logsTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/internal/tools/resource/tools.go
+++ b/internal/tools/resource/tools.go
@@ -27,6 +27,8 @@ type ListResourceArgs struct {
 	FullOutput         bool   `json:"fullOutput,omitempty"`
 	IncludeLabels      bool   `json:"includeLabels,omitempty"`
 	IncludeAnnotations bool   `json:"includeAnnotations,omitempty"`
+	Limit              int64  `json:"limit,omitempty"`
+	Continue           string `json:"continue,omitempty"`
 }
 
 // DescribeResourceArgs defines the arguments for kubectl describe operations
@@ -135,6 +137,12 @@ func RegisterResourceTools(s *mcpserver.MCPServer, sc *server.ServerContext) err
 		),
 		mcp.WithBoolean("includeAnnotations",
 			mcp.Description("Include resource annotations in summary output (default: false)"),
+		),
+		mcp.WithNumber("limit",
+			mcp.Description("Maximum number of items to return per page (optional, default: 20, 0 = no limit)"),
+		),
+		mcp.WithString("continue",
+			mcp.Description("Continue token from previous paginated request (optional)"),
 		),
 	)
 


### PR DESCRIPTION
- Add native Kubernetes pagination support using limit and continue tokens
- Implement offset-based pagination for API resources with filtering
- Add log pagination with sinceLines and maxLines parameters
- Set default limit of 20 items per page across all tools
- Add PaginatedListResponse and PaginatedSummaryResponse types
- Add PaginatedAPIResourceResponse for API resource pagination
- Update all MCP tools to support pagination parameters:
  * kubernetes_list: limit, continue token support
  * kubernetes_api_resources: limit, offset, filtering support
  * kubernetes_logs: sinceLines, maxLines support
- Simplify interface by making pagination the default behavior
- Remove backward compatibility code for cleaner implementation
- Make namespace optional when listing namespaces or using allNamespaces
- Maintain rich pagination metadata in all responses

All tools now return paginated results with continuation tokens and remaining item indicators for efficient handling of large datasets.