### PR TITLE
Don't expect a kubeconfig or context to exist at startup

### DIFF
--- a/internal/k8s/client_impl.go
+++ b/internal/k8s/client_impl.go
@@ -189,7 +189,7 @@ func NewClient(config *ClientConfig) (*kubernetesClient, error) {
 	}
 
 	// Validate current context exists
-	if _, exists := client.kubeconfigData.Contexts[client.currentContext]; !exists {
+	if _, exists := client.kubeconfigData.Contexts[client.currentContext]; !exists && client.currentContext != "" {
 		return nil, fmt.Errorf("context %q does not exist in kubeconfig", client.currentContext)
 	}
 


### PR DESCRIPTION
Fixes

```
Error: failed to create Kubernetes client: context "" does not exist in kubeconfig
```