### PR TITLE
Allow kubeconfig to be read from an environment variable if set

### DIFF
--- a/internal/k8s/client_impl.go
+++ b/internal/k8s/client_impl.go
@@ -3,6 +3,9 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -199,6 +202,18 @@ func NewClient(config *ClientConfig) (*kubernetesClient, error) {
 // loadKubeconfig loads the kubeconfig from the specified path or default locations.
 func (c *kubernetesClient) loadKubeconfig() error {
 	var err error
+
+	{
+		kconf := os.Getenv("KUBECONFIG")
+		if strings.HasPrefix(kconf, "~/") {
+			uhd, _ := os.UserHomeDir()
+			kconf = filepath.Join(uhd, kconf[2:])
+		}
+
+		if kconf != "" && c.config.KubeconfigPath == "" {
+			c.config.KubeconfigPath = kconf
+		}
+	}
 
 	// Load kubeconfig
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()


### PR DESCRIPTION
At the moment, the MCP server starts up with the default kubeconfig

This is problematic for users who have a per session kubeconfig so instead we allow the kubeconfig to be read from an environment variable given in the config as 

```
apiVersion: muster.giantswarm.io/v1alpha1
kind: MCPServer
metadata:
  name: kubernetes
  namespace: default
spec:
  type: localCommand
  ...
  env:
    KUBECONFIG: ~/.kube/mcp-kubeconfig
 ```
 
This, at the very least, allows the user to symlink the `mcp-kubeconfig` to another dedicated session kubeconfig in order to re-use / share the contexts from that config without the need to maintain a single multi-context config which may have a mix of test and production clusters, thereby reducing the blast radius of a mis-interpreted command.