### PR TITLE
feat(helm): Add CAPI Mode configuration to Helm chart

### DIFF
--- a/helm/mcp-kubernetes/templates/deployment.yaml
+++ b/helm/mcp-kubernetes/templates/deployment.yaml
@@ -170,6 +170,42 @@ spec:
               value: "true"
             {{- end }}
             {{- end }}
+            # CAPI Mode Configuration
+            {{- if .Values.capiMode.enabled }}
+            - name: CAPI_MODE_ENABLED
+              value: "true"
+            # Cache Configuration
+            - name: CLIENT_CACHE_TTL
+              value: {{ .Values.capiMode.cache.ttl | quote }}
+            - name: CLIENT_CACHE_MAX_ENTRIES
+              value: {{ .Values.capiMode.cache.maxEntries | quote }}
+            - name: CLIENT_CACHE_CLEANUP_INTERVAL
+              value: {{ .Values.capiMode.cache.cleanupInterval | quote }}
+            # Connectivity Configuration
+            - name: CONNECTIVITY_TIMEOUT
+              value: {{ .Values.capiMode.connectivity.timeout | quote }}
+            - name: CONNECTIVITY_RETRY_ATTEMPTS
+              value: {{ .Values.capiMode.connectivity.retryAttempts | quote }}
+            - name: CONNECTIVITY_RETRY_BACKOFF
+              value: {{ .Values.capiMode.connectivity.retryBackoff | quote }}
+            - name: CONNECTIVITY_REQUEST_TIMEOUT
+              value: {{ .Values.capiMode.connectivity.requestTimeout | quote }}
+            - name: CONNECTIVITY_QPS
+              value: {{ .Values.capiMode.connectivity.qps | quote }}
+            - name: CONNECTIVITY_BURST
+              value: {{ .Values.capiMode.connectivity.burst | quote }}
+            # Output Processing Configuration
+            - name: OUTPUT_MAX_ITEMS
+              value: {{ .Values.capiMode.output.maxItems | quote }}
+            - name: OUTPUT_MAX_CLUSTERS
+              value: {{ .Values.capiMode.output.maxClusters | quote }}
+            - name: OUTPUT_MAX_RESPONSE_BYTES
+              value: {{ .Values.capiMode.output.maxResponseBytes | quote }}
+            - name: OUTPUT_SLIM_MODE
+              value: {{ .Values.capiMode.output.slimOutput | quote }}
+            - name: OUTPUT_MASK_SECRETS
+              value: {{ .Values.capiMode.output.maskSecrets | quote }}
+            {{- end }}
             # Kubernetes metadata for OpenTelemetry resource attributes
             - name: K8S_NAMESPACE
               valueFrom:

--- a/helm/mcp-kubernetes/templates/rbac.yaml
+++ b/helm/mcp-kubernetes/templates/rbac.yaml
@@ -72,3 +72,136 @@ subjects:
     name: {{ include "mcp-kubernetes.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }}
+
+{{/*
+CAPI Mode RBAC - Only created when CAPI mode is enabled
+*/}}
+{{- if and .Values.serviceAccount.create .Values.capiMode.enabled .Values.capiMode.rbac.create }}
+---
+# ClusterRole for CAPI resource discovery and authentication
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "mcp-kubernetes.fullname" . }}-capi
+  labels:
+    {{- include "mcp-kubernetes.labels" . | nindent 4 }}
+rules:
+  # CAPI cluster discovery (read-only)
+  - apiGroups: ["cluster.x-k8s.io"]
+    resources:
+      - clusters
+      - clusters/status
+      - machinepools
+      - machinepools/status
+      - machinedeployments
+      - machinedeployments/status
+      - machines
+      - machines/status
+    verbs: ["get", "list", "watch"]
+
+  # Infrastructure provider resources (read-only, for cluster details)
+  - apiGroups: ["infrastructure.cluster.x-k8s.io"]
+    resources: ["*"]
+    verbs: ["get", "list"]
+
+  # TokenReviews for validating tokens
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["tokenreviews"]
+    verbs: ["create"]
+
+  # SubjectAccessReviews for pre-flight permission checks
+  - apiGroups: ["authorization.k8s.io"]
+    resources: ["subjectaccessreviews", "selfsubjectaccessreviews"]
+    verbs: ["create"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "mcp-kubernetes.fullname" . }}-capi
+  labels:
+    {{- include "mcp-kubernetes.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "mcp-kubernetes.fullname" . }}-capi
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "mcp-kubernetes.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+
+{{/*
+Cluster-wide secret access (only if explicitly enabled - NOT RECOMMENDED)
+WARNING: This grants access to ALL secrets in the cluster
+*/}}
+{{- if .Values.capiMode.rbac.clusterWideSecrets }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "mcp-kubernetes.fullname" . }}-secrets
+  labels:
+    {{- include "mcp-kubernetes.labels" . | nindent 4 }}
+  annotations:
+    # Security warning annotation
+    security.kubernetes.io/warning: "This role grants cluster-wide secret access. Use namespace-scoped roles instead."
+rules:
+  # HIGH PRIVILEGE - grants access to ALL secrets cluster-wide
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "mcp-kubernetes.fullname" . }}-secrets
+  labels:
+    {{- include "mcp-kubernetes.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "mcp-kubernetes.fullname" . }}-secrets
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "mcp-kubernetes.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}
+
+{{/*
+Namespace-scoped secret access (recommended)
+Creates Role and RoleBinding for each allowed namespace
+*/}}
+{{- range .Values.capiMode.rbac.allowedNamespaces }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "mcp-kubernetes.fullname" $ }}-secrets
+  namespace: {{ . }}
+  labels:
+    {{- include "mcp-kubernetes.labels" $ | nindent 4 }}
+rules:
+  # Access to kubeconfig secrets in this namespace
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "mcp-kubernetes.fullname" $ }}-secrets
+  namespace: {{ . }}
+  labels:
+    {{- include "mcp-kubernetes.labels" $ | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "mcp-kubernetes.fullname" $ }}-secrets
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "mcp-kubernetes.serviceAccountName" $ }}
+    namespace: {{ $.Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/helm/mcp-kubernetes/values-capi-production.yaml
+++ b/helm/mcp-kubernetes/values-capi-production.yaml
@@ -1,0 +1,161 @@
+# Example values for deploying mcp-kubernetes in CAPI Mode (Production)
+# This configuration enables multi-cluster federation via Cluster API.
+#
+# Prerequisites:
+# 1. Deploy on a CAPI Management Cluster
+# 2. Configure Dex OIDC for authentication
+# 3. Create organization namespaces (org-*) with kubeconfig secrets
+# 4. Set up proper TLS certificates for the ingress
+
+# Ingress configuration for external access
+ingress:
+  enabled: true
+  className: "nginx"
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+  hosts:
+    - host: mcp.g8s.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: mcp-kubernetes-tls
+      hosts:
+        - mcp.g8s.example.com
+
+# MCP Kubernetes specific configuration
+mcpKubernetes:
+  kubernetes:
+    # Use in-cluster configuration on the Management Cluster
+    inCluster: true
+
+  # OAuth 2.1 configuration with Dex
+  oauth:
+    enabled: true
+    provider: "dex"
+    baseURL: "https://mcp.g8s.example.com"
+    
+    dex:
+      # Dex issuer URL - the OIDC discovery endpoint
+      issuerURL: "https://dex.g8s.example.com"
+      # Dex OAuth Client ID
+      clientID: "mcp-kubernetes"
+      # Optional: bypass connector selection for better UX
+      # connectorID: "github"
+
+    # Use existing secret for OAuth credentials
+    # Create with:
+    # kubectl create secret generic mcp-kubernetes-oauth \
+    #   --from-literal=dex-client-secret=YOUR_SECRET \
+    #   --from-literal=registration-token=$(openssl rand -hex 32) \
+    #   --from-literal=oauth-encryption-key=$(openssl rand -base64 32)
+    existingSecret: "mcp-kubernetes-oauth"
+
+    # Security settings
+    allowPublicRegistration: false
+    encryptionKey: true
+    
+    # Enable downstream OAuth for Kubernetes API authentication
+    # User tokens are used for all Kubernetes API calls
+    enableDownstreamOAuth: true
+
+  # OpenTelemetry Instrumentation
+  instrumentation:
+    enabled: true
+    metricsExporter: "prometheus"
+    tracingExporter: "otlp"
+    otlpEndpoint: "tempo.monitoring.svc.cluster.local:4317"
+    otlpInsecure: true
+    traceSamplingRate: 0.1
+    detailedLabels: true
+    serviceMonitor:
+      enabled: true
+      labels:
+        release: prometheus
+
+  # Additional environment variables (if needed)
+  env: []
+
+# CAPI Mode Configuration
+capiMode:
+  enabled: true
+
+  # Client cache settings - tuned for production
+  cache:
+    # Match this to your OAuth token lifetime
+    ttl: "15m"
+    # Support many concurrent users across many clusters
+    maxEntries: 2000
+    cleanupInterval: "1m"
+
+  # Connectivity settings for workload clusters
+  connectivity:
+    timeout: "5s"
+    retryAttempts: 3
+    retryBackoff: "1s"
+    requestTimeout: "30s"
+    qps: 50
+    burst: 100
+
+  # Output processing limits
+  output:
+    maxItems: 100
+    maxClusters: 20
+    maxResponseBytes: 524288  # 512KB
+    slimOutput: true
+    maskSecrets: true
+
+  # RBAC for CAPI mode - namespace-scoped (recommended)
+  rbac:
+    create: true
+    # Grant access to organization namespaces
+    # Add all organization namespaces that contain workload clusters
+    allowedNamespaces:
+      - org-acme
+      - org-beta
+      - org-gamma
+    # Do NOT enable cluster-wide secret access in production
+    clusterWideSecrets: false
+
+# Resources for production workloads
+resources:
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+  requests:
+    cpu: 200m
+    memory: 256Mi
+
+# Enable horizontal pod autoscaling
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: 80
+
+# Pod security settings
+podSecurityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+  runAsNonRoot: true
+  fsGroup: 1000
+
+securityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  runAsUser: 1000
+  runAsGroup: 1000
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+  capabilities:
+    drop:
+    - ALL
+
+# Network policy for security
+ciliumNetworkPolicy:
+  enabled: true
+

--- a/helm/mcp-kubernetes/values.schema.json
+++ b/helm/mcp-kubernetes/values.schema.json
@@ -292,6 +292,130 @@
         }
       }
     },
+    "capiMode": {
+      "type": "object",
+      "description": "CAPI Mode configuration for multi-cluster federation",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable CAPI federation mode"
+        },
+        "cache": {
+          "type": "object",
+          "description": "Client cache settings for workload cluster connections",
+          "properties": {
+            "ttl": {
+              "type": "string",
+              "description": "Time-to-live for cached clients (e.g., '10m')",
+              "pattern": "^[0-9]+(s|m|h)$"
+            },
+            "maxEntries": {
+              "type": "integer",
+              "description": "Maximum number of cached (cluster, user) pairs",
+              "minimum": 1,
+              "maximum": 10000
+            },
+            "cleanupInterval": {
+              "type": "string",
+              "description": "How often to clean up expired entries (e.g., '1m')",
+              "pattern": "^[0-9]+(s|m|h)$"
+            }
+          }
+        },
+        "connectivity": {
+          "type": "object",
+          "description": "Connectivity settings for workload clusters",
+          "properties": {
+            "timeout": {
+              "type": "string",
+              "description": "Timeout for initial TCP connection (e.g., '5s')",
+              "pattern": "^[0-9]+(s|m|h)$"
+            },
+            "retryAttempts": {
+              "type": "integer",
+              "description": "Number of retry attempts for transient failures",
+              "minimum": 0,
+              "maximum": 10
+            },
+            "retryBackoff": {
+              "type": "string",
+              "description": "Initial backoff between retries (e.g., '1s')",
+              "pattern": "^[0-9]+(s|m|h)$"
+            },
+            "requestTimeout": {
+              "type": "string",
+              "description": "Request timeout for API operations (e.g., '30s')",
+              "pattern": "^[0-9]+(s|m|h)$"
+            },
+            "qps": {
+              "type": "integer",
+              "description": "QPS rate limit for Kubernetes client",
+              "minimum": 1,
+              "maximum": 1000
+            },
+            "burst": {
+              "type": "integer",
+              "description": "Burst limit for Kubernetes client",
+              "minimum": 1,
+              "maximum": 2000
+            }
+          }
+        },
+        "output": {
+          "type": "object",
+          "description": "Output processing limits for fleet-scale operations",
+          "properties": {
+            "maxItems": {
+              "type": "integer",
+              "description": "Maximum items per query (absolute max: 1000)",
+              "minimum": 1,
+              "maximum": 1000
+            },
+            "maxClusters": {
+              "type": "integer",
+              "description": "Maximum clusters in fleet-wide queries (absolute max: 100)",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "maxResponseBytes": {
+              "type": "integer",
+              "description": "Maximum response size in bytes (absolute max: 2MB)",
+              "minimum": 1024,
+              "maximum": 2097152
+            },
+            "slimOutput": {
+              "type": "boolean",
+              "description": "Enable slim output (removes verbose fields)"
+            },
+            "maskSecrets": {
+              "type": "boolean",
+              "description": "Mask secret data with ***REDACTED***"
+            }
+          }
+        },
+        "rbac": {
+          "type": "object",
+          "description": "RBAC configuration for CAPI mode",
+          "properties": {
+            "create": {
+              "type": "boolean",
+              "description": "Create CAPI-specific RBAC resources"
+            },
+            "allowedNamespaces": {
+              "type": "array",
+              "description": "Namespaces to grant kubeconfig secret access",
+              "items": {
+                "type": "string"
+              }
+            },
+            "clusterWideSecrets": {
+              "type": "boolean",
+              "description": "Grant cluster-wide secret access (NOT recommended)"
+            }
+          }
+        }
+      }
+    },
     "ciliumNetworkPolicy": {
       "type": "object",
       "properties": {

--- a/helm/mcp-kubernetes/values.yaml
+++ b/helm/mcp-kubernetes/values.yaml
@@ -212,6 +212,63 @@ mcpKubernetes:
   # - name: EXAMPLE_VAR
   #   value: "example-value"
 
+# CAPI Mode Configuration
+# When enabled, the MCP server operates as a multi-cluster federation gateway
+# using Cluster API (CAPI) for cluster discovery and kubeconfig retrieval.
+capiMode:
+  # Enable CAPI federation mode
+  enabled: false
+
+  # Client cache settings for workload cluster connections
+  cache:
+    # Time-to-live for cached clients
+    # Security: Set this to be <= your OAuth token lifetime
+    ttl: "10m"
+    # Maximum number of cached (cluster, user) pairs
+    maxEntries: 1000
+    # How often to clean up expired entries
+    cleanupInterval: "1m"
+
+  # Connectivity settings for workload clusters
+  connectivity:
+    # Timeout for initial TCP connection
+    timeout: "5s"
+    # Number of retry attempts for transient failures
+    retryAttempts: 3
+    # Initial backoff between retries (exponential)
+    retryBackoff: "1s"
+    # Request timeout for API operations
+    requestTimeout: "30s"
+    # QPS rate limit for Kubernetes client
+    qps: 50
+    # Burst limit for Kubernetes client
+    burst: 100
+
+  # Output processing limits for fleet-scale operations
+  output:
+    # Maximum items per query (absolute max: 1000)
+    maxItems: 100
+    # Maximum clusters in fleet-wide queries (absolute max: 100)
+    maxClusters: 20
+    # Maximum response size in bytes (absolute max: 2MB)
+    maxResponseBytes: 524288  # 512KB
+    # Enable slim output (removes verbose fields)
+    slimOutput: true
+    # Mask secret data with "***REDACTED***"
+    maskSecrets: true
+
+  # RBAC configuration for CAPI mode
+  rbac:
+    # Create CAPI-specific RBAC resources
+    create: true
+    # Namespaces to grant kubeconfig secret access
+    # Use [] for cluster-wide access (not recommended)
+    # Giant Swarm convention: org-* namespaces
+    allowedNamespaces: []
+    # When allowedNamespaces is empty and clusterWideSecrets is true,
+    # grants cluster-wide secret access (use with caution)
+    clusterWideSecrets: false
+
 # Cilium Network Policy configuration
 ciliumNetworkPolicy:
   # Specifies whether a CiliumNetworkPolicy should be created


### PR DESCRIPTION
## Summary

This PR updates the Helm chart to support CAPI Mode deployment, enabling multi-cluster federation via Cluster API.

**Epic:** #104 - Multi-Cluster Federation via CAPI and Secure OAuth Impersonation

## Changes

### values.yaml
- Added `capiMode` configuration section with:
  - `enabled`: Enable/disable CAPI federation mode
  - `cache`: Client cache settings (TTL, maxEntries, cleanupInterval)
  - `connectivity`: Network settings (timeout, retryAttempts, retryBackoff, requestTimeout, QPS, burst)
  - `output`: Response limits (maxItems, maxClusters, maxResponseBytes, slimOutput, maskSecrets)
  - `rbac`: CAPI-specific RBAC configuration

### deployment.yaml
- Added environment variable mappings for all CAPI mode settings
- Environment variables are only set when `capiMode.enabled: true`

### rbac.yaml
- Added ClusterRole for CAPI resource discovery (cluster.x-k8s.io resources)
- Added ClusterRole for authentication/authorization APIs
- Added namespace-scoped Roles for kubeconfig secret access (recommended)
- Added optional cluster-wide secret access (not recommended, requires explicit opt-in)

### values.schema.json
- Added JSON schema definitions for all new configuration fields
- Includes validation patterns for duration strings and numeric limits

### values-capi-production.yaml
- Added production-ready example values file
- Documents best practices for CAPI mode deployment

### README.md
- Documented CAPI mode configuration options
- Added CAPI Mode installation guide
- Documented RBAC permissions for CAPI mode
- Added security considerations for secret access

## Security Considerations

The RBAC design follows the principle of least privilege:
- **Namespace-scoped secret access** is the default (recommended)
- **Cluster-wide secret access** requires explicit opt-in (`clusterWideSecrets: true`)
- CAPI resource access is read-only
- Cache TTL should match OAuth token lifetime

## Testing

- [x] `helm lint` passes
- [x] `helm template` renders correctly with CAPI mode enabled
- [x] Namespace-scoped RBAC resources created correctly
- [x] Environment variables properly mapped
- [x] All unit tests pass

Closes #116