### PR TITLE
docs: Clarify RBAC usage in Service Account vs OAuth Downstream modes

### DIFF
--- a/helm/mcp-kubernetes/templates/rbac.yaml
+++ b/helm/mcp-kubernetes/templates/rbac.yaml
@@ -1,3 +1,23 @@
+{{/*
+RBAC Configuration for mcp-kubernetes
+
+IMPORTANT: Authentication Mode Context
+======================================
+The RBAC resources in this file are used ONLY when OAuth Downstream is DISABLED.
+
+When enableDownstreamOAuth: false (Service Account Mode):
+  - These ClusterRoles/Roles grant permissions to the ServiceAccount
+  - All Kubernetes API operations use the ServiceAccount's identity
+  - All users share the ServiceAccount's RBAC permissions
+
+When enableDownstreamOAuth: true (OAuth Downstream Mode):
+  - These RBAC resources are NOT used for Kubernetes API operations
+  - User's OAuth token authenticates directly to the Management Cluster
+  - Users must have their own RBAC permissions on both MC and WCs
+  - The ServiceAccount only needs permissions for pod lifecycle (network, etc.)
+
+See docs/rbac-security.md for detailed requirements per deployment mode.
+*/}}
 {{- if .Values.serviceAccount.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -5,8 +25,19 @@ metadata:
   name: {{ include "mcp-kubernetes.fullname" . }}
   labels:
     {{- include "mcp-kubernetes.labels" . | nindent 4 }}
+  {{- if not .Values.mcpKubernetes.oauth.enableDownstreamOAuth }}
+  annotations:
+    # This ClusterRole is actively used for Kubernetes API operations
+    mcp-kubernetes.giantswarm.io/rbac-mode: "service-account"
+  {{- else }}
+  annotations:
+    # OAuth Downstream is enabled - this RBAC is NOT used for API operations
+    # Users must have their own RBAC permissions
+    mcp-kubernetes.giantswarm.io/rbac-mode: "oauth-downstream"
+    mcp-kubernetes.giantswarm.io/note: "ServiceAccount RBAC not used when enableDownstreamOAuth is true"
+  {{- end }}
 rules:
-  # Core resources
+  # Core resources (used in Service Account Mode only)
   - apiGroups: [""]
     resources: ["pods", "services", "endpoints", "nodes", "namespaces", "configmaps", "secrets", "persistentvolumes", "persistentvolumeclaims", "events"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
@@ -75,18 +106,29 @@ subjects:
 
 {{/*
 CAPI Mode RBAC - Only created when CAPI mode is enabled
+
+NOTE: Like the base RBAC above, this is for Service Account Mode.
+When enableDownstreamOAuth is true, users need equivalent permissions
+in their own RoleBindings/ClusterRoleBindings.
 */}}
 {{- if and .Values.serviceAccount.create .Values.capiMode.enabled .Values.capiMode.rbac.create }}
 ---
 # ClusterRole for CAPI resource discovery and authentication
+# NOTE: Used by ServiceAccount when enableDownstreamOAuth: false
+#       Users need equivalent RBAC when enableDownstreamOAuth: true
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "mcp-kubernetes.fullname" . }}-capi
   labels:
     {{- include "mcp-kubernetes.labels" . | nindent 4 }}
+  {{- if .Values.mcpKubernetes.oauth.enableDownstreamOAuth }}
+  annotations:
+    mcp-kubernetes.giantswarm.io/note: "Users need these permissions in their own RBAC when OAuth Downstream is enabled"
+  {{- end }}
 rules:
   # CAPI cluster discovery (read-only)
+  # In OAuth Downstream mode, users need this permission in their own ClusterRoleBinding
   - apiGroups: ["cluster.x-k8s.io"]
     resources:
       - clusters
@@ -174,6 +216,10 @@ subjects:
 {{/*
 Namespace-scoped secret access (recommended)
 Creates Role and RoleBinding for each allowed namespace
+
+NOTE: For kubeconfig secret retrieval in CAPI mode.
+- Service Account Mode: ServiceAccount needs this to read kubeconfig secrets
+- OAuth Downstream Mode: Users need equivalent Role/RoleBinding in their own RBAC
 */}}
 {{- range .Values.capiMode.rbac.allowedNamespaces }}
 ---
@@ -184,8 +230,13 @@ metadata:
   namespace: {{ . }}
   labels:
     {{- include "mcp-kubernetes.labels" $ | nindent 4 }}
+  {{- if $.Values.mcpKubernetes.oauth.enableDownstreamOAuth }}
+  annotations:
+    mcp-kubernetes.giantswarm.io/note: "Users need this permission in namespace {{ . }} when OAuth Downstream is enabled"
+  {{- end }}
 rules:
   # Access to kubeconfig secrets in this namespace
+  # In OAuth Downstream mode, users need this permission via their own RoleBinding
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get"]

--- a/helm/mcp-kubernetes/values.yaml
+++ b/helm/mcp-kubernetes/values.yaml
@@ -161,6 +161,15 @@ mcpKubernetes:
     # Enable downstream OAuth token passthrough to Kubernetes API
     # When enabled, user OAuth tokens are used for Kubernetes authentication
     # Requires inCluster mode and Kubernetes cluster configured with OIDC
+    #
+    # CRITICAL: This setting fundamentally changes the security model:
+    #   - When FALSE: ServiceAccount RBAC (from this chart) is used for all K8s API calls
+    #   - When TRUE:  User's OAuth token is used; ServiceAccount RBAC is NOT used
+    #
+    # In CAPI Mode with enableDownstreamOAuth: true:
+    #   - Management Cluster: User's OAuth token authenticates directly
+    #   - Workload Clusters: User identity is propagated via impersonation headers
+    #   - Users must have their own RBAC permissions (not the ServiceAccount's)
     enableDownstreamOAuth: false
     # Use an existing secret for OAuth credentials
     # The secret should contain keys: google-client-id, google-client-secret, dex-client-secret, registration-token, oauth-encryption-key (optional)
@@ -215,6 +224,21 @@ mcpKubernetes:
 # CAPI Mode Configuration
 # When enabled, the MCP server operates as a multi-cluster federation gateway
 # using Cluster API (CAPI) for cluster discovery and kubeconfig retrieval.
+#
+# IMPORTANT: RBAC Behavior in CAPI Mode
+# --------------------------------------
+# The RBAC resources created by this chart (ClusterRoles, Roles, RoleBindings)
+# are ONLY used when OAuth Downstream is DISABLED (enableDownstreamOAuth: false).
+#
+# When OAuth Downstream is ENABLED (enableDownstreamOAuth: true):
+#   - The ServiceAccount RBAC is NOT used for Kubernetes API operations
+#   - Users must have their own RBAC permissions on the Management Cluster to:
+#     * List CAPI Cluster resources (cluster.x-k8s.io/clusters)
+#     * Read kubeconfig secrets in organization namespaces
+#   - On Workload Clusters, user identity is propagated via impersonation headers
+#   - Users need appropriate RBAC on each Workload Cluster they access
+#
+# See docs/rbac-security.md for detailed RBAC requirements per deployment mode.
 capiMode:
   # Enable CAPI federation mode
   enabled: false
@@ -258,8 +282,10 @@ capiMode:
     maskSecrets: true
 
   # RBAC configuration for CAPI mode
+  # NOTE: This RBAC is for the ServiceAccount and is ONLY used when
+  # enableDownstreamOAuth is FALSE. See the oauth section above.
   rbac:
-    # Create CAPI-specific RBAC resources
+    # Create CAPI-specific RBAC resources (for ServiceAccount mode only)
     create: true
     # Namespaces to grant kubeconfig secret access
     # Use [] for cluster-wide access (not recommended)


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation and comments explaining when the Helm chart's RBAC resources are used vs when users need their own RBAC permissions.

## Problem

The relationship between ServiceAccount RBAC (created by the Helm chart) and OAuth Downstream mode was not immediately clear. Users could be confused about:
1. When the Helm chart's RBAC resources are actually used
2. What RBAC users need in OAuth Downstream mode
3. How impersonation works on Workload Clusters

## Changes

### `helm/mcp-kubernetes/values.yaml`
- Added explanatory comments for `capiMode` section explaining RBAC behavior
- Added detailed comments for `enableDownstreamOAuth` explaining the security model difference

### `helm/mcp-kubernetes/templates/rbac.yaml`
- Added comprehensive header comment explaining both modes
- Added conditional annotations that indicate which RBAC mode is active:
  - `mcp-kubernetes.giantswarm.io/rbac-mode: service-account` when OAuth Downstream is disabled
  - `mcp-kubernetes.giantswarm.io/rbac-mode: oauth-downstream` when enabled
- Added helpful notes to namespace-scoped secret access Roles

### `docs/rbac-security.md`
- Added TL;DR section with quick reference table
- Added clearer explanation of how MC vs WC authentication differs
- Explained the impersonation flow for Workload Clusters

## Key Insight

The Helm chart RBAC is **ONLY used when `enableDownstreamOAuth` is `false`** (Service Account mode). When OAuth Downstream is enabled, users authenticate with their own OAuth tokens and need their own RBAC bindings.

Closes #138