### PR TITLE
fix(helm): remove trailing spaces from values.yaml

### DIFF
--- a/helm/mcp-kubernetes/values.yaml
+++ b/helm/mcp-kubernetes/values.yaml
@@ -35,7 +35,7 @@ serviceAccount:
 rbac:
   # Create RBAC resources (ClusterRole and ClusterRoleBinding)
   create: true
-  
+
   # RBAC profile controls the permission level
   # Options:
   #   - "minimal":  Only pod lifecycle permissions (for downstream OAuth mode)
@@ -51,7 +51,7 @@ rbac:
   # WARNING: "standard" profile grants CLUSTER-WIDE SECRET ACCESS.
   # Consider using "readonly" if you don't need write operations.
   profile: "standard"
-  
+
   # REQUIRED when using profile: "admin"
   # The admin profile grants dangerous permissions:
   #   - RBAC management (privilege escalation risk)
@@ -59,7 +59,7 @@ rbac:
   #   - Webhook configurations (API interception risk)
   # You must set this to true to acknowledge these risks.
   adminConfirmation: false
-  
+
   # Custom RBAC rules (overrides profile when enabled)
   #
   # WARNING: Custom rules BYPASS ALL PROFILE SAFETY CONTROLS!


### PR DESCRIPTION
Fix YAML linting errors caused by trailing whitespace on empty lines in the RBAC configuration section.

This fixes the CI failure in the Helm chart linter:

```
helm/mcp-kubernetes/values.yaml
  38:1      error    trailing spaces  (trailing-spaces)
  54:1      error    trailing spaces  (trailing-spaces)
  62:1      error    trailing spaces  (trailing-spaces)
```