### PR TITLE
chore(deps): upgrade mcp-oauth to v0.2.15

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.25.5
 
 require (
 	github.com/creativeprojects/go-selfupdate v1.5.1
-	github.com/giantswarm/mcp-oauth v0.2.14
+	github.com/giantswarm/mcp-oauth v0.2.15
 	github.com/mark3labs/mcp-go v0.43.2
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/giantswarm/mcp-oauth v0.2.14 h1:udSWaVSzkPsfgQTKoQI72rhJiSSYY7DzCLzGkDL/EPE=
-github.com/giantswarm/mcp-oauth v0.2.14/go.mod h1:Ro8Gv2L57lcM2P8ZHyFzEAFd9F+puETlHlq/hkQOvNo=
+github.com/giantswarm/mcp-oauth v0.2.15 h1:2RDQBhgIuwlkefwKZvuU5Z1bUIvNapRy63wx4jc+wKw=
+github.com/giantswarm/mcp-oauth v0.2.15/go.mod h1:Ro8Gv2L57lcM2P8ZHyFzEAFd9F+puETlHlq/hkQOvNo=
 github.com/go-fed/httpsig v1.1.0 h1:9M+hb0jkEICD8/cAiNqEB66R87tTINszBRTjwjQzWcI=
 github.com/go-fed/httpsig v1.1.0/go.mod h1:RCMrTZvN1bJYtofsG4rd5NaO5obxQ5xBkdiS7xsT7bM=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=


### PR DESCRIPTION
Upgrade github.com/giantswarm/mcp-oauth from v0.2.14 to v0.2.15.