### PR TITLE
fix(oauth): add --allow-private-oauth-urls flag for internal deployments

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -118,6 +118,7 @@ func newServeCmd() *cobra.Command {
 		registrationToken             string
 		allowPublicRegistration       bool
 		allowInsecureAuthWithoutState bool
+		allowPrivateOAuthURLs         bool
 		maxClientsPerIP               int
 		oauthEncryptionKey            string
 		downstreamOAuth               bool
@@ -199,6 +200,7 @@ Downstream OAuth (--downstream-oauth):
 					RegistrationToken:             registrationToken,
 					AllowPublicRegistration:       allowPublicRegistration,
 					AllowInsecureAuthWithoutState: allowInsecureAuthWithoutState,
+					AllowPrivateURLs:              allowPrivateOAuthURLs,
 					MaxClientsPerIP:               maxClientsPerIP,
 					EncryptionKey:                 oauthEncryptionKey,
 					Storage:                       storageConfig,
@@ -238,6 +240,7 @@ Downstream OAuth (--downstream-oauth):
 	cmd.Flags().StringVar(&registrationToken, "registration-token", "", "OAuth client registration access token (required if public registration is disabled)")
 	cmd.Flags().BoolVar(&allowPublicRegistration, "allow-public-registration", false, "Allow unauthenticated OAuth client registration (NOT RECOMMENDED for production)")
 	cmd.Flags().BoolVar(&allowInsecureAuthWithoutState, "allow-insecure-auth-without-state", false, "Allow authorization requests without state parameter (for older MCP client compatibility)")
+	cmd.Flags().BoolVar(&allowPrivateOAuthURLs, "allow-private-oauth-urls", false, "Allow OAuth URLs that resolve to private/internal IP addresses (for internal deployments)")
 	cmd.Flags().IntVar(&maxClientsPerIP, "max-clients-per-ip", 10, "Maximum number of OAuth clients that can be registered per IP address")
 	cmd.Flags().StringVar(&oauthEncryptionKey, "oauth-encryption-key", "", "AES-256 encryption key for token encryption (32 bytes, can also be set via OAUTH_ENCRYPTION_KEY env var)")
 	cmd.Flags().BoolVar(&downstreamOAuth, "downstream-oauth", false, "Use OAuth access tokens for downstream Kubernetes API authentication (requires --enable-oauth and --in-cluster)")
@@ -556,7 +559,7 @@ func runServe(config ServeConfig) error {
 				return fmt.Errorf("--oauth-base-url is required when --enable-oauth is set")
 			}
 			// Validate OAuth base URL is HTTPS and not vulnerable to SSRF
-			if err := validateSecureURL(config.OAuth.BaseURL, "OAuth base URL"); err != nil {
+			if err := validateSecureURL(config.OAuth.BaseURL, "OAuth base URL", config.OAuth.AllowPrivateURLs); err != nil {
 				return err
 			}
 
@@ -567,7 +570,7 @@ func runServe(config ServeConfig) error {
 					return fmt.Errorf("dex issuer URL is required when using Dex provider (--dex-issuer-url or DEX_ISSUER_URL)")
 				}
 				// Validate Dex issuer URL is HTTPS and not vulnerable to SSRF
-				if err := validateSecureURL(config.OAuth.DexIssuerURL, "Dex issuer URL"); err != nil {
+				if err := validateSecureURL(config.OAuth.DexIssuerURL, "Dex issuer URL", config.OAuth.AllowPrivateURLs); err != nil {
 					return err
 				}
 				if config.OAuth.DexClientID == "" {

--- a/cmd/serve_config_test.go
+++ b/cmd/serve_config_test.go
@@ -74,7 +74,7 @@ func TestValidateSecureURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateSecureURL(tt.url, tt.fieldName)
+			err := validateSecureURL(tt.url, tt.fieldName, false)
 			if tt.wantErr {
 				assert.Error(t, err)
 				if tt.errMsg != "" {
@@ -85,6 +85,16 @@ func TestValidateSecureURL(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestValidateSecureURLAllowPrivate tests URL validation with allowPrivate=true
+func TestValidateSecureURLAllowPrivate(t *testing.T) {
+	// With allowPrivate=true, private IPs should be allowed
+	// This simulates a URL that would normally be blocked due to private IP
+	err := validateSecureURL("https://internal.example.com", "test URL", true)
+	// Since we can't control DNS resolution in tests, just verify the function accepts the parameter
+	// and doesn't panic. Real private IP testing would require mocking net.LookupIP
+	_ = err
 }
 
 // TestIsPrivateOrLoopbackIP tests private/loopback IP detection

--- a/cmd/serve_validation_test.go
+++ b/cmd/serve_validation_test.go
@@ -275,7 +275,7 @@ func validateOAuthConfig(config OAuthServeConfig) error {
 		return fmt.Errorf("--oauth-base-url is required when --enable-oauth is set")
 	}
 	// Validate OAuth base URL is HTTPS and not vulnerable to SSRF
-	if err := validateSecureURL(config.BaseURL, "OAuth base URL"); err != nil {
+	if err := validateSecureURL(config.BaseURL, "OAuth base URL", config.AllowPrivateURLs); err != nil {
 		return err
 	}
 
@@ -286,7 +286,7 @@ func validateOAuthConfig(config OAuthServeConfig) error {
 			return fmt.Errorf("dex issuer URL is required when using Dex provider (--dex-issuer-url or DEX_ISSUER_URL)")
 		}
 		// Validate Dex issuer URL is HTTPS and not vulnerable to SSRF
-		if err := validateSecureURL(config.DexIssuerURL, "Dex issuer URL"); err != nil {
+		if err := validateSecureURL(config.DexIssuerURL, "Dex issuer URL", config.AllowPrivateURLs); err != nil {
 			return err
 		}
 		if config.DexClientID == "" {

--- a/helm/mcp-kubernetes/templates/deployment.yaml
+++ b/helm/mcp-kubernetes/templates/deployment.yaml
@@ -68,6 +68,9 @@ spec:
             {{- else }}
             - --allow-insecure-auth-without-state=false
             {{- end }}
+            {{- if .Values.mcpKubernetes.oauth.allowPrivateURLs }}
+            - --allow-private-oauth-urls=true
+            {{- end }}
             - --max-clients-per-ip={{ .Values.mcpKubernetes.oauth.maxClientsPerIP }}
             {{- if .Values.mcpKubernetes.oauth.disableStreaming }}
             - --disable-streaming=true

--- a/helm/mcp-kubernetes/values.schema.json
+++ b/helm/mcp-kubernetes/values.schema.json
@@ -309,6 +309,10 @@
             "allowInsecureAuthWithoutState": {
               "type": "boolean"
             },
+            "allowPrivateURLs": {
+              "type": "boolean",
+              "description": "Allow OAuth URLs that resolve to private/internal IP addresses (for internal deployments)"
+            },
             "maxClientsPerIP": {
               "type": "integer"
             },


### PR DESCRIPTION
## Summary

Add new flag `--allow-private-oauth-urls` that allows OAuth base URL and Dex issuer URL to resolve to private/internal IP addresses. This is required for internal/enterprise deployments where services resolve to private IPs.

## Problem

Several clusters are failing to start mcp-kubernetes 0.0.80 with:

```
Error: OAuth base URL resolves to a private or loopback IP address (10.x.x.x), which could be a security risk
```

This security check was added in 0.0.80 to prevent SSRF attacks, but it's too strict for internal deployments where OAuth URLs legitimately resolve to private IPs.

## Solution

Add a new flag `--allow-private-oauth-urls` (and corresponding Helm value `mcpKubernetes.oauth.allowPrivateURLs`) that skips the private IP validation when set to true.

## Usage

### CLI
```bash
mcp-kubernetes serve --enable-oauth --allow-private-oauth-urls ...
```

### Helm values
```yaml
mcpKubernetes:
  oauth:
    enabled: true
    allowPrivateURLs: true  # Allow URLs that resolve to private IPs
```

## Testing

- Unit tests updated and passing
- Linter passing