### PR TITLE
feat(oauth): add --dex-ca-file flag for private CA support

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -124,6 +124,7 @@ func newServeCmd() *cobra.Command {
 		dexClientID                   string
 		dexClientSecret               string
 		dexConnectorID                string
+		dexCAFile                     string
 		disableStreaming              bool
 		registrationToken             string
 		allowPublicRegistration       bool
@@ -207,6 +208,7 @@ Downstream OAuth (--downstream-oauth):
 					DexClientID:                   dexClientID,
 					DexClientSecret:               dexClientSecret,
 					DexConnectorID:                dexConnectorID,
+					DexCAFile:                     dexCAFile,
 					DisableStreaming:              disableStreaming,
 					RegistrationToken:             registrationToken,
 					AllowPublicRegistration:       allowPublicRegistration,
@@ -247,6 +249,7 @@ Downstream OAuth (--downstream-oauth):
 	cmd.Flags().StringVar(&dexClientID, "dex-client-id", "", "Dex OAuth Client ID (can also be set via DEX_CLIENT_ID env var)")
 	cmd.Flags().StringVar(&dexClientSecret, "dex-client-secret", "", "Dex OAuth Client Secret (can also be set via DEX_CLIENT_SECRET env var)")
 	cmd.Flags().StringVar(&dexConnectorID, "dex-connector-id", "", "Dex connector ID to bypass connector selection (optional, can also be set via DEX_CONNECTOR_ID env var)")
+	cmd.Flags().StringVar(&dexCAFile, "dex-ca-file", "", "Path to CA certificate file for Dex TLS verification (optional, can also be set via DEX_CA_FILE env var)")
 	cmd.Flags().BoolVar(&disableStreaming, "disable-streaming", false, "Disable streaming for streamable-http transport")
 	cmd.Flags().StringVar(&registrationToken, "registration-token", "", "OAuth client registration access token (required if public registration is disabled)")
 	cmd.Flags().BoolVar(&allowPublicRegistration, "allow-public-registration", false, "Allow unauthenticated OAuth client registration (NOT RECOMMENDED for production)")
@@ -565,6 +568,7 @@ func runServe(config ServeConfig) error {
 			loadEnvIfEmpty(&config.OAuth.DexClientID, "DEX_CLIENT_ID")
 			loadEnvIfEmpty(&config.OAuth.DexClientSecret, "DEX_CLIENT_SECRET")
 			loadEnvIfEmpty(&config.OAuth.DexConnectorID, "DEX_CONNECTOR_ID")
+			loadEnvIfEmpty(&config.OAuth.DexCAFile, "DEX_CA_FILE")
 			loadEnvIfEmpty(&config.OAuth.EncryptionKey, "OAUTH_ENCRYPTION_KEY")
 			// Note: Valkey storage env vars are loaded in RunE closure where cmd is available
 
@@ -651,6 +655,7 @@ func runServe(config ServeConfig) error {
 				DexClientID:                   config.OAuth.DexClientID,
 				DexClientSecret:               config.OAuth.DexClientSecret,
 				DexConnectorID:                config.OAuth.DexConnectorID,
+				DexCAFile:                     config.OAuth.DexCAFile,
 				DisableStreaming:              config.OAuth.DisableStreaming,
 				DebugMode:                     config.DebugMode,
 				AllowPublicClientRegistration: config.OAuth.AllowPublicRegistration,

--- a/cmd/serve_config.go
+++ b/cmd/serve_config.go
@@ -80,6 +80,7 @@ type OAuthServeConfig struct {
 	DexClientID                   string
 	DexClientSecret               string
 	DexConnectorID                string // optional: bypasses connector selection screen
+	DexCAFile                     string // optional: CA certificate file for Dex TLS verification
 	DisableStreaming              bool
 	RegistrationToken             string
 	AllowPublicRegistration       bool

--- a/helm/mcp-kubernetes/templates/deployment.yaml
+++ b/helm/mcp-kubernetes/templates/deployment.yaml
@@ -133,6 +133,10 @@ spec:
             - name: DEX_CONNECTOR_ID
               value: {{ .Values.mcpKubernetes.oauth.dex.connectorID | quote }}
             {{- end }}
+            {{- if .Values.mcpKubernetes.oauth.dex.caSecret.name }}
+            - name: DEX_CA_FILE
+              value: "/etc/ssl/certs/dex-ca/{{ .Values.mcpKubernetes.oauth.dex.caSecret.key | default "ca.crt" }}"
+            {{- end }}
             {{- end }}
             {{- if not .Values.mcpKubernetes.oauth.allowPublicRegistration }}
             - name: REGISTRATION_TOKEN
@@ -257,6 +261,11 @@ spec:
             - name: sa-token
               mountPath: /var/run/secrets/kubernetes.io/serviceaccount
               readOnly: true
+            {{- if and .Values.mcpKubernetes.oauth.enabled .Values.mcpKubernetes.oauth.dex.caSecret.name }}
+            - name: dex-ca
+              mountPath: /etc/ssl/certs/dex-ca
+              readOnly: true
+            {{- end }}
           {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -279,6 +288,14 @@ spec:
                     - path: namespace
                       fieldRef:
                         fieldPath: metadata.namespace
+        {{- if and .Values.mcpKubernetes.oauth.enabled .Values.mcpKubernetes.oauth.dex.caSecret.name }}
+        - name: dex-ca
+          secret:
+            secretName: {{ .Values.mcpKubernetes.oauth.dex.caSecret.name }}
+            items:
+              - key: {{ .Values.mcpKubernetes.oauth.dex.caSecret.key | default "ca.crt" }}
+                path: {{ .Values.mcpKubernetes.oauth.dex.caSecret.key | default "ca.crt" }}
+        {{- end }}
       {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/helm/mcp-kubernetes/values.yaml
+++ b/helm/mcp-kubernetes/values.yaml
@@ -192,6 +192,14 @@ mcpKubernetes:
       # Dex connector ID (optional)
       # When set, bypasses the connector selection screen for better UX
       connectorID: ""
+      # CA certificate for Dex TLS verification (optional)
+      # Use this when Dex uses a private/internal CA
+      # Can reference a secret containing the CA certificate
+      caSecret:
+        # Name of the secret containing the CA certificate
+        name: ""
+        # Key in the secret containing the CA certificate (default: ca.crt)
+        key: "ca.crt"
     # OAuth client registration access token
     # Required if allowPublicRegistration is false
     # Should be set via existingSecret for security


### PR DESCRIPTION
## Problem

Some Giant Swarm management clusters use a private CA for internal TLS certificates including Dex. The mcp-kubernetes pod fails to verify the Dex TLS certificate during OIDC discovery:

```
Error: failed to create Dex provider: OIDC discovery failed:
x509: certificate signed by unknown authority
```

## Solution

Add a new `--dex-ca-file` flag (and `DEX_CA_FILE` env var) that allows specifying a custom CA certificate file for Dex TLS verification.

### Changes

1. **cmd/serve.go**: Add `--dex-ca-file` flag
2. **cmd/serve_config.go**: Add `DexCAFile` to `OAuthServeConfig`
3. **internal/server/oauth_http.go**: 
   - Add `createHTTPClientWithCA()` function that creates an HTTP client trusting both system CAs and the custom CA
   - Pass custom HTTP client to Dex provider when CA file is configured
4. **Helm chart**:
   - Add `mcpKubernetes.oauth.dex.caSecret` configuration
   - Mount CA secret as volume
   - Set `DEX_CA_FILE` environment variable automatically

### Helm Configuration Example

```yaml
mcpKubernetes:
  oauth:
    enabled: true
    provider: dex
    dex:
      issuerURL: "https://dex.garm.gawsprivate.gigantic.io"
      clientID: "mcp-kubernetes"
      caSecret:
        name: "private-giantswarm-secret"  # Secret containing the CA
        key: "ca.crt"                       # Key in the secret (default: ca.crt)
```

## Testing

1. Build and run with a Dex using private CA
2. Verify OIDC discovery succeeds
3. Verify public CAs still work (custom CA is appended, not replaced)
