### PR TITLE
fix(logging): configure default slog logger for debug mode

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -303,6 +303,14 @@ func validateEncryptionKey(key []byte) error {
 
 // runServe contains the main server logic with support for multiple transports
 func runServe(config ServeConfig) error {
+	// Configure default slog logger level based on debug mode
+	// This ensures all slog.Debug() calls throughout the codebase respect the --debug flag
+	if config.DebugMode {
+		slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		})))
+	}
+
 	// Create Kubernetes client configuration with structured logging
 	var k8sLogger = logging.NewSlogAdapter(slog.Default())
 


### PR DESCRIPTION
## Problem

The `--debug` flag was only configuring a custom logger for the mcp-oauth library, but `slog.Debug()` calls throughout the application (AccessTokenInjector, tool handlers, federation) were using the default slog logger which remained at INFO level.

This meant that debug logs added in #158 and #159 for diagnosing tool call issues were not visible, even with `--debug` enabled.

## Solution

Set `slog.SetDefault()` at the start of `runServe()` when `--debug` is enabled, ensuring all debug logs are visible.

## Testing

- Verified builds and passes linter
- Once deployed with `--debug`, the following logs will now be visible:
  - `AccessTokenInjector: middleware entry`
  - `kubernetes_list tool invoked`
  - `handleListResources called`
  - `GetClusterClient called`

This will help diagnose where requests are hanging in the MCP request chain.