### PR TITLE
ci: enable Go build caching to speed up CI

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.25'  # Specify Go version
+          cache: true  # Cache Go modules and build cache
 
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.25'  # Match the version used in auto-release
+          cache: true  # Cache Go modules and build cache
 
       - name: Install Python for yamllint
         uses: actions/setup-python@v6


### PR DESCRIPTION
## Summary

- Enable explicit `cache: true` option in `setup-go` action for both `ci.yaml` and `auto-release.yaml` workflows
- The `setup-go@v5` action caches both Go modules (`~/go/pkg/mod`) and the build cache (`~/.cache/go-build`)

## Background

The "Run Release Dry-Run" step was taking ~7+ minutes due to cross-compiling 6 binaries (linux/darwin/windows x amd64/arm64). With build caching enabled, subsequent runs should benefit from cached compilation artifacts.

## Test plan

- [ ] Monitor CI run times after merge
- [ ] Verify cache hit/miss in GitHub Actions logs