### PR TITLE
ci: optimize release dry-run to build only linux/amd64

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,8 +48,9 @@ jobs:
 
       - name: Run Release Dry-Run
         # Only run on PRs, not on direct pushes to main
+        # Uses fast config (linux/amd64 only) to validate release works
         if: github.event_name == 'pull_request'
-        run: make release-dry-run
+        run: make release-dry-run-fast
         env:
           # GoReleaser needs a GITHUB_TOKEN even for dry runs
           # to check API rate limits, etc.

--- a/.goreleaser.ci.yaml
+++ b/.goreleaser.ci.yaml
@@ -1,0 +1,54 @@
+---
+# yamllint disable rule:truthy
+# .goreleaser.ci.yaml
+# Minimal GoReleaser config for CI dry-run validation.
+# Only builds linux/amd64 to validate the release config works.
+# The full release uses .goreleaser.yaml which builds all platforms.
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: mcp-kubernetes
+    main: .
+    binary: mcp-kubernetes
+    # Only build linux/amd64 for CI validation - saves ~6 minutes
+    goos:
+      - linux
+    goarch:
+      - amd64
+    env:
+      - CGO_ENABLED=0
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    flags:
+      - -trimpath
+    ldflags:
+      - >-
+        -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}}
+        -X main.date={{.Date}}
+
+archives:
+  - id: default
+    formats: [tar.gz]
+    name_template: >-
+      {{ .ProjectName }}_ {{- title .Os }}_ {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    wrap_in_directory: true
+    files:
+      - LICENSE
+      - README.md
+
+checksum:
+  algorithm: sha256
+  name_template: '{{ .ProjectName }}_checksums.txt'
+
+# Skip changelog generation in CI - not needed for validation
+changelog:
+  disable: true
+
+# Modelines
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -1,8 +1,12 @@
 ##@ Release
 
 .PHONY: release-dry-run
-release-dry-run: ## Test the release process without publishing
+release-dry-run: ## Test the release process without publishing (all platforms)
 	goreleaser release --snapshot --clean --skip=announce,publish,validate
+
+.PHONY: release-dry-run-fast
+release-dry-run-fast: ## Fast release dry-run for CI (linux/amd64 only, ~6min faster)
+	goreleaser release --config .goreleaser.ci.yaml --snapshot --clean --skip=announce,publish,validate
 
 .PHONY: release-local
 release-local: ## Create a release locally
@@ -14,7 +18,7 @@ release-local: ## Create a release locally
 lint-yaml: ## Run YAML linter
 	@echo "Running YAML linter..."
 	@# Exclude zz_generated files
-	@yamllint .github/workflows/auto-release.yaml .github/workflows/ci.yaml .goreleaser.yaml
+	@yamllint .github/workflows/auto-release.yaml .github/workflows/ci.yaml .goreleaser.yaml .goreleaser.ci.yaml
 
 .PHONY: check
 check: lint-yaml ## Run YAML linter


### PR DESCRIPTION
## Summary

- Add `.goreleaser.ci.yaml` that only builds `linux/amd64` for CI validation
- Reduces dry-run time from **~7 minutes to ~1 minute** (tested locally: 51 seconds)
- Full `.goreleaser.yaml` with all 6 platforms is still used for actual releases

## Background

The previous PR #173 (Go build caching) did not help because cross-compilation for different OS/arch combinations cannot share cached build artifacts. The real bottleneck was building 6 binaries for all platforms.

For CI validation, we only need to verify that the GoReleaser configuration works - building all platforms is unnecessary.

## Changes

- ``.goreleaser.ci.yaml`` - minimal config for CI (linux/amd64 only)
- ``Makefile.custom.mk`` - add `release-dry-run-fast` target
- ``.github/workflows/ci.yaml`` - use fast dry-run in CI

## Test plan

- [ ] Verify CI run completes faster (~1min vs ~7min for dry-run step)
- [ ] Verify the dry-run still catches config errors