### PR TITLE
fix(helm): make registration-token optional when using trusted schemes

### DIFF
--- a/helm/mcp-kubernetes/templates/deployment.yaml
+++ b/helm/mcp-kubernetes/templates/deployment.yaml
@@ -188,11 +188,16 @@ spec:
               value: "/etc/ssl/certs/dex-ca/{{ .Values.mcpKubernetes.oauth.dex.caSecret.key | default "ca.crt" }}"
             {{- end }}
             {{- end }}
-            {{- /* Only reference registration token if:
-                   1. Not using public registration, AND
-                   2. Either using existingSecret OR registrationAccessToken is explicitly provided
-                   When only trustedPublicRegistrationSchemes is used, no token is needed */}}
-            {{- if and (not .Values.mcpKubernetes.oauth.allowPublicRegistration) (or .Values.mcpKubernetes.oauth.existingSecret .Values.mcpKubernetes.oauth.registrationAccessToken) }}
+            {{- /* Only mount REGISTRATION_TOKEN if registrationAccessToken is explicitly configured.
+                   DCR behavior matrix:
+                   - No token + no schemes: fully open (not recommended)
+                   - No token + schemes: only trusted schemes work
+                   - Token + no schemes: only registration token works
+                   - Token + schemes: token OR trusted scheme
+                   Note: existingSecret may be used for other credentials (dex-client-secret,
+                   oauth-encryption-key) without requiring a registration-token key.
+                   CIMD is the preferred client authentication method over DCR. */}}
+            {{- if .Values.mcpKubernetes.oauth.registrationAccessToken }}
             - name: REGISTRATION_TOKEN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary

Fixes an issue where the `REGISTRATION_TOKEN` environment variable was incorrectly required when using `existingSecret` for other OAuth credentials (dex-client-secret, oauth-encryption-key), even when `trustedPublicRegistrationSchemes` was configured as an alternative to registration tokens.

## Problem

The previous condition for mounting `REGISTRATION_TOKEN` was:

```yaml
{{- if and (not .Values.mcpKubernetes.oauth.allowPublicRegistration) (or .Values.mcpKubernetes.oauth.existingSecret .Values.mcpKubernetes.oauth.registrationAccessToken) }}
```

This meant that if `existingSecret` was set (even just for dex credentials), the template expected a `registration-token` key in that secret, regardless of whether `trustedPublicRegistrationSchemes` was being used instead.

## Solution

Changed the condition to only check for `registrationAccessToken`:

```yaml
{{- if .Values.mcpKubernetes.oauth.registrationAccessToken }}
```

## DCR Behavior Matrix

| Registration Token | Trusted Schemes | DCR Behavior |
|-------------------|-----------------|--------------|
| Not set | Not set | Fully open (not recommended) |
| Not set | Configured | Only trusted schemes work |
| Set | Not set | Only registration token works |
| Set | Configured | Token OR trusted scheme |

## Notes

- CIMD (Client ID Metadata Documents) remains the preferred client authentication method over DCR
- This allows operators to use `trustedPublicRegistrationSchemes` as the sole DCR authentication method without needing to provide a dummy `registration-token` in their secrets