### PR TITLE
chore(deps): upgrade mcp-oauth to v0.2.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.25.5
 
 require (
 	github.com/creativeprojects/go-selfupdate v1.5.1
-	github.com/giantswarm/mcp-oauth v0.2.22
+	github.com/giantswarm/mcp-oauth v0.2.23
 	github.com/mark3labs/mcp-go v0.43.2
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/giantswarm/mcp-oauth v0.2.22 h1:XjmrK4DFZuqZUN9BYpqOoHhDXJfyXFHKY6Lw2obc3L0=
-github.com/giantswarm/mcp-oauth v0.2.22/go.mod h1:ujN2TWJ3L1oH7ncm6ghx+kV+fSSJV2abYE5QQ+WFlYg=
+github.com/giantswarm/mcp-oauth v0.2.23 h1:sYyxBJmDLosQS/OdD+3IkGiRpsZKaiNuDtD0dx5K4Pg=
+github.com/giantswarm/mcp-oauth v0.2.23/go.mod h1:ujN2TWJ3L1oH7ncm6ghx+kV+fSSJV2abYE5QQ+WFlYg=
 github.com/go-fed/httpsig v1.1.0 h1:9M+hb0jkEICD8/cAiNqEB66R87tTINszBRTjwjQzWcI=
 github.com/go-fed/httpsig v1.1.0/go.mod h1:RCMrTZvN1bJYtofsG4rd5NaO5obxQ5xBkdiS7xsT7bM=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=


### PR DESCRIPTION
## Summary

- Upgrade mcp-oauth from v0.2.22 to v0.2.23

## Changes in mcp-oauth v0.2.23

Fix for advertising `registration_endpoint` in OAuth Authorization Server Metadata when `TrustedPublicRegistrationSchemes` is configured.

**Problem**: When `--trusted-public-registration-schemes` was configured (without `--allow-public-registration` or `--registration-token`), the `registration_endpoint` was not being advertised in `/.well-known/oauth-authorization-server` metadata. This caused clients like Cursor to fail with "Incompatible auth server: does not support dynamic client registration".

**Fix**: https://github.com/giantswarm/mcp-oauth/pull/150

## Test plan

- [x] Build passes
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)