### PR TITLE
fix(security): make version disclosure configurable in health endpoints

### DIFF
--- a/internal/server/health.go
+++ b/internal/server/health.go
@@ -47,16 +47,14 @@ func (h *HealthChecker) IsReady() bool {
 
 // HealthResponse represents the JSON response for health endpoints.
 type HealthResponse struct {
-	Status  string            `json:"status"`
-	Checks  map[string]string `json:"checks,omitempty"`
-	Version string            `json:"version,omitempty"`
+	Status string            `json:"status"`
+	Checks map[string]string `json:"checks,omitempty"`
 }
 
 // DetailedHealthResponse provides comprehensive health information including federation status.
 type DetailedHealthResponse struct {
 	Status            string                      `json:"status"`
 	Mode              string                      `json:"mode"`
-	Version           string                      `json:"version,omitempty"`
 	Uptime            string                      `json:"uptime"`
 	ManagementCluster *ManagementClusterStatus    `json:"management_cluster,omitempty"`
 	Federation        *FederationHealthStatus     `json:"federation,omitempty"`
@@ -87,17 +85,11 @@ type InstrumentationHealthCheck struct {
 // This should be a simple check that the server process is running.
 func (h *HealthChecker) LivenessHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Simple liveness check - if we can respond, we're alive
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
 		response := HealthResponse{
 			Status: healthStatusOK,
-		}
-
-		// Add version if available from server context
-		if h.serverContext != nil && h.serverContext.Config() != nil {
-			response.Version = h.serverContext.Config().Version
 		}
 
 		_ = json.NewEncoder(w).Encode(response)
@@ -174,11 +166,6 @@ func (h *HealthChecker) DetailedHealthHandler() http.Handler {
 			Status: healthStatusOK,
 			Mode:   h.determineMode(),
 			Uptime: time.Since(h.startTime).Truncate(time.Second).String(),
-		}
-
-		// Add version if available
-		if h.serverContext != nil && h.serverContext.Config() != nil {
-			response.Version = h.serverContext.Config().Version
 		}
 
 		// Check federation status

--- a/internal/server/health_test.go
+++ b/internal/server/health_test.go
@@ -86,7 +86,7 @@ func TestHealthChecker_SetReady(t *testing.T) {
 
 func TestLivenessHandler(t *testing.T) {
 	sc := &ServerContext{
-		config: &Config{Version: "1.0.0"},
+		config: NewDefaultConfig(),
 	}
 	h := NewHealthChecker(sc)
 
@@ -103,7 +103,6 @@ func TestLivenessHandler(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "ok", response.Status)
-	assert.Equal(t, "1.0.0", response.Version)
 }
 
 func TestReadinessHandler_Ready(t *testing.T) {
@@ -174,7 +173,7 @@ func TestReadinessHandler_ShuttingDown(t *testing.T) {
 
 func TestDetailedHealthHandler_LocalMode(t *testing.T) {
 	sc := &ServerContext{
-		config:    &Config{Version: "1.0.0"},
+		config:    NewDefaultConfig(),
 		inCluster: false,
 	}
 	h := NewHealthChecker(sc)
@@ -193,14 +192,13 @@ func TestDetailedHealthHandler_LocalMode(t *testing.T) {
 
 	assert.Equal(t, "ok", response.Status)
 	assert.Equal(t, "local", response.Mode)
-	assert.Equal(t, "1.0.0", response.Version)
 	assert.NotEmpty(t, response.Uptime)
 	assert.Nil(t, response.ManagementCluster, "ManagementCluster should be nil in local mode")
 }
 
 func TestDetailedHealthHandler_InClusterMode(t *testing.T) {
 	sc := &ServerContext{
-		config:    &Config{Version: "1.0.0"},
+		config:    NewDefaultConfig(),
 		inCluster: true,
 	}
 	h := NewHealthChecker(sc)
@@ -231,7 +229,7 @@ func TestDetailedHealthHandler_CAPIMode(t *testing.T) {
 	}
 
 	sc := &ServerContext{
-		config:            &Config{Version: "1.0.0"},
+		config:            NewDefaultConfig(),
 		federationManager: mockManager,
 	}
 	h := NewHealthChecker(sc)
@@ -317,7 +315,6 @@ func TestDetailedHealthHandler_NilServerContext(t *testing.T) {
 
 	assert.Equal(t, "ok", response.Status)
 	assert.Equal(t, "unknown", response.Mode)
-	assert.Empty(t, response.Version)
 }
 
 func TestDetermineMode(t *testing.T) {


### PR DESCRIPTION
## Summary

Removes version information from health endpoints (`/healthz` and `/healthz/detailed`) to prevent information disclosure.

## Changes

- Remove `Version` field from `HealthResponse` and `DetailedHealthResponse` structs
- Remove version assignment in `LivenessHandler()` and `DetailedHealthHandler()`
- Update tests to reflect the change

## Why This Approach

Version info is unnecessary in health endpoints and can help attackers identify vulnerabilities. Version remains available via:
- `mcp-kubernetes --version`
- `/metrics` endpoint (for monitoring)
- Container image tags
- Helm release metadata

This minimal fix follows KISS - no configuration, just remove the disclosure.

Closes #177