### PR TITLE
feat(resource): Add _meta response metadata to all resource tool calls

### DIFF
--- a/docs/cluster-scoped-resources.md
+++ b/docs/cluster-scoped-resources.md
@@ -86,11 +86,11 @@ The `mcp-kubernetes` server follows kubectl's namespace behavior:
 
 ## Response Metadata
 
-For list operations, responses include a `_meta` field that provides transparency:
+All resource operations include a `_meta` field that provides transparency about how the request was interpreted:
 
 ```json
 {
-  "items": [...],
+  "resource": {...},
   "_meta": {
     "resourceScope": "cluster",
     "requestedNamespace": "kube-system",
@@ -100,10 +100,25 @@ For list operations, responses include a `_meta` field that provides transparenc
 }
 ```
 
+This metadata is included in responses from:
+- `kubernetes_get` - wrapped response with resource and `_meta`
+- `kubernetes_list` - paginated response includes `_meta`
+- `kubernetes_describe` - description includes `_meta`
+- `kubernetes_delete` - response with message and `_meta`
+- `kubernetes_patch` - response with patched resource and `_meta`
+- `kubernetes_scale` - response with message, replicas count, and `_meta`
+
 This helps agents understand:
 - Whether the resource is namespaced or cluster-scoped
 - What namespace was requested vs. what was actually used
 - Explanatory hints when behavior might be unexpected
+
+### Benefits
+
+1. **Transparency for agents**: Agents learn when parameters are being interpreted differently than expected
+2. **Reduced debugging roundtrips**: Hints explain unexpected behavior upfront
+3. **Consistent interface**: Same metadata structure across all resource tools
+4. **Self-correcting agents**: Agents can adjust future calls based on feedback
 
 ## How Discovery Works
 

--- a/internal/k8s/bearer_client.go
+++ b/internal/k8s/bearer_client.go
@@ -351,7 +351,7 @@ func (c *bearerTokenClient) SwitchContext(ctx context.Context, contextName strin
 // by using the internal clients created with bearer token authentication.
 
 // Get retrieves a specific resource by name and namespace.
-func (c *bearerTokenClient) Get(ctx context.Context, kubeContext, namespace, resourceType, apiGroup, name string) (runtime.Object, error) {
+func (c *bearerTokenClient) Get(ctx context.Context, kubeContext, namespace, resourceType, apiGroup, name string) (*GetResponse, error) {
 	c.logOperation("get", kubeContext, namespace, resourceType, name)
 
 	if err := c.isNamespaceRestricted(namespace); err != nil {
@@ -484,34 +484,34 @@ func (c *bearerTokenClient) Apply(ctx context.Context, kubeContext, namespace st
 }
 
 // Delete removes a resource.
-func (c *bearerTokenClient) Delete(ctx context.Context, kubeContext, namespace, resourceType, apiGroup, name string) error {
+func (c *bearerTokenClient) Delete(ctx context.Context, kubeContext, namespace, resourceType, apiGroup, name string) (*DeleteResponse, error) {
 	c.logOperation("delete", kubeContext, namespace, resourceType, name)
 
 	if err := c.isOperationAllowed("delete"); err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := c.isNamespaceRestricted(namespace); err != nil {
-		return err
+		return nil, err
 	}
 
 	dynamicClient, err := c.getDynamicClient()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Use discovery for resource resolution and scope determination.
 	// The discovery client caches results for performance.
 	discoveryClient, err := c.getDiscoveryClient()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	return deleteResource(ctx, dynamicClient, discoveryClient, namespace, resourceType, apiGroup, name, c.dryRun)
 }
 
 // Patch updates specific fields of a resource.
-func (c *bearerTokenClient) Patch(ctx context.Context, kubeContext, namespace, resourceType, apiGroup, name string, patchType types.PatchType, data []byte) (runtime.Object, error) {
+func (c *bearerTokenClient) Patch(ctx context.Context, kubeContext, namespace, resourceType, apiGroup, name string, patchType types.PatchType, data []byte) (*PatchResponse, error) {
 	c.logOperation("patch", kubeContext, namespace, resourceType, name)
 
 	if err := c.isOperationAllowed("patch"); err != nil {
@@ -538,27 +538,27 @@ func (c *bearerTokenClient) Patch(ctx context.Context, kubeContext, namespace, r
 }
 
 // Scale changes the number of replicas.
-func (c *bearerTokenClient) Scale(ctx context.Context, kubeContext, namespace, resourceType, apiGroup, name string, replicas int32) error {
+func (c *bearerTokenClient) Scale(ctx context.Context, kubeContext, namespace, resourceType, apiGroup, name string, replicas int32) (*ScaleResponse, error) {
 	c.logOperation("scale", kubeContext, namespace, resourceType, name)
 
 	if err := c.isOperationAllowed("scale"); err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := c.isNamespaceRestricted(namespace); err != nil {
-		return err
+		return nil, err
 	}
 
 	dynamicClient, err := c.getDynamicClient()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Use discovery for resource resolution and scope determination.
 	// The discovery client caches results for performance.
 	discoveryClient, err := c.getDiscoveryClient()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	return scaleResource(ctx, dynamicClient, discoveryClient, namespace, resourceType, apiGroup, name, replicas, c.dryRun)

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -53,7 +53,7 @@ type ContextManager interface {
 // ResourceManager handles Kubernetes resource operations.
 type ResourceManager interface {
 	// Get retrieves a specific resource by name and namespace.
-	Get(ctx context.Context, kubeContext, namespace, resourceType, apiGroup, name string) (runtime.Object, error)
+	Get(ctx context.Context, kubeContext, namespace, resourceType, apiGroup, name string) (*GetResponse, error)
 
 	// List retrieves resources with pagination support.
 	List(ctx context.Context, kubeContext, namespace, resourceType, apiGroup string, opts ListOptions) (*PaginatedListResponse, error)
@@ -68,13 +68,13 @@ type ResourceManager interface {
 	Apply(ctx context.Context, kubeContext, namespace string, obj runtime.Object) (runtime.Object, error)
 
 	// Delete removes a resource by name and namespace.
-	Delete(ctx context.Context, kubeContext, namespace, resourceType, apiGroup, name string) error
+	Delete(ctx context.Context, kubeContext, namespace, resourceType, apiGroup, name string) (*DeleteResponse, error)
 
 	// Patch updates specific fields of a resource.
-	Patch(ctx context.Context, kubeContext, namespace, resourceType, apiGroup, name string, patchType types.PatchType, data []byte) (runtime.Object, error)
+	Patch(ctx context.Context, kubeContext, namespace, resourceType, apiGroup, name string, patchType types.PatchType, data []byte) (*PatchResponse, error)
 
 	// Scale changes the number of replicas for scalable resources.
-	Scale(ctx context.Context, kubeContext, namespace, resourceType, apiGroup, name string, replicas int32) error
+	Scale(ctx context.Context, kubeContext, namespace, resourceType, apiGroup, name string, replicas int32) (*ScaleResponse, error)
 }
 
 // PodManager handles pod-specific operations.
@@ -130,22 +130,22 @@ type PaginatedListResponse struct {
 	TotalItems      int              `json:"totalItems"`                // Number of items in this response
 
 	// Metadata about the request and resource resolution
-	Meta *ListResponseMeta `json:"_meta,omitempty"` // Optional metadata for transparency
+	Meta *ResponseMeta `json:"_meta,omitempty"` // Optional metadata for transparency
 }
 
-// ListResponseMeta provides metadata about the list operation for transparency.
+// ResponseMeta provides metadata about resource operations for transparency.
 // This helps agents understand how parameters were interpreted.
-type ListResponseMeta struct {
+type ResponseMeta struct {
 	ResourceScope      string `json:"resourceScope"`                // "cluster" or "namespaced"
 	RequestedNamespace string `json:"requestedNamespace,omitempty"` // Namespace provided in request
 	EffectiveNamespace string `json:"effectiveNamespace,omitempty"` // Namespace actually used (empty for cluster-scoped)
 	Hint               string `json:"hint,omitempty"`               // Helpful message for agents
 }
 
-// BuildListResponseMeta creates metadata for list operations to provide transparency
+// BuildResponseMeta creates metadata for resource operations to provide transparency
 // about how the request was handled.
-func BuildListResponseMeta(namespaced bool, requestedNS, effectiveNS, resourceType string, allNamespaces bool) *ListResponseMeta {
-	meta := &ListResponseMeta{
+func BuildResponseMeta(namespaced bool, requestedNS, effectiveNS, resourceType string, allNamespaces bool) *ResponseMeta {
+	meta := &ResponseMeta{
 		RequestedNamespace: requestedNS,
 		EffectiveNamespace: effectiveNS,
 	}
@@ -168,6 +168,32 @@ type ResourceDescription struct {
 	Resource runtime.Object         `json:"resource"`
 	Events   []corev1.Event         `json:"events,omitempty"`
 	Metadata map[string]interface{} `json:"metadata,omitempty"`
+	Meta     *ResponseMeta          `json:"_meta,omitempty"` // Operation metadata for transparency
+}
+
+// GetResponse wraps a resource with operation metadata for transparency.
+type GetResponse struct {
+	Resource runtime.Object `json:"resource"`
+	Meta     *ResponseMeta  `json:"_meta,omitempty"`
+}
+
+// DeleteResponse contains the result of a delete operation with metadata.
+type DeleteResponse struct {
+	Message string        `json:"message"`
+	Meta    *ResponseMeta `json:"_meta,omitempty"`
+}
+
+// PatchResponse wraps a patched resource with operation metadata.
+type PatchResponse struct {
+	Resource runtime.Object `json:"resource"`
+	Meta     *ResponseMeta  `json:"_meta,omitempty"`
+}
+
+// ScaleResponse contains the result of a scale operation with metadata.
+type ScaleResponse struct {
+	Message  string        `json:"message"`
+	Replicas int32         `json:"replicas"`
+	Meta     *ResponseMeta `json:"_meta,omitempty"`
 }
 
 // LogOptions configures log retrieval.

--- a/internal/k8s/federated_client.go
+++ b/internal/k8s/federated_client.go
@@ -127,7 +127,7 @@ func (c *FederatedClient) SwitchContext(_ context.Context, _ string) error {
 
 // Get retrieves a specific resource by name and namespace.
 // The kubeContext parameter is ignored (federated clients operate on a single cluster).
-func (c *FederatedClient) Get(ctx context.Context, _, namespace, resourceType, apiGroup, name string) (runtime.Object, error) {
+func (c *FederatedClient) Get(ctx context.Context, _, namespace, resourceType, apiGroup, name string) (*GetResponse, error) {
 	c.logOperation("get", namespace, resourceType, name)
 	return getResource(ctx, c.dynamicClient, c.discoveryClient, namespace, resourceType, apiGroup, name)
 }
@@ -162,21 +162,21 @@ func (c *FederatedClient) Apply(ctx context.Context, _, namespace string, obj ru
 
 // Delete removes a resource by name and namespace.
 // The kubeContext parameter is ignored (federated clients operate on a single cluster).
-func (c *FederatedClient) Delete(ctx context.Context, _, namespace, resourceType, apiGroup, name string) error {
+func (c *FederatedClient) Delete(ctx context.Context, _, namespace, resourceType, apiGroup, name string) (*DeleteResponse, error) {
 	c.logOperation("delete", namespace, resourceType, name)
 	return deleteResource(ctx, c.dynamicClient, c.discoveryClient, namespace, resourceType, apiGroup, name, false)
 }
 
 // Patch updates specific fields of a resource.
 // The kubeContext parameter is ignored (federated clients operate on a single cluster).
-func (c *FederatedClient) Patch(ctx context.Context, _, namespace, resourceType, apiGroup, name string, patchType types.PatchType, data []byte) (runtime.Object, error) {
+func (c *FederatedClient) Patch(ctx context.Context, _, namespace, resourceType, apiGroup, name string, patchType types.PatchType, data []byte) (*PatchResponse, error) {
 	c.logOperation("patch", namespace, resourceType, name)
 	return patchResource(ctx, c.dynamicClient, c.discoveryClient, namespace, resourceType, apiGroup, name, patchType, data, false)
 }
 
 // Scale changes the number of replicas for scalable resources.
 // The kubeContext parameter is ignored (federated clients operate on a single cluster).
-func (c *FederatedClient) Scale(ctx context.Context, _, namespace, resourceType, apiGroup, name string, replicas int32) error {
+func (c *FederatedClient) Scale(ctx context.Context, _, namespace, resourceType, apiGroup, name string, replicas int32) (*ScaleResponse, error) {
 	c.logOperation("scale", namespace, resourceType, name)
 	return scaleResource(ctx, c.dynamicClient, c.discoveryClient, namespace, resourceType, apiGroup, name, replicas, false)
 }

--- a/internal/k8s/response_meta_test.go
+++ b/internal/k8s/response_meta_test.go
@@ -6,9 +6,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestListResponseMetaFields verifies that ListResponseMeta struct has the correct JSON tags.
-func TestListResponseMetaFields(t *testing.T) {
-	meta := &ListResponseMeta{
+// TestResponseMetaFields verifies that ResponseMeta struct has the correct JSON tags.
+func TestResponseMetaFields(t *testing.T) {
+	meta := &ResponseMeta{
 		ResourceScope:      "cluster",
 		RequestedNamespace: "kube-system",
 		EffectiveNamespace: "",
@@ -22,9 +22,9 @@ func TestListResponseMetaFields(t *testing.T) {
 	assert.Contains(t, meta.Hint, "cluster-scoped")
 }
 
-// TestListResponseMetaClusterScoped verifies metadata for cluster-scoped resources.
-func TestListResponseMetaClusterScoped(t *testing.T) {
-	meta := &ListResponseMeta{
+// TestResponseMetaClusterScoped verifies metadata for cluster-scoped resources.
+func TestResponseMetaClusterScoped(t *testing.T) {
+	meta := &ResponseMeta{
 		ResourceScope:      "cluster",
 		RequestedNamespace: "some-namespace",
 		EffectiveNamespace: "",
@@ -36,9 +36,9 @@ func TestListResponseMetaClusterScoped(t *testing.T) {
 	assert.NotEmpty(t, meta.Hint, "should have hint about ignored namespace")
 }
 
-// TestListResponseMetaNamespaced verifies metadata for namespaced resources.
-func TestListResponseMetaNamespaced(t *testing.T) {
-	meta := &ListResponseMeta{
+// TestResponseMetaNamespaced verifies metadata for namespaced resources.
+func TestResponseMetaNamespaced(t *testing.T) {
+	meta := &ResponseMeta{
 		ResourceScope:      "namespaced",
 		RequestedNamespace: "production",
 		EffectiveNamespace: "production",
@@ -50,9 +50,9 @@ func TestListResponseMetaNamespaced(t *testing.T) {
 	assert.Empty(t, meta.Hint, "namespaced resource with matching namespace should have no hint")
 }
 
-// TestListResponseMetaAllNamespaces verifies metadata for all-namespaces query.
-func TestListResponseMetaAllNamespaces(t *testing.T) {
-	meta := &ListResponseMeta{
+// TestResponseMetaAllNamespaces verifies metadata for all-namespaces query.
+func TestResponseMetaAllNamespaces(t *testing.T) {
+	meta := &ResponseMeta{
 		ResourceScope:      "namespaced",
 		RequestedNamespace: "",
 		EffectiveNamespace: "",
@@ -69,7 +69,7 @@ func TestPaginatedListResponseWithMeta(t *testing.T) {
 	response := &PaginatedListResponse{
 		Items:      nil,
 		TotalItems: 0,
-		Meta: &ListResponseMeta{
+		Meta: &ResponseMeta{
 			ResourceScope:      "cluster",
 			RequestedNamespace: "default",
 			EffectiveNamespace: "",
@@ -81,8 +81,8 @@ func TestPaginatedListResponseWithMeta(t *testing.T) {
 	assert.Equal(t, "cluster", response.Meta.ResourceScope)
 }
 
-// TestBuildListResponseMeta verifies the BuildListResponseMeta helper function.
-func TestBuildListResponseMeta(t *testing.T) {
+// TestBuildResponseMeta verifies the BuildResponseMeta helper function.
+func TestBuildResponseMeta(t *testing.T) {
 	tests := []struct {
 		name           string
 		namespaced     bool
@@ -142,7 +142,7 @@ func TestBuildListResponseMeta(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			meta := BuildListResponseMeta(tt.namespaced, tt.requestedNS, tt.effectiveNS, tt.resourceType, tt.allNamespaces)
+			meta := BuildResponseMeta(tt.namespaced, tt.requestedNS, tt.effectiveNS, tt.resourceType, tt.allNamespaces)
 
 			assert.Equal(t, tt.expectScope, meta.ResourceScope)
 			assert.Equal(t, tt.requestedNS, meta.RequestedNamespace)

--- a/internal/tools/access/testdata/mocks.go
+++ b/internal/tools/access/testdata/mocks.go
@@ -81,8 +81,11 @@ func (m *MockK8sClient) SwitchContext(_ context.Context, _ string) error {
 }
 
 // Get implements k8s.ResourceManager.
-func (m *MockK8sClient) Get(_ context.Context, _, _, _, _, _ string) (runtime.Object, error) {
-	return nil, nil
+func (m *MockK8sClient) Get(_ context.Context, _, _, _, _, _ string) (*k8s.GetResponse, error) {
+	return &k8s.GetResponse{
+		Resource: nil,
+		Meta:     nil,
+	}, nil
 }
 
 // List implements k8s.ResourceManager.
@@ -106,18 +109,28 @@ func (m *MockK8sClient) Apply(_ context.Context, _, _ string, _ runtime.Object) 
 }
 
 // Delete implements k8s.ResourceManager.
-func (m *MockK8sClient) Delete(_ context.Context, _, _, _, _, _ string) error {
-	return nil
+func (m *MockK8sClient) Delete(_ context.Context, _, _, _, _, _ string) (*k8s.DeleteResponse, error) {
+	return &k8s.DeleteResponse{
+		Message: "deleted",
+		Meta:    nil,
+	}, nil
 }
 
 // Patch implements k8s.ResourceManager.
-func (m *MockK8sClient) Patch(_ context.Context, _, _, _, _, _ string, _ types.PatchType, _ []byte) (runtime.Object, error) {
-	return nil, nil
+func (m *MockK8sClient) Patch(_ context.Context, _, _, _, _, _ string, _ types.PatchType, _ []byte) (*k8s.PatchResponse, error) {
+	return &k8s.PatchResponse{
+		Resource: nil,
+		Meta:     nil,
+	}, nil
 }
 
 // Scale implements k8s.ResourceManager.
-func (m *MockK8sClient) Scale(_ context.Context, _, _, _, _, _ string, _ int32) error {
-	return nil
+func (m *MockK8sClient) Scale(_ context.Context, _, _, _, _, _ string, _ int32) (*k8s.ScaleResponse, error) {
+	return &k8s.ScaleResponse{
+		Message:  "scaled",
+		Replicas: 0,
+		Meta:     nil,
+	}, nil
 }
 
 // GetLogs implements k8s.PodManager.

--- a/internal/tools/capi/testdata/mocks.go
+++ b/internal/tools/capi/testdata/mocks.go
@@ -102,8 +102,11 @@ func (m *MockK8sClient) SwitchContext(_ context.Context, _ string) error {
 }
 
 // Get implements k8s.ResourceManager.
-func (m *MockK8sClient) Get(_ context.Context, _, _, _, _, _ string) (runtime.Object, error) {
-	return nil, nil
+func (m *MockK8sClient) Get(_ context.Context, _, _, _, _, _ string) (*k8s.GetResponse, error) {
+	return &k8s.GetResponse{
+		Resource: nil,
+		Meta:     nil,
+	}, nil
 }
 
 // List implements k8s.ResourceManager.
@@ -127,18 +130,28 @@ func (m *MockK8sClient) Apply(_ context.Context, _, _ string, _ runtime.Object) 
 }
 
 // Delete implements k8s.ResourceManager.
-func (m *MockK8sClient) Delete(_ context.Context, _, _, _, _, _ string) error {
-	return nil
+func (m *MockK8sClient) Delete(_ context.Context, _, _, _, _, _ string) (*k8s.DeleteResponse, error) {
+	return &k8s.DeleteResponse{
+		Message: "deleted",
+		Meta:    nil,
+	}, nil
 }
 
 // Patch implements k8s.ResourceManager.
-func (m *MockK8sClient) Patch(_ context.Context, _, _, _, _, _ string, _ types.PatchType, _ []byte) (runtime.Object, error) {
-	return nil, nil
+func (m *MockK8sClient) Patch(_ context.Context, _, _, _, _, _ string, _ types.PatchType, _ []byte) (*k8s.PatchResponse, error) {
+	return &k8s.PatchResponse{
+		Resource: nil,
+		Meta:     nil,
+	}, nil
 }
 
 // Scale implements k8s.ResourceManager.
-func (m *MockK8sClient) Scale(_ context.Context, _, _, _, _, _ string, _ int32) error {
-	return nil
+func (m *MockK8sClient) Scale(_ context.Context, _, _, _, _, _ string, _ int32) (*k8s.ScaleResponse, error) {
+	return &k8s.ScaleResponse{
+		Message:  "scaled",
+		Replicas: 0,
+		Meta:     nil,
+	}, nil
 }
 
 // GetLogs implements k8s.PodManager.

--- a/internal/tools/resource/handlers.go
+++ b/internal/tools/resource/handlers.go
@@ -66,7 +66,7 @@ func handleGetResource(ctx context.Context, request mcp.CallToolRequest, sc *ser
 	k8sClient := client.K8s()
 
 	start := time.Now()
-	obj, err := k8sClient.Get(ctx, kubeContext, namespace, resourceType, apiGroup, name)
+	getResponse, err := k8sClient.Get(ctx, kubeContext, namespace, resourceType, apiGroup, name)
 	duration := time.Since(start)
 
 	if err != nil {
@@ -78,13 +78,19 @@ func handleGetResource(ctx context.Context, request mcp.CallToolRequest, sc *ser
 
 	// Apply output processing (slim output, secret masking)
 	processor := getOutputProcessor(sc)
-	processedObj, err := output.ProcessSingleRuntimeObject(processor, obj)
+	processedObj, err := output.ProcessSingleRuntimeObject(processor, getResponse.Resource)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to process resource: %v", err)), nil
 	}
 
-	// Convert the resource to JSON for output
-	jsonData, err := json.MarshalIndent(processedObj, "", "  ")
+	// Build response with metadata
+	response := map[string]interface{}{
+		"resource": processedObj,
+		"_meta":    getResponse.Meta,
+	}
+
+	// Convert the response to JSON for output
+	jsonData, err := json.MarshalIndent(response, "", "  ")
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to marshal resource: %v", err)), nil
 	}
@@ -507,7 +513,7 @@ func handleDeleteResource(ctx context.Context, request mcp.CallToolRequest, sc *
 	k8sClient := client.K8s()
 
 	start := time.Now()
-	err = k8sClient.Delete(ctx, kubeContext, namespace, resourceType, apiGroup, name)
+	deleteResponse, err := k8sClient.Delete(ctx, kubeContext, namespace, resourceType, apiGroup, name)
 	duration := time.Since(start)
 
 	if err != nil {
@@ -517,7 +523,13 @@ func handleDeleteResource(ctx context.Context, request mcp.CallToolRequest, sc *
 
 	recordK8sOperation(ctx, sc, instrumentation.OperationDelete, resourceType, namespace, instrumentation.StatusSuccess, duration)
 
-	return mcp.NewToolResultText(fmt.Sprintf("Resource %s/%s deleted successfully", resourceType, name)), nil
+	// Convert the response to JSON for output (includes _meta)
+	jsonData, err := json.MarshalIndent(deleteResponse, "", "  ")
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to marshal response: %v", err)), nil
+	}
+
+	return mcp.NewToolResultText(string(jsonData)), nil
 }
 
 // handlePatchResource handles kubectl patch operations
@@ -585,7 +597,7 @@ func handlePatchResource(ctx context.Context, request mcp.CallToolRequest, sc *s
 	k8sClient := client.K8s()
 
 	start := time.Now()
-	patchedObj, err := k8sClient.Patch(ctx, kubeContext, namespace, resourceType, apiGroup, name, patchType, patchBytes)
+	patchResponse, err := k8sClient.Patch(ctx, kubeContext, namespace, resourceType, apiGroup, name, patchType, patchBytes)
 	duration := time.Since(start)
 
 	if err != nil {
@@ -595,8 +607,8 @@ func handlePatchResource(ctx context.Context, request mcp.CallToolRequest, sc *s
 
 	recordK8sOperation(ctx, sc, instrumentation.OperationPatch, resourceType, namespace, instrumentation.StatusSuccess, duration)
 
-	// Convert the patched resource to JSON for output
-	jsonData, err := json.MarshalIndent(patchedObj, "", "  ")
+	// Convert the patched resource response to JSON for output (includes _meta)
+	jsonData, err := json.MarshalIndent(patchResponse, "", "  ")
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to marshal patched resource: %v", err)), nil
 	}
@@ -643,7 +655,7 @@ func handleScaleResource(ctx context.Context, request mcp.CallToolRequest, sc *s
 	k8sClient := client.K8s()
 
 	start := time.Now()
-	err = k8sClient.Scale(ctx, kubeContext, namespace, resourceType, apiGroup, name, int32(replicas))
+	scaleResponse, err := k8sClient.Scale(ctx, kubeContext, namespace, resourceType, apiGroup, name, int32(replicas))
 	duration := time.Since(start)
 
 	if err != nil {
@@ -653,7 +665,13 @@ func handleScaleResource(ctx context.Context, request mcp.CallToolRequest, sc *s
 
 	recordK8sOperation(ctx, sc, instrumentation.OperationScale, resourceType, namespace, instrumentation.StatusSuccess, duration)
 
-	return mcp.NewToolResultText(fmt.Sprintf("Resource %s/%s scaled to %d replicas successfully", resourceType, name, int32(replicas))), nil
+	// Convert the scale response to JSON for output (includes _meta)
+	jsonData, err := json.MarshalIndent(scaleResponse, "", "  ")
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to marshal response: %v", err)), nil
+	}
+
+	return mcp.NewToolResultText(string(jsonData)), nil
 }
 
 // handleSummaryResponse generates a summary response for large result sets.

--- a/internal/tools/resource/testdata/mocks.go
+++ b/internal/tools/resource/testdata/mocks.go
@@ -41,8 +41,11 @@ func (m *MockK8sClient) SwitchContext(_ context.Context, _ string) error {
 }
 
 // Get implements k8s.ResourceManager.
-func (m *MockK8sClient) Get(_ context.Context, _, _, _, _, _ string) (runtime.Object, error) {
-	return nil, nil
+func (m *MockK8sClient) Get(_ context.Context, _, _, _, _, _ string) (*k8s.GetResponse, error) {
+	return &k8s.GetResponse{
+		Resource: nil,
+		Meta:     nil,
+	}, nil
 }
 
 // List implements k8s.ResourceManager.
@@ -69,18 +72,28 @@ func (m *MockK8sClient) Apply(_ context.Context, _, _ string, _ runtime.Object) 
 }
 
 // Delete implements k8s.ResourceManager.
-func (m *MockK8sClient) Delete(_ context.Context, _, _, _, _, _ string) error {
-	return nil
+func (m *MockK8sClient) Delete(_ context.Context, _, _, _, _, _ string) (*k8s.DeleteResponse, error) {
+	return &k8s.DeleteResponse{
+		Message: "deleted",
+		Meta:    nil,
+	}, nil
 }
 
 // Patch implements k8s.ResourceManager.
-func (m *MockK8sClient) Patch(_ context.Context, _, _, _, _, _ string, _ types.PatchType, _ []byte) (runtime.Object, error) {
-	return nil, nil
+func (m *MockK8sClient) Patch(_ context.Context, _, _, _, _, _ string, _ types.PatchType, _ []byte) (*k8s.PatchResponse, error) {
+	return &k8s.PatchResponse{
+		Resource: nil,
+		Meta:     nil,
+	}, nil
 }
 
 // Scale implements k8s.ResourceManager.
-func (m *MockK8sClient) Scale(_ context.Context, _, _, _, _, _ string, _ int32) error {
-	return nil
+func (m *MockK8sClient) Scale(_ context.Context, _, _, _, _, _ string, _ int32) (*k8s.ScaleResponse, error) {
+	return &k8s.ScaleResponse{
+		Message:  "scaled",
+		Replicas: 0,
+		Meta:     nil,
+	}, nil
 }
 
 // GetLogs implements k8s.PodManager.


### PR DESCRIPTION
## Summary

This PR implements the feature requested in #193: Add `_meta` response metadata to all resource tool calls.

## Problem

Previously, only the `kubernetes_list` tool returned a `_meta` field in its response. Other resource tools (`kubernetes_get`, `kubernetes_describe`, `kubernetes_delete`, `kubernetes_patch`, `kubernetes_scale`) did not provide this feedback, meaning agents had no visibility when:

1. A namespace parameter is silently ignored for cluster-scoped resources
2. A default namespace is applied when none was provided
3. The resource scope differs from what the agent expected

## Solution

Add `_meta` field to responses from all resource operation tools:

| Tool | Change |
|------|--------|
| `kubernetes_get` | Wrapped in `GetResponse` with `resource` and `_meta` |
| `kubernetes_describe` | `ResourceDescription` now includes `_meta` field |
| `kubernetes_delete` | Returns `DeleteResponse` with `message` and `_meta` |
| `kubernetes_patch` | Returns `PatchResponse` with `resource` and `_meta` |
| `kubernetes_scale` | Returns `ScaleResponse` with `message`, `replicas`, and `_meta` |

## Changes

- Renamed `ListResponseMeta` to `ResponseMeta` for broader use
- Added new response types: `GetResponse`, `DeleteResponse`, `PatchResponse`, `ScaleResponse`
- Updated `ResourceManager` interface with new return types
- Updated all implementations (`kubernetesClient`, `bearerTokenClient`, `FederatedClient`)
- Updated shared functions in `resource_ops.go`
- Updated all handlers to output `_meta` in JSON responses
- Updated mock clients in testdata packages
- Updated documentation

## Example Response

```json
{
  "resource": { ... },
  "_meta": {
    "resourceScope": "cluster",
    "requestedNamespace": "production",
    "effectiveNamespace": "",
    "hint": "nodes is cluster-scoped; namespace parameter was ignored"
  }
}
```

## Testing

- All existing tests pass
- Linter shows no issues

Closes #193