### PR TITLE
fix: apply output processing to Patch and Describe handlers

### DIFF
--- a/internal/tools/resource/testdata/mocks.go
+++ b/internal/tools/resource/testdata/mocks.go
@@ -58,7 +58,11 @@ func (m *MockK8sClient) List(_ context.Context, _, _, _, _ string, _ k8s.ListOpt
 
 // Describe implements k8s.ResourceManager.
 func (m *MockK8sClient) Describe(_ context.Context, _, _, _, _, _ string) (*k8s.ResourceDescription, error) {
-	return nil, nil
+	return &k8s.ResourceDescription{
+		Resource: nil,
+		Metadata: make(map[string]interface{}),
+		Meta:     nil,
+	}, nil
 }
 
 // Create implements k8s.ResourceManager.


### PR DESCRIPTION
## Summary

This PR ensures consistent output processing across all resource handlers.

## Problem

After the recent PR adding `_meta` to resource responses (#193), there was an inconsistency:
- `handleGetResource` applies output processing (slim output, secret masking)
- `handlePatchResource` and `handleDescribeResource` did **not** apply output processing

This meant:
- Secrets returned from `kubernetes_patch` operations wouldn't be masked
- Responses from `kubernetes_patch` and `kubernetes_describe` wouldn't be slimmed down
- Inconsistent behavior between similar operations

## Changes

1. **`handlePatchResource`**: Now applies `output.ProcessSingleRuntimeObject` before marshaling the response
2. **`handleDescribeResource`**: Now applies `output.ProcessSingleRuntimeObject` before marshaling the response
3. **Mock fix**: Updated `Describe` mock to return a valid empty `ResourceDescription` instead of `nil`

## Testing

- All existing tests pass
- The mock was fixed to prevent nil pointer dereference during tests
