### PR TITLE
Update mcp-oauth to v0.2.27

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.25.5
 
 require (
 	github.com/creativeprojects/go-selfupdate v1.5.2
-	github.com/giantswarm/mcp-oauth v0.2.26
+	github.com/giantswarm/mcp-oauth v0.2.27
 	github.com/mark3labs/mcp-go v0.43.2
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/giantswarm/mcp-oauth v0.2.26 h1:SKJiLKww37edC1ItFMOfjfXfp8uX8Xw10D9IQXlXPCI=
-github.com/giantswarm/mcp-oauth v0.2.26/go.mod h1:e8W2usiHVKJhj4f4Zfgk/Bcnqx8Ck2XJFxLqyg0YC64=
+github.com/giantswarm/mcp-oauth v0.2.27 h1:GL/sQJ1UtGQubllgNAyJUQToGUQvy2gesf2AB3D98TY=
+github.com/giantswarm/mcp-oauth v0.2.27/go.mod h1:e8W2usiHVKJhj4f4Zfgk/Bcnqx8Ck2XJFxLqyg0YC64=
 github.com/go-fed/httpsig v1.1.0 h1:9M+hb0jkEICD8/cAiNqEB66R87tTINszBRTjwjQzWcI=
 github.com/go-fed/httpsig v1.1.0/go.mod h1:RCMrTZvN1bJYtofsG4rd5NaO5obxQ5xBkdiS7xsT7bM=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=


### PR DESCRIPTION
## Summary

Updates the mcp-oauth dependency from v0.2.26 to v0.2.27.

## Problem

Tokens stored by user ID (Dex `sub` claim) could not be retrieved by email, causing "AccessTokenInjector: failed to get token from store" errors even when using Valkey persistent storage.

## Solution

The mcp-oauth library v0.2.27 now always stores tokens by email in addition to user ID, ensuring consistent token lookup.

Fixes #200