### PR TITLE
fix: propagate access token to mcp-go tool execution context

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.25.5
 
 require (
 	github.com/creativeprojects/go-selfupdate v1.5.2
-	github.com/giantswarm/mcp-oauth v0.2.27
+	github.com/giantswarm/mcp-oauth v0.2.29
 	github.com/mark3labs/mcp-go v0.43.2
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/giantswarm/mcp-oauth v0.2.27 h1:GL/sQJ1UtGQubllgNAyJUQToGUQvy2gesf2AB3D98TY=
-github.com/giantswarm/mcp-oauth v0.2.27/go.mod h1:e8W2usiHVKJhj4f4Zfgk/Bcnqx8Ck2XJFxLqyg0YC64=
+github.com/giantswarm/mcp-oauth v0.2.29 h1:dZyaeWVaXWFD1LMkAg0dT6fUtY8zJ+nCIDLXoGDwJ4U=
+github.com/giantswarm/mcp-oauth v0.2.29/go.mod h1:e8W2usiHVKJhj4f4Zfgk/Bcnqx8Ck2XJFxLqyg0YC64=
 github.com/go-fed/httpsig v1.1.0 h1:9M+hb0jkEICD8/cAiNqEB66R87tTINszBRTjwjQzWcI=
 github.com/go-fed/httpsig v1.1.0/go.mod h1:RCMrTZvN1bJYtofsG4rd5NaO5obxQ5xBkdiS7xsT7bM=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=


### PR DESCRIPTION
## Summary

Fixes the issue where `AccessTokenInjector` successfully extracts and injects the ID token, but tool handlers still report "No access token in context".

## Root Cause

There were actually **two issues** causing #202:

### Issue 1: Valkey Token Serialization (mcp-oauth)
When using Valkey storage, the `id_token` in the `ProviderToken.Extra` field was lost during JSON serialization because `oauth2.Token` stores Extra fields in a private `raw` field. This was fixed in mcp-oauth v0.2.29.

### Issue 2: Context Propagation (mcp-kubernetes) - THE REAL BUG
The `AccessTokenInjector` middleware was correctly extracting the ID token and setting it in the HTTP request context (`r.Context()`). **However**, mcp-go's `StreamableHTTPServer` creates its own internal context for tool execution and doesn't automatically inherit values from the HTTP request context.

This is why the logs showed:
```
AccessTokenInjector: successfully injected ID token  ✓
...
[WARN] No access token in context, denying access (strict mode enabled)  ✗
```

## The Fix

1. **Update mcp-oauth to v0.2.29** - Fixes Valkey token serialization
2. **Use `WithHTTPContextFunc`** - Copies the access token from `r.Context()` (where the middleware sets it) to mcp-go's internal context that is used for tool handlers

```go
httpContextFunc := func(ctx context.Context, r *http.Request) context.Context {
    // Copy access token from HTTP request context to mcp-go's tool execution context
    accessToken, ok := mcpoauth.GetAccessTokenFromContext(r.Context())
    if ok && accessToken != "" {
        return mcpoauth.ContextWithAccessToken(ctx, accessToken)
    }
    return ctx
}

httpServer = mcpserver.NewStreamableHTTPServer(s.mcpServer,
    mcpserver.WithEndpointPath("/mcp"),
    mcpserver.WithHTTPContextFunc(httpContextFunc),
)
```

## Testing

After this fix, the flow will be:
1. `ValidateToken` middleware validates the MCP access token and sets user info in context
2. `AccessTokenInjector` middleware gets the provider token from store and sets ID token in `r.Context()`
3. `HTTPContextFunc` copies the ID token from `r.Context()` to mcp-go's tool execution context
4. Tool handlers can now access the token via `GetAccessTokenFromContext(ctx)`
5. `K8sClientForContext` creates a per-user Kubernetes client with the token

## Related Issues

- Fixes #202
- Upstream fix: giantswarm/mcp-oauth#158