### PR TITLE
fix(helm): use correct allowPublicRegistration key in deployment template

### DIFF
--- a/helm/mcp-kubernetes/templates/deployment.yaml
+++ b/helm/mcp-kubernetes/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
             - --enable-oauth=true
             - --oauth-base-url={{ required "mcpKubernetes.oauth.baseURL is required when OAuth is enabled" .Values.mcpKubernetes.oauth.baseURL }}
             - --oauth-provider={{ .Values.mcpKubernetes.oauth.provider | default "dex" }}
-            {{- if .Values.mcpKubernetes.oauth.allowPublicClientRegistration }}
+            {{- if .Values.mcpKubernetes.oauth.allowPublicRegistration }}
             - --allow-public-registration=true
             {{- else }}
             - --allow-public-registration=false


### PR DESCRIPTION
## Summary

Fixes a typo in the Helm deployment template where `allowPublicClientRegistration` was used instead of `allowPublicRegistration`.

## Changes

- Corrected the conditional check in `deployment.yaml` to use the correct key `.Values.mcpKubernetes.oauth.allowPublicRegistration`

## Impact

This bug prevented the `--allow-public-registration=true` flag from being set correctly, even when users configured `allowPublicRegistration: true` in their values. The condition would always evaluate to false due to the mismatched key name.

## Verification

The field `allowPublicRegistration` is consistently defined in:
- `values.yaml`
- `values.schema.json`
- All `values-oauth-*.yaml` example files