### PR TITLE
fix(oauth): allow CIMD-only mode without DCR configuration

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -725,11 +725,15 @@ func runServe(config ServeConfig) error {
 
 			// Registration token is required unless:
 			// 1. Public registration is enabled (anyone can register), OR
-			// 2. Trusted schemes are configured (Cursor/VSCode can register without token)
+			// 2. Trusted schemes are configured (Cursor/VSCode can register without token), OR
+			// 3. CIMD is enabled (clients use HTTPS URLs as client IDs)
 			hasTrustedSchemes := len(config.OAuth.TrustedPublicRegistrationSchemes) > 0
-			if !config.OAuth.AllowPublicRegistration && config.OAuth.RegistrationToken == "" && !hasTrustedSchemes {
-				return fmt.Errorf("--registration-token is required when public registration is disabled and no trusted schemes are configured. " +
-					"Either set --registration-token, enable --allow-public-registration, or configure --trusted-public-registration-schemes for Cursor/VSCode")
+			cimdEnabled := config.OAuth.EnableCIMD
+			if !config.OAuth.AllowPublicRegistration && config.OAuth.RegistrationToken == "" && !hasTrustedSchemes && !cimdEnabled {
+				return fmt.Errorf("--registration-token is required when public registration is disabled, " +
+					"no trusted schemes are configured, and CIMD is disabled. " +
+					"Either set --registration-token, enable --allow-public-registration, " +
+					"configure --trusted-public-registration-schemes, or enable --enable-cimd")
 			}
 
 			// Prepare encryption key if provided (must be base64 encoded)


### PR DESCRIPTION
## Summary

This PR updates the OAuth validation logic to recognize CIMD (Client ID Metadata Documents) as a valid client registration method. When CIMD is enabled (the default), operators no longer need to configure DCR methods like registration tokens, public registration, or trusted schemes.

## Changes

### `cmd/serve.go`
- Updated the registration token validation logic to also check if CIMD is enabled
- Updated the error message to include CIMD as an option

### `cmd/serve_validation_test.go`
- Updated `validateOAuthConfig()` test helper to include CIMD check
- Added test cases for:
  - CIMD-only mode (CIMD enabled, no token, no public reg, no trusted schemes -> PASS)
  - CIMD disabled with no other methods (-> FAIL with clear error message)
  - CIMD and trusted schemes together (both methods work together -> PASS)

## Testing

All existing tests pass, plus new tests for CIMD-only scenarios:
- `TestOAuthProviderValidation/CIMD_enabled_allows_registration_without_token`
- `TestTrustedSchemesAllowsRegistrationWithoutToken/CIMD_alone_allows_registration_without_token`
- `TestTrustedSchemesAllowsRegistrationWithoutToken/CIMD_and_trusted_schemes_together_is_valid`

## Closes

Closes #210