### PR TITLE
fix(helm): make debug flag configurable with secure default

### DIFF
--- a/helm/mcp-kubernetes/templates/deployment.yaml
+++ b/helm/mcp-kubernetes/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
           args:
             - serve
             - --transport=streamable-http
-            - --debug=true
+            - --debug={{ .Values.mcpKubernetes.debug | default false }}
             {{- if .Values.mcpKubernetes.kubernetes.inCluster }}
             - --in-cluster=true
             {{- end }}

--- a/helm/mcp-kubernetes/tests/deployment_test.yaml
+++ b/helm/mcp-kubernetes/tests/deployment_test.yaml
@@ -76,3 +76,18 @@ tests:
           path: spec.template.spec.containers[0].securityContext.runAsNonRoot
           value: true
 
+  - it: should disable debug mode by default
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--debug=false"
+
+  - it: should enable debug mode when configured
+    set:
+      mcpKubernetes:
+        debug: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--debug=true"
+

--- a/helm/mcp-kubernetes/values.schema.json
+++ b/helm/mcp-kubernetes/values.schema.json
@@ -368,6 +368,11 @@
     "mcpKubernetes": {
       "type": "object",
       "properties": {
+        "debug": {
+          "type": "boolean",
+          "description": "Enable debug mode. WARNING: May expose sensitive information in logs. Only for development/troubleshooting, never in production.",
+          "default": false
+        },
         "kubernetes": {
           "type": "object",
           "properties": {

--- a/helm/mcp-kubernetes/values.yaml
+++ b/helm/mcp-kubernetes/values.yaml
@@ -213,6 +213,11 @@ affinity: {}
 
 # MCP Kubernetes specific configuration
 mcpKubernetes:
+  # Enable debug mode (default: false)
+  # WARNING: Debug mode may expose sensitive information in logs.
+  # Only enable for development or troubleshooting, never in production.
+  debug: false
+
   # Kubernetes configuration
   kubernetes:
     # If true, use in-cluster configuration


### PR DESCRIPTION
## Summary

- Makes the debug flag configurable via Helm values with a secure default (`false`)
- Previously `--debug=true` was hardcoded in the deployment template

## Changes

- Added `mcpKubernetes.debug` option in `values.yaml` (default: `false`)
- Updated `deployment.yaml` template to use the configurable value
- Updated `values.schema.json` with the new property definition
- Added Helm unit tests to verify both default and enabled states

## Security

This change addresses a security concern where debug mode was always enabled in production deployments, which could potentially expose sensitive information in logs.

## Test plan

- [x] Helm lint passes
- [x] Helm unit tests pass (62 tests, including 2 new tests for debug flag)
- [x] Go tests pass
- [x] Linter passes (0 issues)

Closes #227