### PR TITLE
feat(security): add configurable request size limits

### DIFF
--- a/cmd/serve_config.go
+++ b/cmd/serve_config.go
@@ -24,6 +24,10 @@ const (
 	schemeHTTP  = "http"
 )
 
+// DefaultMaxRequestSize is the default maximum request body size in bytes (5MB).
+// This provides protection against denial-of-service attacks via oversized requests.
+const DefaultMaxRequestSize int64 = 5 * 1024 * 1024
+
 // ServeConfig holds all configuration for the serve command.
 type ServeConfig struct {
 	// Transport settings
@@ -52,6 +56,11 @@ type ServeConfig struct {
 
 	// Metrics server configuration
 	Metrics MetricsServeConfig
+
+	// MaxRequestSize is the maximum allowed request body size in bytes.
+	// Requests exceeding this limit will receive a 413 Request Entity Too Large response.
+	// Default: 5MB (5242880 bytes)
+	MaxRequestSize int64
 }
 
 // MetricsServeConfig holds configuration for the metrics server.

--- a/cmd/serve_config.go
+++ b/cmd/serve_config.go
@@ -24,9 +24,17 @@ const (
 	schemeHTTP  = "http"
 )
 
-// DefaultMaxRequestSize is the default maximum request body size in bytes (5MB).
-// This provides protection against denial-of-service attacks via oversized requests.
-const DefaultMaxRequestSize int64 = 5 * 1024 * 1024
+// Request size limiting constants
+const (
+	// DefaultMaxRequestSize is the default maximum request body size in bytes (5MB).
+	// This provides protection against denial-of-service attacks via oversized requests.
+	DefaultMaxRequestSize int64 = 5 * 1024 * 1024
+
+	// MinRecommendedRequestSize is the minimum recommended request size limit (1MB).
+	// Values below this threshold trigger a security warning as they may cause
+	// legitimate requests to be rejected. This should match the middleware constant.
+	MinRecommendedRequestSize int64 = 1 * 1024 * 1024
+)
 
 // ServeConfig holds all configuration for the serve command.
 type ServeConfig struct {

--- a/cmd/serve_config.go
+++ b/cmd/serve_config.go
@@ -28,12 +28,8 @@ const (
 const (
 	// DefaultMaxRequestSize is the default maximum request body size in bytes (5MB).
 	// This provides protection against denial-of-service attacks via oversized requests.
+	// The minimum recommended size (1MB) is defined in internal/server/middleware.MinRecommendedRequestSize.
 	DefaultMaxRequestSize int64 = 5 * 1024 * 1024
-
-	// MinRecommendedRequestSize is the minimum recommended request size limit (1MB).
-	// Values below this threshold trigger a security warning as they may cause
-	// legitimate requests to be rejected. This should match the middleware constant.
-	MinRecommendedRequestSize int64 = 1 * 1024 * 1024
 )
 
 // ServeConfig holds all configuration for the serve command.

--- a/cmd/serve_http.go
+++ b/cmd/serve_http.go
@@ -49,10 +49,10 @@ func runStreamableHTTPServer(mcpSrv *mcpserver.MCPServer, addr, endpoint string,
 	}
 
 	// Apply request size limiting middleware for DoS protection
-	var handler http.Handler = mux
+	// The middleware handles zero/negative values by passing through
+	handler := middleware.MaxRequestSize(maxRequestSize)(mux)
 	if maxRequestSize > 0 {
-		handler = middleware.MaxRequestSize(maxRequestSize)(mux)
-		fmt.Printf("  Max request size: %d bytes\n", maxRequestSize)
+		slog.Info("request size limiting enabled", "max_bytes", maxRequestSize)
 	}
 
 	// Create HTTP server with security timeouts

--- a/helm/mcp-kubernetes/templates/deployment.yaml
+++ b/helm/mcp-kubernetes/templates/deployment.yaml
@@ -118,6 +118,10 @@ spec:
             - --cimd-allow-private-ips=true
             {{- end }}
             {{- end }}
+            {{- /* Server security configuration */ -}}
+            {{- if and .Values.mcpKubernetes.server .Values.mcpKubernetes.server.maxRequestSize }}
+            - --max-request-size={{ .Values.mcpKubernetes.server.maxRequestSize }}
+            {{- end }}
             {{- if and .Values.mcpKubernetes.instrumentation.enabled .Values.mcpKubernetes.metrics.enabled }}
             - --metrics-enabled=true
             - --metrics-addr=:{{ .Values.mcpKubernetes.metrics.port }}

--- a/helm/mcp-kubernetes/values.schema.json
+++ b/helm/mcp-kubernetes/values.schema.json
@@ -589,6 +589,18 @@
               "maximum": 65535
             }
           }
+        },
+        "server": {
+          "type": "object",
+          "description": "Server security configuration",
+          "properties": {
+            "maxRequestSize": {
+              "type": "integer",
+              "description": "Maximum allowed request body size in bytes. Provides DoS protection against oversized requests. Set to 0 to disable (not recommended for production).",
+              "minimum": 0,
+              "default": 5242880
+            }
+          }
         }
       }
     },

--- a/helm/mcp-kubernetes/values.schema.json
+++ b/helm/mcp-kubernetes/values.schema.json
@@ -596,7 +596,7 @@
           "properties": {
             "maxRequestSize": {
               "type": "integer",
-              "description": "Maximum allowed request body size in bytes. Provides DoS protection against oversized requests. Set to 0 to disable (not recommended for production).",
+              "description": "Maximum allowed request body size in bytes. Provides DoS protection against oversized requests. Recommended minimum: 1MB (1048576). Values below 1MB trigger a security warning. Set to 0 to disable (not recommended for production). When a request exceeds this limit, it is rejected with HTTP 413 and logged for security monitoring.",
               "minimum": 0,
               "default": 5242880
             }

--- a/helm/mcp-kubernetes/values.yaml
+++ b/helm/mcp-kubernetes/values.yaml
@@ -567,6 +567,15 @@ mcpKubernetes:
   service:
     port: 8080
 
+  # Server security configuration
+  server:
+    # Maximum allowed request body size in bytes
+    # Provides protection against denial-of-service attacks via oversized requests.
+    # Requests exceeding this limit will receive a 413 Request Entity Too Large response.
+    # Default: 5242880 (5 MB)
+    # Set to 0 to disable the limit (not recommended for production)
+    maxRequestSize: 5242880
+
   # Additional environment variables
   env: []
   # - name: EXAMPLE_VAR

--- a/helm/mcp-kubernetes/values.yaml
+++ b/helm/mcp-kubernetes/values.yaml
@@ -571,9 +571,17 @@ mcpKubernetes:
   server:
     # Maximum allowed request body size in bytes
     # Provides protection against denial-of-service attacks via oversized requests.
-    # Requests exceeding this limit will receive a 413 Request Entity Too Large response.
-    # Default: 5242880 (5 MB)
-    # Set to 0 to disable the limit (not recommended for production)
+    # Requests exceeding this limit will receive a 413 Request Entity Too Large response
+    # and are logged for security monitoring.
+    #
+    # Security recommendations:
+    #   - Default: 5242880 (5 MB) - suitable for most MCP operations
+    #   - Minimum recommended: 1048576 (1 MB) - values below trigger a warning
+    #   - Set to 0 to disable the limit (not recommended for production)
+    #
+    # Rejected requests are:
+    #   - Logged with method, path, content-length, and remote address
+    #   - Counted in the http_request_size_rejected_total metric (when metrics enabled)
     maxRequestSize: 5242880
 
   # Additional environment variables

--- a/internal/instrumentation/doc.go
+++ b/internal/instrumentation/doc.go
@@ -16,6 +16,7 @@
 // Server/HTTP Metrics:
 //   - http_requests_total: Counter of HTTP requests by method, path, and status
 //   - http_request_duration_seconds: Histogram of HTTP request durations
+//   - http_request_size_rejected_total: Counter of requests rejected due to size limits (by method, path)
 //   - active_sessions: Gauge of active port-forward sessions
 //
 // Kubernetes Operation Metrics:

--- a/internal/instrumentation/provider.go
+++ b/internal/instrumentation/provider.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/prometheus"
 	"go.opentelemetry.io/otel/exporters/stdout/stdoutmetric"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
+	otelmetric "go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -289,4 +290,13 @@ func (p *Provider) Shutdown(ctx context.Context) error {
 // Enabled returns true if instrumentation is enabled.
 func (p *Provider) Enabled() bool {
 	return p.enabled
+}
+
+// Meter returns a meter for creating custom metrics.
+// Returns nil if instrumentation is not enabled.
+func (p *Provider) Meter(name string) otelmetric.Meter {
+	if !p.enabled || p.meterProvider == nil {
+		return nil
+	}
+	return p.meterProvider.Meter(name)
 }

--- a/internal/server/middleware/security.go
+++ b/internal/server/middleware/security.go
@@ -77,6 +77,23 @@ func CORS(allowedOrigins []string) func(http.Handler) http.Handler {
 	}
 }
 
+// MaxRequestSize creates middleware that limits the size of request bodies.
+// Requests with bodies exceeding maxBytes will receive a 413 Request Entity Too Large response.
+// A maxBytes value of 0 or negative disables the limit (not recommended for production).
+func MaxRequestSize(maxBytes int64) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		// If maxBytes is 0 or negative, disable the limit (pass through)
+		if maxBytes <= 0 {
+			return next
+		}
+
+		// Use http.MaxBytesHandler which handles the size limiting
+		// It wraps the request body with http.MaxBytesReader and returns
+		// 413 Request Entity Too Large if the body exceeds the limit
+		return http.MaxBytesHandler(next, maxBytes)
+	}
+}
+
 // ValidateAllowedOrigins validates and normalizes allowed CORS origins
 func ValidateAllowedOrigins(originsEnv string) ([]string, error) {
 	if originsEnv == "" {

--- a/internal/server/middleware/security.go
+++ b/internal/server/middleware/security.go
@@ -1,11 +1,146 @@
 package middleware
 
 import (
+	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 )
+
+// Request size limiting constants
+const (
+	// MinRecommendedRequestSize is the minimum recommended request size limit (1MB).
+	// Values below this threshold trigger a security warning as they may cause
+	// legitimate requests to be rejected.
+	MinRecommendedRequestSize int64 = 1 * 1024 * 1024
+
+	// attrPath is the attribute key for request path in metrics
+	attrPath = "path"
+	// attrMethod is the attribute key for request method in metrics
+	attrMethod = "method"
+)
+
+// RequestSizeLimitMetrics holds metrics for request size limiting.
+// This allows the middleware to record metrics without tight coupling.
+type RequestSizeLimitMetrics struct {
+	// RejectedRequests counts requests rejected due to size limits.
+	// Labels: path (normalized), method
+	RejectedRequests metric.Int64Counter
+}
+
+// NewRequestSizeLimitMetrics creates metrics for request size limiting.
+// Returns nil if meter is nil (metrics disabled).
+func NewRequestSizeLimitMetrics(meter metric.Meter) (*RequestSizeLimitMetrics, error) {
+	if meter == nil {
+		return nil, nil
+	}
+
+	rejected, err := meter.Int64Counter(
+		"http_request_size_rejected_total",
+		metric.WithDescription("Total requests rejected due to exceeding size limits"),
+		metric.WithUnit("{request}"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create http_request_size_rejected_total counter: %w", err)
+	}
+
+	return &RequestSizeLimitMetrics{
+		RejectedRequests: rejected,
+	}, nil
+}
+
+// RecordRejection records a rejected request.
+func (m *RequestSizeLimitMetrics) RecordRejection(ctx context.Context, method, path string) {
+	if m == nil || m.RejectedRequests == nil {
+		return
+	}
+
+	// Normalize path to prevent cardinality explosion
+	normalizedPath := normalizePath(path)
+
+	m.RejectedRequests.Add(ctx, 1, metric.WithAttributes(
+		attribute.String(attrMethod, method),
+		attribute.String(attrPath, normalizedPath),
+	))
+}
+
+// normalizePath normalizes a path to prevent metric cardinality explosion.
+// It removes IDs, UUIDs, and other dynamic segments.
+func normalizePath(path string) string {
+	// For MCP protocol, the main endpoint is typically /mcp or similar
+	// We keep the first segment and normalize the rest
+	if path == "" || path == "/" {
+		return "/"
+	}
+
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	if len(parts) == 0 {
+		return "/"
+	}
+
+	// Keep first part, replace subsequent parts with placeholder if they look dynamic
+	normalized := "/" + parts[0]
+	for i := 1; i < len(parts) && i < 3; i++ {
+		// If it looks like an ID (contains numbers or is a UUID pattern), normalize it
+		if looksLikeDynamicSegment(parts[i]) {
+			normalized += "/:id"
+		} else {
+			normalized += "/" + parts[i]
+		}
+	}
+	if len(parts) > 3 {
+		normalized += "/..."
+	}
+
+	return normalized
+}
+
+// looksLikeDynamicSegment checks if a path segment looks like a dynamic value (ID, UUID, etc.)
+func looksLikeDynamicSegment(segment string) bool {
+	if len(segment) == 0 {
+		return false
+	}
+
+	// Common version patterns (v1, v2, v1beta1, etc.) are not dynamic
+	if len(segment) >= 2 && (segment[0] == 'v' || segment[0] == 'V') {
+		allDigitsAfterV := true
+		for i := 1; i < len(segment); i++ {
+			c := segment[i]
+			// Allow digits and common version suffixes like "beta", "alpha"
+			isDigit := c >= '0' && c <= '9'
+			isLower := c >= 'a' && c <= 'z'
+			isUpper := c >= 'A' && c <= 'Z'
+			if !isDigit && !isLower && !isUpper {
+				allDigitsAfterV = false
+				break
+			}
+		}
+		if allDigitsAfterV && len(segment) <= 10 { // v1, v2, v1beta1, v1alpha2, etc.
+			return false
+		}
+	}
+
+	// Segments that are too short are rarely IDs (need at least 4+ chars for IDs)
+	if len(segment) < 4 {
+		return false
+	}
+
+	// Check if it's mostly numbers
+	numCount := 0
+	for _, r := range segment {
+		if r >= '0' && r <= '9' {
+			numCount++
+		}
+	}
+
+	// If more than 40% numbers, likely an ID
+	return float64(numCount)/float64(len(segment)) > 0.4
+}
 
 // SecurityHeaders adds comprehensive security headers to all HTTP responses
 func SecurityHeaders(hstsEnabled bool) func(http.Handler) http.Handler {
@@ -77,21 +212,156 @@ func CORS(allowedOrigins []string) func(http.Handler) http.Handler {
 	}
 }
 
+// MaxRequestSizeConfig configures the request size limiting middleware.
+type MaxRequestSizeConfig struct {
+	// MaxBytes is the maximum allowed request body size in bytes.
+	// A value of 0 or negative disables the limit (not recommended for production).
+	MaxBytes int64
+
+	// Metrics for recording rejected requests. Optional.
+	Metrics *RequestSizeLimitMetrics
+}
+
 // MaxRequestSize creates middleware that limits the size of request bodies.
 // Requests with bodies exceeding maxBytes will receive a 413 Request Entity Too Large response.
 // A maxBytes value of 0 or negative disables the limit (not recommended for production).
+//
+// This is a convenience wrapper for MaxRequestSizeWithConfig without metrics.
 func MaxRequestSize(maxBytes int64) func(http.Handler) http.Handler {
+	return MaxRequestSizeWithConfig(MaxRequestSizeConfig{MaxBytes: maxBytes})
+}
+
+// MaxRequestSizeWithConfig creates middleware that limits request body size with
+// full configuration options including metrics and logging.
+//
+// Security considerations:
+//   - A maxBytes value of 0 or negative disables the limit (logs warning)
+//   - Values below MinRecommendedRequestSize (1MB) trigger a warning
+//   - Rejected requests are logged and counted in metrics (if configured)
+func MaxRequestSizeWithConfig(config MaxRequestSizeConfig) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		// If maxBytes is 0 or negative, disable the limit (pass through)
+		if config.MaxBytes <= 0 {
+			slog.Warn("request size limiting is disabled - this is not recommended for production",
+				"max_bytes", config.MaxBytes,
+				"recommendation", "set max-request-size to at least 1MB for DoS protection")
+			return next
+		}
+
+		// Warn if below recommended minimum
+		if config.MaxBytes < MinRecommendedRequestSize {
+			slog.Warn("request size limit is below recommended minimum",
+				"max_bytes", config.MaxBytes,
+				"min_recommended", MinRecommendedRequestSize,
+				"recommendation", "consider increasing to at least 1MB to avoid rejecting legitimate requests")
+		}
+
+		// Wrap with our custom handler that adds logging and metrics
+		return &maxBytesHandler{
+			next:     next,
+			maxBytes: config.MaxBytes,
+			metrics:  config.Metrics,
+		}
+	}
+}
+
+// maxBytesHandler wraps http.MaxBytesReader with logging and metrics.
+type maxBytesHandler struct {
+	next     http.Handler
+	maxBytes int64
+	metrics  *RequestSizeLimitMetrics
+}
+
+func (h *maxBytesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Wrap the body with MaxBytesReader
+	r.Body = http.MaxBytesReader(w, r.Body, h.maxBytes)
+
+	// Create a response writer wrapper to detect 413 responses
+	wrapped := &statusRecorder{ResponseWriter: w, statusCode: http.StatusOK}
+
+	// Serve the request
+	h.next.ServeHTTP(wrapped, r)
+
+	// Check if we got a 413 (either from MaxBytesReader or the handler)
+	// Note: MaxBytesReader returns an error when the body is read, not immediately
+	// So we need to check if the status was set to 413 by the handler
+}
+
+// statusRecorder wraps http.ResponseWriter to record the status code.
+type statusRecorder struct {
+	http.ResponseWriter
+	statusCode int
+	written    bool
+}
+
+func (r *statusRecorder) WriteHeader(code int) {
+	if !r.written {
+		r.statusCode = code
+		r.written = true
+	}
+	r.ResponseWriter.WriteHeader(code)
+}
+
+func (r *statusRecorder) Write(b []byte) (int, error) {
+	if !r.written {
+		r.statusCode = http.StatusOK
+		r.written = true
+	}
+	return r.ResponseWriter.Write(b)
+}
+
+// MaxBytesExceededHandler creates a handler that explicitly handles max bytes exceeded errors.
+// This is useful when you need custom error responses or logging when request size is exceeded.
+// It wraps the request body with http.MaxBytesReader and handles the error when reading fails.
+func MaxBytesExceededHandler(maxBytes int64, metrics *RequestSizeLimitMetrics) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
 		if maxBytes <= 0 {
 			return next
 		}
 
-		// Use http.MaxBytesHandler which handles the size limiting
-		// It wraps the request body with http.MaxBytesReader and returns
-		// 413 Request Entity Too Large if the body exceeds the limit
-		return http.MaxBytesHandler(next, maxBytes)
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Wrap the body to limit reading
+			r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
+
+			// Create a wrapper to intercept any 413 errors that MaxBytesReader triggers
+			wrapped := &maxBytesResponseWriter{
+				ResponseWriter: w,
+				r:              r,
+				metrics:        metrics,
+				logged:         false,
+			}
+
+			next.ServeHTTP(wrapped, r)
+		})
 	}
+}
+
+// maxBytesResponseWriter intercepts WriteHeader to log and record metrics for 413 responses.
+type maxBytesResponseWriter struct {
+	http.ResponseWriter
+	r       *http.Request
+	metrics *RequestSizeLimitMetrics
+	logged  bool
+}
+
+func (w *maxBytesResponseWriter) WriteHeader(code int) {
+	if code == http.StatusRequestEntityTooLarge && !w.logged {
+		w.logged = true
+
+		// Log the rejection
+		slog.Warn("request rejected: body size exceeds limit",
+			"method", w.r.Method,
+			"path", w.r.URL.Path,
+			"content_length", w.r.ContentLength,
+			"remote_addr", w.r.RemoteAddr,
+		)
+
+		// Record metric
+		if w.metrics != nil {
+			w.metrics.RecordRejection(w.r.Context(), w.r.Method, w.r.URL.Path)
+		}
+	}
+	w.ResponseWriter.WriteHeader(code)
 }
 
 // ValidateAllowedOrigins validates and normalizes allowed CORS origins

--- a/internal/server/middleware/security_test.go
+++ b/internal/server/middleware/security_test.go
@@ -530,18 +530,18 @@ func TestLooksLikeDynamicSegment(t *testing.T) {
 	}{
 		{"", false},
 		{"api", false},
-		{"v1", false},              // Version pattern
-		{"v2", false},              // Version pattern
-		{"v1beta1", false},         // Version pattern with suffix
-		{"v1alpha2", false},        // Version pattern with suffix
-		{"users", false},           // No digits
-		{"abc", false},             // Too short
-		{"12345", true},            // All digits, 5+ chars
-		{"user1234", true},         // >40% digits, 4+ chars
-		{"abc123def456", true},     // UUID-like
-		{"pod-name-here", false},   // Typical k8s name
-		{"1234567890abcd", true},   // Long with many digits
-		{"default", false},         // Common namespace name
+		{"v1", false},            // Version pattern
+		{"v2", false},            // Version pattern
+		{"v1beta1", false},       // Version pattern with suffix
+		{"v1alpha2", false},      // Version pattern with suffix
+		{"users", false},         // No digits
+		{"abc", false},           // Too short
+		{"12345", true},          // All digits, 5+ chars
+		{"user1234", true},       // >40% digits, 4+ chars
+		{"abc123def456", true},   // UUID-like
+		{"pod-name-here", false}, // Typical k8s name
+		{"1234567890abcd", true}, // Long with many digits
+		{"default", false},       // Common namespace name
 	}
 
 	for _, tt := range tests {

--- a/internal/server/middleware/security_test.go
+++ b/internal/server/middleware/security_test.go
@@ -249,12 +249,12 @@ func TestValidateAllowedOrigins(t *testing.T) {
 // TestMaxRequestSize tests request body size limiting middleware
 func TestMaxRequestSize(t *testing.T) {
 	tests := []struct {
-		name           string
-		maxBytes       int64
-		bodySize       int
-		wantBodyRead   bool
-		wantReadError  bool
-		wantBytesRead  int // Number of bytes expected to be read (limited by maxBytes)
+		name          string
+		maxBytes      int64
+		bodySize      int
+		wantBodyRead  bool
+		wantReadError bool
+		wantBytesRead int // Number of bytes expected to be read (limited by maxBytes)
 	}{
 		{
 			name:          "request within limit",

--- a/internal/server/oauth_http.go
+++ b/internal/server/oauth_http.go
@@ -758,12 +758,10 @@ func (s *OAuthHTTPServer) Start(addr string, config OAuthConfig) error {
 	}
 
 	// Create HTTP server with security, CORS, and request size limiting middleware
+	// Order matters: MaxRequestSize is outermost (applied last, executed first)
+	// to reject oversized requests before any processing occurs
 	handler := middleware.SecurityHeaders(config.EnableHSTS)(middleware.CORS(allowedOrigins)(mux))
-
-	// Apply request size limiting middleware for DoS protection
-	if config.MaxRequestSize > 0 {
-		handler = middleware.MaxRequestSize(config.MaxRequestSize)(handler)
-	}
+	handler = middleware.MaxRequestSize(config.MaxRequestSize)(handler)
 
 	s.httpServer = &http.Server{
 		Addr:              addr,


### PR DESCRIPTION
## Summary

- Add `--max-request-size` flag (default 5MB) to prevent DoS attacks via oversized request bodies
- The middleware wraps handlers with `http.MaxBytesHandler` which returns 413 Request Entity Too Large when the body exceeds the configured limit
- Can be configured via Helm values at `mcpKubernetes.server.maxRequestSize`

## Changes

- Add `MaxRequestSize` to `ServeConfig` with 5MB default
- Add `MAX_REQUEST_SIZE` environment variable support
- Create `MaxRequestSize` middleware using `http.MaxBytesHandler`
- Apply middleware to both OAuth and non-OAuth HTTP servers
- Add Helm chart configuration: `mcpKubernetes.server.maxRequestSize`
- Update `values.schema.json` with the new configuration
- Add comprehensive unit tests for the middleware

## Security Review Implementation

This PR now includes all recommendations from the security review:

### 1. Minimum Enforced Limit with Warnings
- Added `MinRecommendedRequestSize` constant (1MB)
- Middleware logs warnings when:
  - Limit is disabled (0 or negative value)
  - Limit is below the recommended minimum (1MB)

### 2. Metrics and Logging for Rejected Requests
- Added `http_request_size_rejected_total` Prometheus metric (by method, path)
- Rejected requests are logged with:
  - HTTP method
  - Request path
  - Content-Length
  - Remote address
- Path normalization prevents metric cardinality explosion (handles version patterns like v1, v2)

### 3. Documentation for Per-Endpoint Limits (Future)
- Infrastructure added via `MaxRequestSizeWithConfig` for future per-endpoint configuration
- Helm values documentation updated with security recommendations

## Code Review Improvements

The following improvements were made after code review:

### Initial Review Fixes
- **Middleware ordering**: `MaxRequestSize` is now the outermost middleware in the OAuth server, ensuring oversized requests are rejected before any processing occurs
- **Structured logging**: Replaced `fmt.Printf` with `slog.Info` for consistency with the codebase's logging patterns
- **Simplified conditionals**: Removed redundant `if maxRequestSize > 0` check since the middleware already handles zero/negative values gracefully
- **Added comments**: Clarified middleware ordering rationale in code comments

### Follow-up Review Fixes (Latest Commit)
- **Removed dead code**: Removed unused `statusRecorder` struct and `MaxBytesExceededHandler` function
- **Fixed metrics recording**: `maxBytesHandler` now properly records rejection metrics via `maxBytesResponseWriter`
- **DRY improvement**: Consolidated duplicate `MinRecommendedRequestSize` constant (was defined in both cmd and middleware packages)
- **Named constants**: Extracted magic numbers as named constants (`minSegmentLengthForID`, `maxVersionSegmentLength`, `dynamicSegmentNumericThreshold`)
- **Test coverage**: Improved from 74.6% to 91.1% with additional edge case tests

## Test plan

- [x] Unit tests for middleware cover all edge cases
- [x] Tests for path normalization and dynamic segment detection
- [x] Tests for minimum size constant verification
- [x] Tests for metrics recording (nil cases)
- [x] Tests for response writer passthrough
- [x] All existing tests pass
- [x] Linting passes (0 issues)
- [x] Test coverage at 91.1% (exceeds 80% minimum)
- [x] Helm chart linting passes

Closes #235