### PR TITLE
fix(federation): use CAPI v1beta2 for cluster discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Updated CAPI Cluster discovery to use `cluster.x-k8s.io/v1beta2` API ([#253](https://github.com/giantswarm/mcp-kubernetes/issues/253))
+
 ## [0.0.19] - 2025-07-24
 
 ### Changed

--- a/internal/federation/discovery_test.go
+++ b/internal/federation/discovery_test.go
@@ -15,7 +15,7 @@ import (
 func createTestCAPIClusterWithDetails(name, namespace string, opts ...clusterOption) *unstructured.Unstructured {
 	cluster := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": "cluster.x-k8s.io/v1beta1",
+			"apiVersion": "cluster.x-k8s.io/v1beta2",
 			"kind":       "Cluster",
 			"metadata": map[string]interface{}{
 				"name":              name,

--- a/internal/federation/kubeconfig_test.go
+++ b/internal/federation/kubeconfig_test.go
@@ -706,7 +706,7 @@ func TestRemoteClientWithKubeconfig(t *testing.T) {
 
 func TestCAPIClusterGVR(t *testing.T) {
 	assert.Equal(t, "cluster.x-k8s.io", CAPIClusterGVR.Group)
-	assert.Equal(t, "v1beta1", CAPIClusterGVR.Version)
+	assert.Equal(t, "v1beta2", CAPIClusterGVR.Version)
 	assert.Equal(t, "clusters", CAPIClusterGVR.Resource)
 }
 

--- a/internal/federation/manager.go
+++ b/internal/federation/manager.go
@@ -451,7 +451,7 @@ func (m *Manager) GetRestConfig(ctx context.Context, clusterName string, user *U
 // The results are filtered based on the user's RBAC permissions - only clusters
 // in namespaces the user can access will be returned.
 //
-// This method queries CAPI Cluster resources (cluster.x-k8s.io/v1beta1) on the
+// This method queries CAPI Cluster resources (cluster.x-k8s.io/v1beta2) on the
 // Management Cluster and extracts metadata including:
 //   - Provider (AWS, Azure, vSphere, etc.)
 //   - Giant Swarm release version

--- a/internal/federation/sso_passthrough_test.go
+++ b/internal/federation/sso_passthrough_test.go
@@ -53,7 +53,7 @@ func TestManager_GetClusterEndpoint(t *testing.T) {
 			clusterName: "test-cluster",
 			cluster: &unstructured.Unstructured{
 				Object: map[string]interface{}{
-					"apiVersion": "cluster.x-k8s.io/v1beta1",
+					"apiVersion": "cluster.x-k8s.io/v1beta2",
 					"kind":       "Cluster",
 					"metadata": map[string]interface{}{
 						"name":      "test-cluster",
@@ -75,7 +75,7 @@ func TestManager_GetClusterEndpoint(t *testing.T) {
 			clusterName: "test-cluster",
 			cluster: &unstructured.Unstructured{
 				Object: map[string]interface{}{
-					"apiVersion": "cluster.x-k8s.io/v1beta1",
+					"apiVersion": "cluster.x-k8s.io/v1beta2",
 					"kind":       "Cluster",
 					"metadata": map[string]interface{}{
 						"name":      "test-cluster",
@@ -96,7 +96,7 @@ func TestManager_GetClusterEndpoint(t *testing.T) {
 			clusterName: "nonexistent",
 			cluster: &unstructured.Unstructured{
 				Object: map[string]interface{}{
-					"apiVersion": "cluster.x-k8s.io/v1beta1",
+					"apiVersion": "cluster.x-k8s.io/v1beta2",
 					"kind":       "Cluster",
 					"metadata": map[string]interface{}{
 						"name":      "other-cluster",
@@ -111,7 +111,7 @@ func TestManager_GetClusterEndpoint(t *testing.T) {
 			clusterName: "test-cluster",
 			cluster: &unstructured.Unstructured{
 				Object: map[string]interface{}{
-					"apiVersion": "cluster.x-k8s.io/v1beta1",
+					"apiVersion": "cluster.x-k8s.io/v1beta2",
 					"kind":       "Cluster",
 					"metadata": map[string]interface{}{
 						"name":      "test-cluster",

--- a/internal/federation/testing_helpers_test.go
+++ b/internal/federation/testing_helpers_test.go
@@ -67,7 +67,7 @@ func createTestFakeDynamicClient(scheme *runtime.Scheme, objects ...runtime.Obje
 func createTestCAPICluster(name, namespace string) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": "cluster.x-k8s.io/v1beta1",
+			"apiVersion": "cluster.x-k8s.io/v1beta2",
 			"kind":       "Cluster",
 			"metadata": map[string]interface{}{
 				"name":      name,

--- a/internal/federation/types.go
+++ b/internal/federation/types.go
@@ -167,7 +167,7 @@ var (
 	// CAPIClusterGVR is the GroupVersionResource for CAPI Cluster objects.
 	CAPIClusterGVR = schema.GroupVersionResource{
 		Group:    "cluster.x-k8s.io",
-		Version:  "v1beta1",
+		Version:  "v1beta2",
 		Resource: "clusters",
 	}
 )


### PR DESCRIPTION
## Summary

- Switch CAPI Cluster discovery from `cluster.x-k8s.io/v1beta1` to `v1beta2`
- Update `CAPIClusterGVR` constant in `internal/federation/types.go`
- Update all test fixtures and assertions to use v1beta2
- Add CHANGELOG entry

## Background

The federation manager was targeting the deprecated v1beta1 CAPI Cluster API, causing deprecation warnings from the Kubernetes API server. All clusters in Gazelle already serve v1beta2.

## Changes

| File | Change |
|------|--------|
| `internal/federation/types.go` | Updated `CAPIClusterGVR` to v1beta2 |
| `internal/federation/manager.go` | Updated documentation comment |
| `internal/federation/discovery_test.go` | Updated test helper |
| `internal/federation/kubeconfig_test.go` | Updated GVR assertion |
| `internal/federation/sso_passthrough_test.go` | Updated 4 test fixtures |
| `internal/federation/testing_helpers_test.go` | Updated shared test helper |
| `CHANGELOG.md` | Added entry under Unreleased |

## Test plan

- [x] All federation tests pass
- [x] Linter reports 0 issues
- [x] CI passes

Closes #253