### PR TITLE
fix(metrics): unify Kubernetes ops metric labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,8 +171,8 @@ OTEL_TRACES_SAMPLER_ARG=0.1
 **Available Metrics:**
 - `http_requests_total` - HTTP request counter
 - `http_request_duration_seconds` - HTTP request duration histogram
-- `kubernetes_operations_total` - Kubernetes operation counter
-- `kubernetes_operation_duration_seconds` - K8s operation duration histogram
+- `mcp_kubernetes_operations_total` - Kubernetes operation counter (management + workload scopes)
+- `mcp_kubernetes_operation_duration_seconds` - K8s operation duration histogram
 - `kubernetes_pod_operations_total` - Pod operation counter
 - `oauth_downstream_auth_total` - OAuth authentication counter
 - `active_port_forward_sessions` - Active port-forward sessions gauge

--- a/helm/mcp-kubernetes/dashboards/administrator-dashboard.json
+++ b/helm/mcp-kubernetes/dashboards/administrator-dashboard.json
@@ -650,7 +650,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (operation) (rate(kubernetes_operations_total{namespace=~\"$namespace\"}[$__rate_interval]))",
+          "expr": "sum by (operation) (rate(mcp_kubernetes_operations_total{namespace=~\"$namespace\", cluster_scope=\"management\", discovery_mode=\"single\"}[$__rate_interval]))",
           "legendFormat": "{{operation}}",
           "refId": "A"
         }
@@ -739,7 +739,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (operation) (rate(kubernetes_operations_total{namespace=~\"$namespace\", status=\"error\"}[$__rate_interval]))",
+          "expr": "sum by (operation) (rate(mcp_kubernetes_operations_total{namespace=~\"$namespace\", cluster_scope=\"management\", discovery_mode=\"single\", status=\"error\"}[$__rate_interval]))",
           "legendFormat": "{{operation}} errors",
           "refId": "A"
         }
@@ -828,7 +828,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le, operation) (rate(kubernetes_operation_duration_seconds_bucket{namespace=~\"$namespace\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le, operation) (rate(mcp_kubernetes_operation_duration_seconds_bucket{namespace=~\"$namespace\", cluster_scope=\"management\", discovery_mode=\"single\"}[$__rate_interval])))",
           "legendFormat": "{{operation}}",
           "refId": "A"
         }

--- a/helm/mcp-kubernetes/dashboards/cluster-operator-dashboard.json
+++ b/helm/mcp-kubernetes/dashboards/cluster-operator-dashboard.json
@@ -98,7 +98,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(mcp_cluster_operations_total{namespace=~\"$namespace\"}[$__rate_interval]))",
+          "expr": "sum(rate(mcp_kubernetes_operations_total{namespace=~\"$namespace\", cluster_scope=\"workload\", discovery_mode=\"capi\"}[$__rate_interval]))",
           "legendFormat": "Operations/s",
           "refId": "A"
         }
@@ -295,7 +295,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "100 * sum(rate(mcp_cluster_operations_total{namespace=~\"$namespace\", status=\"error\"}[$__rate_interval])) / sum(rate(mcp_cluster_operations_total{namespace=~\"$namespace\"}[$__rate_interval]))",
+          "expr": "100 * sum(rate(mcp_kubernetes_operations_total{namespace=~\"$namespace\", cluster_scope=\"workload\", discovery_mode=\"capi\", status=\"error\"}[$__rate_interval])) / sum(rate(mcp_kubernetes_operations_total{namespace=~\"$namespace\", cluster_scope=\"workload\", discovery_mode=\"capi\"}[$__rate_interval]))",
           "legendFormat": "Error Rate",
           "refId": "A"
         }
@@ -397,8 +397,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (cluster) (rate(mcp_cluster_operations_total{namespace=~\"$namespace\"}[$__rate_interval]))",
-          "legendFormat": "{{cluster}}",
+          "expr": "sum by (cluster_type) (rate(mcp_kubernetes_operations_total{namespace=~\"$namespace\", cluster_scope=\"workload\", discovery_mode=\"capi\"}[$__rate_interval]))",
+          "legendFormat": "{{cluster_type}}",
           "refId": "A"
         }
       ],
@@ -486,8 +486,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (cluster) (rate(mcp_cluster_operations_total{namespace=~\"$namespace\", status=\"error\"}[$__rate_interval]))",
-          "legendFormat": "{{cluster}}",
+          "expr": "sum by (cluster_type) (rate(mcp_kubernetes_operations_total{namespace=~\"$namespace\", cluster_scope=\"workload\", discovery_mode=\"capi\", status=\"error\"}[$__rate_interval]))",
+          "legendFormat": "{{cluster_type}}",
           "refId": "A"
         }
       ],
@@ -575,8 +575,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le, cluster) (rate(mcp_cluster_operation_duration_seconds_bucket{namespace=~\"$namespace\"}[$__rate_interval])))",
-          "legendFormat": "{{cluster}}",
+          "expr": "histogram_quantile(0.95, sum by (le, cluster_type) (rate(mcp_kubernetes_operation_duration_seconds_bucket{namespace=~\"$namespace\", cluster_scope=\"workload\", discovery_mode=\"capi\"}[$__rate_interval])))",
+          "legendFormat": "{{cluster_type}}",
           "refId": "A"
         }
       ],
@@ -664,7 +664,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (operation) (rate(mcp_cluster_operations_total{namespace=~\"$namespace\"}[$__rate_interval]))",
+          "expr": "sum by (operation) (rate(mcp_kubernetes_operations_total{namespace=~\"$namespace\", cluster_scope=\"workload\", discovery_mode=\"capi\"}[$__rate_interval]))",
           "legendFormat": "{{operation}}",
           "refId": "A"
         }
@@ -753,7 +753,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le, operation) (rate(mcp_cluster_operation_duration_seconds_bucket{namespace=~\"$namespace\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le, operation) (rate(mcp_kubernetes_operation_duration_seconds_bucket{namespace=~\"$namespace\", cluster_scope=\"workload\", discovery_mode=\"capi\"}[$__rate_interval])))",
           "legendFormat": "{{operation}}",
           "refId": "A"
         }

--- a/helm/mcp-kubernetes/dashboards/security-dashboard.json
+++ b/helm/mcp-kubernetes/dashboards/security-dashboard.json
@@ -98,7 +98,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(increase(kubernetes_operations_total{namespace=~\"$namespace\"}[24h]))",
+          "expr": "sum(increase(mcp_kubernetes_operations_total{namespace=~\"$namespace\", cluster_scope=\"management\", discovery_mode=\"single\"}[24h]))",
           "legendFormat": "Operations",
           "refId": "A"
         }
@@ -165,7 +165,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(increase(kubernetes_operations_total{namespace=~\"$namespace\", status=\"error\"}[24h]))",
+          "expr": "sum(increase(mcp_kubernetes_operations_total{namespace=~\"$namespace\", cluster_scope=\"management\", discovery_mode=\"single\", status=\"error\"}[24h]))",
           "legendFormat": "Failures",
           "refId": "A"
         }

--- a/helm/mcp-kubernetes/templates/prometheusrule.yaml
+++ b/helm/mcp-kubernetes/templates/prometheusrule.yaml
@@ -56,13 +56,17 @@ spec:
             runbook_url: {{ .Values.prometheusRules.runbookBaseUrl }}/mcp-kubernetes-k8s-operation-failures
           expr: |
             (
-              sum by (operation) (rate(kubernetes_operations_total{
+              sum by (operation) (rate(mcp_kubernetes_operations_total{
                 job="{{ include "mcp-kubernetes.fullname" . }}",
+                cluster_scope="management",
+                discovery_mode="single",
                 status="error"
               }[15m]))
               /
-              sum by (operation) (rate(kubernetes_operations_total{
-                job="{{ include "mcp-kubernetes.fullname" . }}"
+              sum by (operation) (rate(mcp_kubernetes_operations_total{
+                job="{{ include "mcp-kubernetes.fullname" . }}",
+                cluster_scope="management",
+                discovery_mode="single"
               }[15m]))
             ) > 0.2
           for: 15m
@@ -144,13 +148,17 @@ spec:
             runbook_url: {{ .Values.prometheusRules.runbookBaseUrl }}/mcp-kubernetes-cluster-operation-failures
           expr: |
             (
-              sum by (operation) (rate(mcp_cluster_operations_total{
+              sum by (operation) (rate(mcp_kubernetes_operations_total{
                 job="{{ include "mcp-kubernetes.fullname" . }}",
+                cluster_scope="workload",
+                discovery_mode="capi",
                 status="error"
               }[15m]))
               /
-              sum by (operation) (rate(mcp_cluster_operations_total{
-                job="{{ include "mcp-kubernetes.fullname" . }}"
+              sum by (operation) (rate(mcp_kubernetes_operations_total{
+                job="{{ include "mcp-kubernetes.fullname" . }}",
+                cluster_scope="workload",
+                discovery_mode="capi"
               }[15m]))
             ) > 0.3
           for: 15m

--- a/internal/instrumentation/doc.go
+++ b/internal/instrumentation/doc.go
@@ -16,11 +16,11 @@
 // Server/HTTP Metrics:
 //   - http_requests_total: Counter of HTTP requests by method, path, and status
 //   - http_request_duration_seconds: Histogram of HTTP request durations
-//   - active_sessions: Gauge of active port-forward sessions
+//   - active_port_forward_sessions: Gauge of active port-forward sessions
 //
 // Kubernetes Operation Metrics:
-//   - kubernetes_operations_total: Counter of K8s operations by operation, resource_type, namespace, status
-//   - kubernetes_operation_duration_seconds: Histogram of K8s operation durations
+//   - mcp_kubernetes_operations_total: Counter of K8s operations by cluster_scope, discovery_mode, cluster_type, operation, status
+//   - mcp_kubernetes_operation_duration_seconds: Histogram of K8s operation durations by cluster_scope, discovery_mode, cluster_type, operation, status
 //
 // Pod Operation Metrics:
 //   - kubernetes_pod_operations_total: Counter of pod operations
@@ -36,8 +36,8 @@
 // oauth.cimd.fetch.duration, oauth.cimd.cache.total
 //
 // CAPI/Federation Metrics (with cardinality controls):
-//   - mcp_cluster_operations_total: Counter of remote cluster operations (by cluster_type, operation, status)
-//   - mcp_cluster_operation_duration_seconds: Histogram of remote cluster operation durations
+//   - mcp_kubernetes_operations_total: Covers remote cluster operations with cluster_scope=workload and discovery_mode=capi
+//   - mcp_kubernetes_operation_duration_seconds: Histogram of operation durations for management/workload scopes
 //   - mcp_impersonation_total: Counter of impersonation requests (by user_domain, cluster_type, result)
 //   - mcp_federation_client_creations_total: Counter of federation client creation attempts
 //   - mcp_client_cache_hits_total: Counter of client cache hits
@@ -137,7 +137,7 @@
 //	recorder.RecordHTTPRequest(ctx, "POST", "/mcp", 200, time.Since(start))
 //
 //	// Record a Kubernetes operation
-//	recorder.RecordK8sOperation(ctx, "get", "pods", "default", "success", time.Since(start))
+//	recorder.RecordK8sOperation(ctx, "", "get", "pods", "default", "success", time.Since(start))
 //
 //	// Record a CAPI cluster operation with cardinality control
 //	recorder.RecordClusterOperation(ctx, "prod-wc-01", "list", "success", time.Since(start))

--- a/internal/instrumentation/metrics_test.go
+++ b/internal/instrumentation/metrics_test.go
@@ -106,9 +106,9 @@ func TestMetrics_RecordK8sOperation(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	metrics.RecordK8sOperation(ctx, OperationGet, "pods", "default", StatusSuccess, 50*time.Millisecond)
-	metrics.RecordK8sOperation(ctx, OperationList, "deployments", "kube-system", StatusSuccess, 100*time.Millisecond)
-	metrics.RecordK8sOperation(ctx, OperationDelete, "pods", "default", StatusError, 75*time.Millisecond)
+	metrics.RecordK8sOperation(ctx, "", OperationGet, "pods", "default", StatusSuccess, 50*time.Millisecond)
+	metrics.RecordK8sOperation(ctx, "", OperationList, "deployments", "kube-system", StatusSuccess, 100*time.Millisecond)
+	metrics.RecordK8sOperation(ctx, "", OperationDelete, "pods", "default", StatusError, 75*time.Millisecond)
 }
 
 func TestMetrics_RecordK8sOperation_NilMetrics(t *testing.T) {
@@ -116,7 +116,7 @@ func TestMetrics_RecordK8sOperation_NilMetrics(t *testing.T) {
 	ctx := context.Background()
 
 	// Should not panic
-	metrics.RecordK8sOperation(ctx, OperationGet, "pods", "default", StatusSuccess, 50*time.Millisecond)
+	metrics.RecordK8sOperation(ctx, "", OperationGet, "pods", "default", StatusSuccess, 50*time.Millisecond)
 }
 
 func TestMetrics_RecordPodOperation(t *testing.T) {
@@ -288,7 +288,7 @@ func TestMetrics_ConcurrentK8sOperationRecording(t *testing.T) {
 			if id%3 == 0 {
 				namespace = "kube-system"
 			}
-			metrics.RecordK8sOperation(ctx, operation, "pods", namespace, StatusSuccess, 50*time.Millisecond)
+			metrics.RecordK8sOperation(ctx, "", operation, "pods", namespace, StatusSuccess, 50*time.Millisecond)
 		}(i)
 	}
 
@@ -394,12 +394,6 @@ func TestNewMetrics_CAPIMetricsInitialized(t *testing.T) {
 	}
 
 	// Verify CAPI-specific metrics are initialized
-	if metrics.clusterOperationsTotal == nil {
-		t.Error("expected clusterOperationsTotal to be initialized")
-	}
-	if metrics.clusterOperationDuration == nil {
-		t.Error("expected clusterOperationDuration to be initialized")
-	}
 	if metrics.impersonationTotal == nil {
 		t.Error("expected impersonationTotal to be initialized")
 	}
@@ -827,8 +821,6 @@ func TestNewMetrics_AllMetricsInitialized(t *testing.T) {
 		{"clientCacheSize", metrics.clientCacheSize},
 
 		// CAPI/Federation metrics
-		{"clusterOperationsTotal", metrics.clusterOperationsTotal},
-		{"clusterOperationDuration", metrics.clusterOperationDuration},
 		{"impersonationTotal", metrics.impersonationTotal},
 		{"federationClientCreations", metrics.federationClientCreations},
 

--- a/internal/instrumentation/oauth_metrics_integration_test.go
+++ b/internal/instrumentation/oauth_metrics_integration_test.go
@@ -89,7 +89,7 @@ func TestMCPOAuthMetricsExposedViaPrometheus(t *testing.T) {
 	// These should always be present since we record them above
 	mcpK8sMetrics := []string{
 		"http_requests_total",
-		"kubernetes_operations_total",
+		"mcp_kubernetes_operations_total",
 		"oauth_downstream_auth_total",
 		"oauth_sso_token_injection_total",
 	}
@@ -278,8 +278,8 @@ func recordMCPKubernetesMetrics(ctx context.Context, m *Metrics) {
 	m.RecordHTTPRequest(ctx, "POST", "/mcp", 200, 100*time.Millisecond)
 
 	// Kubernetes operation metrics
-	m.RecordK8sOperation(ctx, OperationGet, "pods", "default", StatusSuccess, 50*time.Millisecond)
-	m.RecordK8sOperation(ctx, OperationList, "namespaces", "", StatusSuccess, 100*time.Millisecond)
+	m.RecordK8sOperation(ctx, "", OperationGet, "pods", "default", StatusSuccess, 50*time.Millisecond)
+	m.RecordK8sOperation(ctx, "", OperationList, "namespaces", "", StatusSuccess, 100*time.Millisecond)
 
 	// OAuth downstream auth metrics (mcp-kubernetes, not mcp-oauth library)
 	m.RecordOAuthDownstreamAuth(ctx, OAuthResultSuccess)

--- a/internal/server/context.go
+++ b/internal/server/context.go
@@ -247,13 +247,13 @@ func (sc *ServerContext) OutputConfig() *OutputConfig {
 
 // RecordK8sOperation records a Kubernetes operation metric if instrumentation is enabled.
 // This is a convenience method that handles nil checks internally.
-func (sc *ServerContext) RecordK8sOperation(ctx context.Context, operation, resourceType, namespace, status string, duration time.Duration) {
+func (sc *ServerContext) RecordK8sOperation(ctx context.Context, clusterName, operation, resourceType, namespace, status string, duration time.Duration) {
 	sc.mu.RLock()
 	provider := sc.instrumentationProvider
 	sc.mu.RUnlock()
 
 	if provider != nil && provider.Enabled() {
-		provider.Metrics().RecordK8sOperation(ctx, operation, resourceType, namespace, status, duration)
+		provider.Metrics().RecordK8sOperation(ctx, clusterName, operation, resourceType, namespace, status, duration)
 	}
 }
 


### PR DESCRIPTION
## Summary
- rename Kubernetes operation metrics to mcp_kubernetes_* with scope/discovery labels
- emit management/workload ops via the same metric pipeline
- update dashboards, Prometheus rules, and docs to match

## Test plan
- go test -ldflags "-w -linkmode 'auto' -extldflags '-static' -X 'github.com/giantswarm/mcp-kubernetes/pkg/project.buildTimestamp=2026-01-23T13:07:26Z' -X 'github.com/giantswarm/mcp-kubernetes/pkg/project.gitSHA=313d0201eb6b2367dbd5d1bba3e20788eb771886'" -race ./...
- make lint