### PR TITLE
fix(metrics): wire up federation metrics and rename to mcp_kubernetes_ prefix

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -282,7 +282,7 @@ histogram_quantile(0.95,
 )
 ```
 
-#### `mcp_impersonation_total`
+#### `mcp_kubernetes_impersonation_total`
 Counter of impersonation requests.
 
 **Labels:**
@@ -295,14 +295,14 @@ Counter of impersonation requests.
 **Example:**
 ```promql
 # Total impersonation by domain
-sum by (user_domain) (mcp_impersonation_total)
+sum by (user_domain) (mcp_kubernetes_impersonation_total)
 
 # Impersonation denial rate
-rate(mcp_impersonation_total{result="denied"}[5m])
-/ rate(mcp_impersonation_total[5m])
+rate(mcp_kubernetes_impersonation_total{result="denied"}[5m])
+/ rate(mcp_kubernetes_impersonation_total[5m])
 ```
 
-#### `mcp_federation_client_creations_total`
+#### `mcp_kubernetes_federation_client_creations_total`
 Counter of federation client creation attempts.
 
 **Labels:**
@@ -312,11 +312,11 @@ Counter of federation client creation attempts.
 **Example:**
 ```promql
 # Cache hit ratio
-mcp_federation_client_creations_total{result="cached"}
-/ sum(mcp_federation_client_creations_total)
+mcp_kubernetes_federation_client_creations_total{result="cached"}
+/ sum(mcp_kubernetes_federation_client_creations_total)
 ```
 
-#### `mcp_wc_auth_total`
+#### `mcp_kubernetes_wc_auth_total`
 Counter of workload cluster authentication attempts. Distinguishes between authentication modes.
 
 **Labels:**
@@ -333,29 +333,29 @@ Counter of workload cluster authentication attempts. Distinguishes between authe
 **Example:**
 ```promql
 # Total auth by mode
-sum by (auth_mode) (mcp_wc_auth_total)
+sum by (auth_mode) (mcp_kubernetes_wc_auth_total)
 
 # SSO passthrough success rate
-sum(rate(mcp_wc_auth_total{auth_mode="sso-passthrough", result="success"}[5m]))
-/ sum(rate(mcp_wc_auth_total{auth_mode="sso-passthrough"}[5m]))
+sum(rate(mcp_kubernetes_wc_auth_total{auth_mode="sso-passthrough", result="success"}[5m]))
+/ sum(rate(mcp_kubernetes_wc_auth_total{auth_mode="sso-passthrough"}[5m]))
 
 # Token-related failures in SSO passthrough mode
-rate(mcp_wc_auth_total{auth_mode="sso-passthrough", result=~"token.*"}[5m])
+rate(mcp_kubernetes_wc_auth_total{auth_mode="sso-passthrough", result=~"token.*"}[5m])
 ```
 
-#### `mcp_client_cache_hits_total`
+#### `mcp_kubernetes_client_cache_hits_total`
 Counter of client cache hits.
 
 **Labels:**
 - `cluster`: Cluster name (may have high cardinality)
 
-#### `mcp_client_cache_misses_total`
+#### `mcp_kubernetes_client_cache_misses_total`
 Counter of client cache misses.
 
 **Labels:**
 - `cluster`: Cluster name (may have high cardinality)
 
-#### `mcp_client_cache_evictions_total`
+#### `mcp_kubernetes_client_cache_evictions_total`
 Counter of client cache evictions.
 
 **Labels:**
@@ -364,19 +364,19 @@ Counter of client cache evictions.
 **Example:**
 ```promql
 # Cache eviction rate by reason
-sum by (reason) (rate(mcp_client_cache_evictions_total[5m]))
+sum by (reason) (rate(mcp_kubernetes_client_cache_evictions_total[5m]))
 ```
 
-#### `mcp_client_cache_entries`
+#### `mcp_kubernetes_client_cache_entries`
 Gauge of current entries in the client cache.
 
 **Example:**
 ```promql
 # Current cache size
-mcp_client_cache_entries
+mcp_kubernetes_client_cache_entries
 
 # Cache capacity utilization (if max entries is 1000)
-mcp_client_cache_entries / 1000
+mcp_kubernetes_client_cache_entries / 1000
 ```
 
 ## Example Prometheus Queries
@@ -547,7 +547,7 @@ groups:
 
       - alert: ImpersonationDenials
         expr: |
-          rate(mcp_impersonation_total{result="denied"}[5m]) > 0.1
+          rate(mcp_kubernetes_impersonation_total{result="denied"}[5m]) > 0.1
         for: 5m
         labels:
           severity: warning
@@ -557,7 +557,7 @@ groups:
 
       - alert: HighClientCacheEvictions
         expr: |
-          rate(mcp_client_cache_evictions_total{reason="lru"}[5m]) > 1
+          rate(mcp_kubernetes_client_cache_evictions_total{reason="lru"}[5m]) > 1
         for: 10m
         labels:
           severity: info
@@ -688,13 +688,13 @@ All dashboards support these template variables:
    ```
 6. **Cache Hit Ratio**:
    ```promql
-   100 * sum(rate(mcp_client_cache_hits_total[$__rate_interval])) 
-   / (sum(rate(mcp_client_cache_hits_total[$__rate_interval])) 
-      + sum(rate(mcp_client_cache_misses_total[$__rate_interval])))
+   100 * sum(rate(mcp_kubernetes_client_cache_hits_total[$__rate_interval])) 
+   / (sum(rate(mcp_kubernetes_client_cache_hits_total[$__rate_interval])) 
+      + sum(rate(mcp_kubernetes_client_cache_misses_total[$__rate_interval])))
    ```
 7. **Impersonation Denials**:
    ```promql
-   sum by (user_domain) (rate(mcp_impersonation_total{result="denied"}[$__rate_interval]))
+   sum by (user_domain) (rate(mcp_kubernetes_impersonation_total{result="denied"}[$__rate_interval]))
    ```
 
 ## Tracing

--- a/docs/rbac-security.md
+++ b/docs/rbac-security.md
@@ -605,20 +605,20 @@ Rate limiting protects against:
 Privileged secret access is instrumented with Prometheus metrics:
 
 ```
-# Metric: mcp_privileged_secret_access_total
+# Metric: mcp_kubernetes_privileged_secret_access_total
 # Labels: user_domain, result
 # Result values: success, error, rate_limited, fallback
 
 # Example queries:
 
 # Rate of privileged access attempts
-rate(mcp_privileged_secret_access_total[5m])
+rate(mcp_kubernetes_privileged_secret_access_total[5m])
 
 # Rate-limited requests (potential abuse)
-rate(mcp_privileged_secret_access_total{result="rate_limited"}[5m])
+rate(mcp_kubernetes_privileged_secret_access_total{result="rate_limited"}[5m])
 
 # Fallback to user credentials (weaker security, should be 0 in strict mode)
-rate(mcp_privileged_secret_access_total{result="fallback"}[5m])
+rate(mcp_kubernetes_privileged_secret_access_total{result="fallback"}[5m])
 ```
 
 ## References

--- a/docs/sso-passthrough-wc.md
+++ b/docs/sso-passthrough-wc.md
@@ -369,7 +369,7 @@ For production deployments, choose one of these approaches:
    - Trade-off: Higher latency per request
 
 3. **Monitor and alert:**
-   - Monitor `mcp_wc_auth_total{result="token_expired"}` metric (if enabled)
+   - Monitor `mcp_kubernetes_wc_auth_total{result="token_expired"}` metric (if enabled)
    - Implement retry logic in calling applications
 
 ## Troubleshooting

--- a/helm/mcp-kubernetes/dashboards/cluster-operator-dashboard.json
+++ b/helm/mcp-kubernetes/dashboards/cluster-operator-dashboard.json
@@ -157,7 +157,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(mcp_client_cache_entries{namespace=~\"$namespace\"}) or vector(0)",
+          "expr": "sum(mcp_kubernetes_client_cache_entries{namespace=~\"$namespace\"}) or vector(0)",
           "legendFormat": "Cached Clients",
           "refId": "A"
         }
@@ -226,7 +226,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "100 * sum(rate(mcp_client_cache_hits_total{namespace=~\"$namespace\"}[$__rate_interval])) / (sum(rate(mcp_client_cache_hits_total{namespace=~\"$namespace\"}[$__rate_interval])) + sum(rate(mcp_client_cache_misses_total{namespace=~\"$namespace\"}[$__rate_interval])))",
+          "expr": "100 * sum(rate(mcp_kubernetes_client_cache_hits_total{namespace=~\"$namespace\"}[$__rate_interval])) / (sum(rate(mcp_kubernetes_client_cache_hits_total{namespace=~\"$namespace\"}[$__rate_interval])) + sum(rate(mcp_kubernetes_client_cache_misses_total{namespace=~\"$namespace\"}[$__rate_interval])))",
           "legendFormat": "Cache Hit Ratio",
           "refId": "A"
         }
@@ -855,7 +855,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(mcp_client_cache_entries{namespace=~\"$namespace\"}) or vector(0)",
+          "expr": "sum(mcp_kubernetes_client_cache_entries{namespace=~\"$namespace\"}) or vector(0)",
           "legendFormat": "Cache Entries",
           "refId": "A"
         }
@@ -975,7 +975,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(mcp_client_cache_hits_total{namespace=~\"$namespace\"}[$__rate_interval]))",
+          "expr": "sum(rate(mcp_kubernetes_client_cache_hits_total{namespace=~\"$namespace\"}[$__rate_interval]))",
           "legendFormat": "Hits",
           "refId": "A"
         },
@@ -984,7 +984,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(mcp_client_cache_misses_total{namespace=~\"$namespace\"}[$__rate_interval]))",
+          "expr": "sum(rate(mcp_kubernetes_client_cache_misses_total{namespace=~\"$namespace\"}[$__rate_interval]))",
           "legendFormat": "Misses",
           "refId": "B"
         }
@@ -1073,7 +1073,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (reason) (rate(mcp_client_cache_evictions_total{namespace=~\"$namespace\"}[$__rate_interval]))",
+          "expr": "sum by (reason) (rate(mcp_kubernetes_client_cache_evictions_total{namespace=~\"$namespace\"}[$__rate_interval]))",
           "legendFormat": "{{reason}}",
           "refId": "A"
         }
@@ -1175,7 +1175,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (auth_mode) (rate(mcp_wc_auth_total{namespace=~\"$namespace\"}[$__rate_interval]))",
+          "expr": "sum by (auth_mode) (rate(mcp_kubernetes_wc_auth_total{namespace=~\"$namespace\"}[$__rate_interval]))",
           "legendFormat": "{{auth_mode}}",
           "refId": "A"
         }
@@ -1244,7 +1244,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "100 * sum(rate(mcp_wc_auth_total{namespace=~\"$namespace\", auth_mode=\"sso-passthrough\", result=\"success\"}[$__rate_interval])) / sum(rate(mcp_wc_auth_total{namespace=~\"$namespace\", auth_mode=\"sso-passthrough\"}[$__rate_interval]))",
+          "expr": "100 * sum(rate(mcp_kubernetes_wc_auth_total{namespace=~\"$namespace\", auth_mode=\"sso-passthrough\", result=\"success\"}[$__rate_interval])) / sum(rate(mcp_kubernetes_wc_auth_total{namespace=~\"$namespace\", auth_mode=\"sso-passthrough\"}[$__rate_interval]))",
           "legendFormat": "SSO Success Rate",
           "refId": "A"
         }
@@ -1333,7 +1333,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (cluster_type, result) (rate(mcp_wc_auth_total{namespace=~\"$namespace\"}[$__rate_interval]))",
+          "expr": "sum by (cluster_type, result) (rate(mcp_kubernetes_wc_auth_total{namespace=~\"$namespace\"}[$__rate_interval]))",
           "legendFormat": "{{cluster_type}} - {{result}}",
           "refId": "A"
         }
@@ -1481,7 +1481,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (result) (rate(mcp_federation_client_creations_total{namespace=~\"$namespace\"}[$__rate_interval]))",
+          "expr": "sum by (result) (rate(mcp_kubernetes_federation_client_creations_total{namespace=~\"$namespace\"}[$__rate_interval]))",
           "legendFormat": "{{result}}",
           "refId": "A"
         }
@@ -1570,7 +1570,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (cluster) (rate(mcp_federation_client_creations_total{namespace=~\"$namespace\"}[$__rate_interval]))",
+          "expr": "sum by (cluster) (rate(mcp_kubernetes_federation_client_creations_total{namespace=~\"$namespace\"}[$__rate_interval]))",
           "legendFormat": "{{cluster}}",
           "refId": "A"
         }

--- a/helm/mcp-kubernetes/dashboards/security-dashboard.json
+++ b/helm/mcp-kubernetes/dashboards/security-dashboard.json
@@ -299,7 +299,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(increase(mcp_impersonation_total{namespace=~\"$namespace\", result=\"denied\"}[24h])) or vector(0)",
+          "expr": "sum(increase(mcp_kubernetes_impersonation_total{namespace=~\"$namespace\", result=\"denied\"}[24h])) or vector(0)",
           "legendFormat": "Denials",
           "refId": "A"
         }
@@ -358,7 +358,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(increase(mcp_privileged_secret_access_total{namespace=~\"$namespace\"}[24h])) or vector(0)",
+          "expr": "sum(increase(mcp_kubernetes_privileged_secret_access_total{namespace=~\"$namespace\"}[24h])) or vector(0)",
           "legendFormat": "Secret Access",
           "refId": "A"
         }
@@ -527,7 +527,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (user_domain) (rate(mcp_impersonation_total{namespace=~\"$namespace\"}[$__rate_interval]))",
+          "expr": "sum by (user_domain) (rate(mcp_kubernetes_impersonation_total{namespace=~\"$namespace\"}[$__rate_interval]))",
           "legendFormat": "{{user_domain}}",
           "refId": "A"
         }
@@ -617,7 +617,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (user_domain) (rate(mcp_impersonation_total{namespace=~\"$namespace\", result=\"denied\"}[$__rate_interval]))",
+          "expr": "sum by (user_domain) (rate(mcp_kubernetes_impersonation_total{namespace=~\"$namespace\", result=\"denied\"}[$__rate_interval]))",
           "legendFormat": "{{user_domain}}",
           "refId": "A"
         }
@@ -706,7 +706,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (cluster) (rate(mcp_impersonation_total{namespace=~\"$namespace\"}[$__rate_interval]))",
+          "expr": "sum by (cluster) (rate(mcp_kubernetes_impersonation_total{namespace=~\"$namespace\"}[$__rate_interval]))",
           "legendFormat": "{{cluster}}",
           "refId": "A"
         }
@@ -808,7 +808,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (user_domain) (rate(mcp_privileged_secret_access_total{namespace=~\"$namespace\"}[$__rate_interval]))",
+          "expr": "sum by (user_domain) (rate(mcp_kubernetes_privileged_secret_access_total{namespace=~\"$namespace\"}[$__rate_interval]))",
           "legendFormat": "{{user_domain}}",
           "refId": "A"
         }
@@ -898,7 +898,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (user_domain) (rate(mcp_privileged_secret_access_total{namespace=~\"$namespace\", result=\"rate_limited\"}[$__rate_interval]))",
+          "expr": "sum by (user_domain) (rate(mcp_kubernetes_privileged_secret_access_total{namespace=~\"$namespace\", result=\"rate_limited\"}[$__rate_interval]))",
           "legendFormat": "{{user_domain}}",
           "refId": "A"
         }
@@ -1689,7 +1689,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (auth_mode) (rate(mcp_wc_auth_total{namespace=~\"$namespace\"}[$__rate_interval]))",
+          "expr": "sum by (auth_mode) (rate(mcp_kubernetes_wc_auth_total{namespace=~\"$namespace\"}[$__rate_interval]))",
           "legendFormat": "{{auth_mode}}",
           "refId": "A"
         }
@@ -1794,7 +1794,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (result) (rate(mcp_wc_auth_total{namespace=~\"$namespace\", result=~\"token_.*\"}[$__rate_interval]))",
+          "expr": "sum by (result) (rate(mcp_kubernetes_wc_auth_total{namespace=~\"$namespace\", result=~\"token_.*\"}[$__rate_interval]))",
           "legendFormat": "{{result}}",
           "refId": "A"
         }
@@ -1883,7 +1883,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (cluster_type) (rate(mcp_wc_auth_total{namespace=~\"$namespace\", result=\"error\"}[$__rate_interval]))",
+          "expr": "sum by (cluster_type) (rate(mcp_kubernetes_wc_auth_total{namespace=~\"$namespace\", result=\"error\"}[$__rate_interval]))",
           "legendFormat": "{{cluster_type}}",
           "refId": "A"
         }

--- a/helm/mcp-kubernetes/templates/prometheusrule.yaml
+++ b/helm/mcp-kubernetes/templates/prometheusrule.yaml
@@ -121,12 +121,12 @@ spec:
             runbook_url: {{ .Values.prometheusRules.runbookBaseUrl }}/mcp-kubernetes-workload-cluster-auth-failures
           expr: |
             (
-              sum by (auth_mode) (rate(mcp_wc_auth_total{
+              sum by (auth_mode) (rate(mcp_kubernetes_wc_auth_total{
                 job="{{ include "mcp-kubernetes.fullname" . }}",
                 result="error"
               }[15m]))
               /
-              sum by (auth_mode) (rate(mcp_wc_auth_total{
+              sum by (auth_mode) (rate(mcp_kubernetes_wc_auth_total{
                 job="{{ include "mcp-kubernetes.fullname" . }}"
               }[15m]))
             ) > 0.3

--- a/internal/instrumentation/doc.go
+++ b/internal/instrumentation/doc.go
@@ -38,12 +38,14 @@
 // CAPI/Federation Metrics (with cardinality controls):
 //   - mcp_kubernetes_operations_total: Covers remote cluster operations with cluster_scope=workload and discovery_mode=capi
 //   - mcp_kubernetes_operation_duration_seconds: Histogram of operation durations for management/workload scopes
-//   - mcp_impersonation_total: Counter of impersonation requests (by user_domain, cluster_type, result)
-//   - mcp_federation_client_creations_total: Counter of federation client creation attempts
-//   - mcp_client_cache_hits_total: Counter of client cache hits
-//   - mcp_client_cache_misses_total: Counter of client cache misses
-//   - mcp_client_cache_evictions_total: Counter of client cache evictions
-//   - mcp_client_cache_entries: Gauge of current cache entries
+//   - mcp_kubernetes_impersonation_total: Counter of impersonation requests (by user_domain, cluster_type, result)
+//   - mcp_kubernetes_federation_client_creations_total: Counter of federation client creation attempts
+//   - mcp_kubernetes_privileged_secret_access_total: Counter of privileged secret access attempts
+//   - mcp_kubernetes_wc_auth_total: Counter of workload cluster authentication attempts
+//   - mcp_kubernetes_client_cache_hits_total: Counter of client cache hits
+//   - mcp_kubernetes_client_cache_misses_total: Counter of client cache misses
+//   - mcp_kubernetes_client_cache_evictions_total: Counter of client cache evictions
+//   - mcp_kubernetes_client_cache_entries: Gauge of current cache entries
 //
 // # Cardinality Management
 //

--- a/internal/instrumentation/metrics.go
+++ b/internal/instrumentation/metrics.go
@@ -183,39 +183,39 @@ func NewMetrics(meter metric.Meter, detailedLabels bool) (*Metrics, error) {
 	// high cardinality in environments with many clusters. Monitor your metrics
 	// backend capacity and consider aggregating by cluster if needed.
 	m.clientCacheHitsTotal, err = meter.Int64Counter(
-		"mcp_client_cache_hits_total",
+		"mcp_kubernetes_client_cache_hits_total",
 		metric.WithDescription("Total number of client cache hits. Label: cluster (may be high cardinality)"),
 		metric.WithUnit("{hit}"),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create mcp_client_cache_hits_total counter: %w", err)
+		return nil, fmt.Errorf("failed to create mcp_kubernetes_client_cache_hits_total counter: %w", err)
 	}
 
 	m.clientCacheMissesTotal, err = meter.Int64Counter(
-		"mcp_client_cache_misses_total",
+		"mcp_kubernetes_client_cache_misses_total",
 		metric.WithDescription("Total number of client cache misses. Label: cluster (may be high cardinality)"),
 		metric.WithUnit("{miss}"),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create mcp_client_cache_misses_total counter: %w", err)
+		return nil, fmt.Errorf("failed to create mcp_kubernetes_client_cache_misses_total counter: %w", err)
 	}
 
 	m.clientCacheEvictionsTotal, err = meter.Int64Counter(
-		"mcp_client_cache_evictions_total",
+		"mcp_kubernetes_client_cache_evictions_total",
 		metric.WithDescription("Total number of client cache evictions. Label: reason (expired, lru, manual)"),
 		metric.WithUnit("{eviction}"),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create mcp_client_cache_evictions_total counter: %w", err)
+		return nil, fmt.Errorf("failed to create mcp_kubernetes_client_cache_evictions_total counter: %w", err)
 	}
 
 	m.clientCacheSize, err = meter.Int64Gauge(
-		"mcp_client_cache_entries",
+		"mcp_kubernetes_client_cache_entries",
 		metric.WithDescription("Current number of entries in the client cache"),
 		metric.WithUnit("{entry}"),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create mcp_client_cache_entries gauge: %w", err)
+		return nil, fmt.Errorf("failed to create mcp_kubernetes_client_cache_entries gauge: %w", err)
 	}
 
 	// CAPI/Federation Metrics
@@ -224,21 +224,21 @@ func NewMetrics(meter metric.Meter, detailedLabels bool) (*Metrics, error) {
 	// - cluster_type instead of cluster_name (production/staging/other)
 	// - user_domain instead of full email (e.g., "giantswarm.io")
 	m.impersonationTotal, err = meter.Int64Counter(
-		"mcp_impersonation_total",
+		"mcp_kubernetes_impersonation_total",
 		metric.WithDescription("Total impersonation requests. Labels: user_domain, cluster_type, result"),
 		metric.WithUnit("{request}"),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create mcp_impersonation_total counter: %w", err)
+		return nil, fmt.Errorf("failed to create mcp_kubernetes_impersonation_total counter: %w", err)
 	}
 
 	m.federationClientCreations, err = meter.Int64Counter(
-		"mcp_federation_client_creations_total",
+		"mcp_kubernetes_federation_client_creations_total",
 		metric.WithDescription("Total federation client creation attempts. Labels: cluster_type, result"),
 		metric.WithUnit("{creation}"),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create mcp_federation_client_creations_total counter: %w", err)
+		return nil, fmt.Errorf("failed to create mcp_kubernetes_federation_client_creations_total counter: %w", err)
 	}
 
 	// Privileged Secret Access Metrics
@@ -246,12 +246,12 @@ func NewMetrics(meter metric.Meter, detailedLabels bool) (*Metrics, error) {
 	// Note on cardinality: Uses user_domain instead of full email to control cardinality.
 	// Result values: "success", "error", "rate_limited", "fallback"
 	m.privilegedSecretAccessTotal, err = meter.Int64Counter(
-		"mcp_privileged_secret_access_total",
+		"mcp_kubernetes_privileged_secret_access_total",
 		metric.WithDescription("Total privileged secret access attempts. Labels: user_domain, result"),
 		metric.WithUnit("{access}"),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create mcp_privileged_secret_access_total counter: %w", err)
+		return nil, fmt.Errorf("failed to create mcp_kubernetes_privileged_secret_access_total counter: %w", err)
 	}
 
 	// Workload Cluster Authentication Metrics
@@ -259,12 +259,12 @@ func NewMetrics(meter metric.Meter, detailedLabels bool) (*Metrics, error) {
 	// Note on cardinality: Uses auth_mode (impersonation, sso-passthrough) and result.
 	// cluster_type is used instead of cluster_name for cardinality control.
 	m.wcAuthTotal, err = meter.Int64Counter(
-		"mcp_wc_auth_total",
+		"mcp_kubernetes_wc_auth_total",
 		metric.WithDescription("Total workload cluster authentication attempts. Labels: auth_mode (impersonation, sso-passthrough), cluster_type, result"),
 		metric.WithUnit("{auth}"),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create mcp_wc_auth_total counter: %w", err)
+		return nil, fmt.Errorf("failed to create mcp_kubernetes_wc_auth_total counter: %w", err)
 	}
 
 	return m, nil

--- a/internal/instrumentation/metrics_integration_test.go
+++ b/internal/instrumentation/metrics_integration_test.go
@@ -100,20 +100,20 @@ func TestAllMetricsExposedViaPrometheus(t *testing.T) {
 		{"oauth_sso_token_injection_total", "SSO token injection events", false},
 
 		// Client cache metrics
-		{"mcp_client_cache_hits_total", "Cache hits", false},
-		{"mcp_client_cache_misses_total", "Cache misses", false},
-		{"mcp_client_cache_evictions_total", "Cache evictions", false},
-		{"mcp_client_cache_entries", "Current cache size", false},
+		{"mcp_kubernetes_client_cache_hits_total", "Cache hits", false},
+		{"mcp_kubernetes_client_cache_misses_total", "Cache misses", false},
+		{"mcp_kubernetes_client_cache_evictions_total", "Cache evictions", false},
+		{"mcp_kubernetes_client_cache_entries", "Current cache size", false},
 
 		// CAPI/Federation metrics
-		{"mcp_impersonation_total", "Impersonation requests", false},
-		{"mcp_federation_client_creations_total", "Federation client creations", false},
+		{"mcp_kubernetes_impersonation_total", "Impersonation requests", false},
+		{"mcp_kubernetes_federation_client_creations_total", "Federation client creations", false},
 
 		// Privileged access metrics
-		{"mcp_privileged_secret_access_total", "Privileged secret access", false},
+		{"mcp_kubernetes_privileged_secret_access_total", "Privileged secret access", false},
 
 		// Workload cluster auth metrics
-		{"mcp_wc_auth_total", "Workload cluster auth attempts", false},
+		{"mcp_kubernetes_wc_auth_total", "Workload cluster auth attempts", false},
 	}
 
 	// Check each metric


### PR DESCRIPTION
## Summary

This PR completes the metrics implementation from issue #252:

- **Wire up federation metrics**: Add `RecordImpersonation` and `RecordFederationClientCreation` to `AuthMetricsRecorder` interface and call them in the federation manager
- **Rename metrics to `mcp_kubernetes_` prefix** for consistency with the project naming convention
- **Update dashboards and PrometheusRule** to use the new metric names
- **Update documentation** to reflect the new metric naming convention

## Metric Renames

| Old Name | New Name |
|----------|----------|
| `mcp_client_cache_hits_total` | `mcp_kubernetes_client_cache_hits_total` |
| `mcp_client_cache_misses_total` | `mcp_kubernetes_client_cache_misses_total` |
| `mcp_client_cache_evictions_total` | `mcp_kubernetes_client_cache_evictions_total` |
| `mcp_client_cache_entries` | `mcp_kubernetes_client_cache_entries` |
| `mcp_impersonation_total` | `mcp_kubernetes_impersonation_total` |
| `mcp_federation_client_creations_total` | `mcp_kubernetes_federation_client_creations_total` |
| `mcp_privileged_secret_access_total` | `mcp_kubernetes_privileged_secret_access_total` |
| `mcp_wc_auth_total` | `mcp_kubernetes_wc_auth_total` |

## Changes

- `internal/federation/manager.go`: Add new interface methods and wire up metric recording
- `internal/instrumentation/metrics.go`: Rename metrics to `mcp_kubernetes_` prefix
- `internal/instrumentation/metrics_integration_test.go`: Update test expectations
- `helm/mcp-kubernetes/templates/prometheusrule.yaml`: Update metric references
- `helm/mcp-kubernetes/dashboards/*.json`: Update dashboard queries
- `docs/*.md`: Update documentation

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/instrumentation/... ./internal/federation/...` passes
- [x] `make lint` passes with 0 issues

Closes #252