### PR TITLE
fix(observability): improve cluster classification patterns and dashboard labels

### DIFF
--- a/helm/mcp-kubernetes/dashboards/cluster-operator-dashboard.json
+++ b/helm/mcp-kubernetes/dashboards/cluster-operator-dashboard.json
@@ -321,7 +321,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Operations rate by cluster type",
+      "description": "Operations rate by cluster classification (production, staging, development, cicd, operations, other)",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -402,7 +402,7 @@
           "refId": "A"
         }
       ],
-      "title": "Operations by Cluster Type",
+      "title": "Operations by Cluster Classification",
       "type": "timeseries"
     },
     {
@@ -410,7 +410,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Error rates by cluster type",
+      "description": "Error rates by cluster classification",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -491,7 +491,7 @@
           "refId": "A"
         }
       ],
-      "title": "Errors by Cluster Type",
+      "title": "Errors by Cluster Classification",
       "type": "timeseries"
     },
     {
@@ -499,7 +499,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "P95 operation duration by cluster type",
+      "description": "P95 operation duration by cluster classification",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -580,7 +580,7 @@
           "refId": "A"
         }
       ],
-      "title": "Operation Duration (P95) by Cluster",
+      "title": "Operation Duration (P95) by Cluster Classification",
       "type": "timeseries"
     },
     {
@@ -1257,7 +1257,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Auth result breakdown by cluster type",
+      "description": "Auth result breakdown by cluster classification",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1338,7 +1338,7 @@
           "refId": "A"
         }
       ],
-      "title": "Auth Results by Cluster Type",
+      "title": "Auth Results by Cluster Classification",
       "type": "timeseries"
     },
     {
@@ -1494,7 +1494,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Client creation by cluster type",
+      "description": "Client creation by cluster classification",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1575,7 +1575,7 @@
           "refId": "A"
         }
       ],
-      "title": "Client Creation by Cluster Type",
+      "title": "Client Creation by Cluster Classification",
       "type": "timeseries"
     }
   ],

--- a/helm/mcp-kubernetes/dashboards/security-dashboard.json
+++ b/helm/mcp-kubernetes/dashboards/security-dashboard.json
@@ -52,7 +52,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Total Kubernetes operations in the last 24 hours",
+      "description": "Total Kubernetes operations across all scopes (management + workload clusters) in the last 24 hours",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -98,7 +98,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(increase(mcp_kubernetes_operations_total{namespace=~\"$namespace\", cluster_scope=\"management\", discovery_mode=\"single\"}[24h]))",
+          "expr": "sum(increase(mcp_kubernetes_operations_total{namespace=~\"$namespace\"}[24h]))",
           "legendFormat": "Operations",
           "refId": "A"
         }
@@ -111,7 +111,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Failed operations in the last 24 hours",
+      "description": "Failed operations across all scopes (management + workload clusters) in the last 24 hours",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -165,7 +165,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(increase(mcp_kubernetes_operations_total{namespace=~\"$namespace\", cluster_scope=\"management\", discovery_mode=\"single\", status=\"error\"}[24h]))",
+          "expr": "sum(increase(mcp_kubernetes_operations_total{namespace=~\"$namespace\", status=\"error\"}[24h]))",
           "legendFormat": "Failures",
           "refId": "A"
         }
@@ -630,7 +630,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Impersonation requests by cluster type",
+      "description": "Impersonation requests by cluster classification",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -711,7 +711,7 @@
           "refId": "A"
         }
       ],
-      "title": "Impersonation by Cluster Type",
+      "title": "Impersonation by Cluster Classification",
       "type": "timeseries"
     },
     {
@@ -1807,7 +1807,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Auth errors by cluster type",
+      "description": "Auth errors by cluster classification",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1888,7 +1888,7 @@
           "refId": "A"
         }
       ],
-      "title": "Auth Errors by Cluster Type",
+      "title": "Auth Errors by Cluster Classification",
       "type": "timeseries"
     },
     {

--- a/internal/instrumentation/cardinality_test.go
+++ b/internal/instrumentation/cardinality_test.go
@@ -97,6 +97,100 @@ func TestClassifyClusterName(t *testing.T) {
 			input:    "cluster-dev",
 			expected: ClusterTypeDevelopment,
 		},
+		// Demo patterns (development)
+		{
+			name:     "demo- prefix",
+			input:    "demo-cluster",
+			expected: ClusterTypeDevelopment,
+		},
+		{
+			name:     "demo_ prefix",
+			input:    "demo_test",
+			expected: ClusterTypeDevelopment,
+		},
+		{
+			name:     "contains -demo-",
+			input:    "us-east-demo-01",
+			expected: ClusterTypeDevelopment,
+		},
+		{
+			name:     "demo prefix without separator",
+			input:    "demotech-rds",
+			expected: ClusterTypeDevelopment,
+		},
+		// Test patterns (development)
+		{
+			name:     "test- prefix",
+			input:    "test-cluster",
+			expected: ClusterTypeDevelopment,
+		},
+		{
+			name:     "test_ prefix",
+			input:    "test_env",
+			expected: ClusterTypeDevelopment,
+		},
+		{
+			name:     "contains -test-",
+			input:    "us-west-test-01",
+			expected: ClusterTypeDevelopment,
+		},
+		{
+			name:     "ends with -test",
+			input:    "cluster-test",
+			expected: ClusterTypeDevelopment,
+		},
+		// CI/CD patterns
+		{
+			name:     "cicd prefix",
+			input:    "cicdprod",
+			expected: ClusterTypeCICD,
+		},
+		{
+			name:     "cicd prefix with dev",
+			input:    "cicddev",
+			expected: ClusterTypeCICD,
+		},
+		{
+			name:     "cicd- prefix",
+			input:    "cicd-cluster",
+			expected: ClusterTypeCICD,
+		},
+		{
+			name:     "contains cicd",
+			input:    "my-cicd-env",
+			expected: ClusterTypeCICD,
+		},
+		// Operations patterns
+		{
+			name:     "operations exact",
+			input:    "operations",
+			expected: ClusterTypeOperations,
+		},
+		{
+			name:     "contains operations",
+			input:    "my-operations-cluster",
+			expected: ClusterTypeOperations,
+		},
+		{
+			name:     "ops- prefix",
+			input:    "ops-cluster",
+			expected: ClusterTypeOperations,
+		},
+		{
+			name:     "ops_ prefix",
+			input:    "ops_infra",
+			expected: ClusterTypeOperations,
+		},
+		{
+			name:     "contains -ops-",
+			input:    "infra-ops-01",
+			expected: ClusterTypeOperations,
+		},
+		{
+			name:     "ends with -ops",
+			input:    "infra-ops",
+			expected: ClusterTypeOperations,
+		},
 		// Other (no pattern match)
 		{
 			name:     "random cluster name",
@@ -195,6 +289,8 @@ func TestClusterTypeConstants(t *testing.T) {
 		ClusterTypeProduction,
 		ClusterTypeStaging,
 		ClusterTypeDevelopment,
+		ClusterTypeCICD,
+		ClusterTypeOperations,
 		ClusterTypeManagement,
 		ClusterTypeOther,
 	}
@@ -205,7 +301,7 @@ func TestClusterTypeConstants(t *testing.T) {
 		}
 	}
 
-	// Verify we have 5 distinct constant values
+	// Verify we have 7 distinct constant values
 	seen := make(map[ClusterType]bool)
 	for _, c := range constants {
 		if seen[c] {
@@ -213,8 +309,8 @@ func TestClusterTypeConstants(t *testing.T) {
 		}
 		seen[c] = true
 	}
-	if len(seen) != 5 {
-		t.Errorf("Expected 5 unique ClusterType constants, got %d", len(seen))
+	if len(seen) != 7 {
+		t.Errorf("Expected 7 unique ClusterType constants, got %d", len(seen))
 	}
 }
 


### PR DESCRIPTION
## Summary

- Extends `ClassifyClusterName()` to recognize Giant Swarm naming conventions:
  - Adds `ClusterTypeCICD` for `cicd*` patterns (e.g., `cicdprod`, `cicddev`)
  - Adds `ClusterTypeOperations` for `operations`/`ops` patterns
  - Adds `demo*` and `test*` patterns to development classification
- Updates dashboard panel titles from "Cluster" / "Cluster Type" to "Cluster Classification" to accurately reflect cardinality-controlled grouping
- Updates security dashboard queries to include all cluster scopes (management + workload) instead of filtering to single-mode management only

## Test plan

- [x] All existing unit tests pass
- [x] New test cases added for Giant Swarm naming patterns (`cicdprod`, `cicddev`, `operations`, `demotech-rds`, etc.)
- [x] Linting passes
- [ ] Dashboard queries can be validated against Mimir/Prometheus after deployment

Closes #260