### PR TITLE
fix(oauth): make COOP/COEP headers configurable for popup compatibility

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -949,6 +949,7 @@ func runServe(config ServeConfig) error {
 				MaxClientsPerIP:                    config.OAuth.MaxClientsPerIP,
 				EncryptionKey:                      encryptionKey,
 				EnableHSTS:                         os.Getenv("ENABLE_HSTS") == envValueTrue,
+				EnableCrossOriginIsolation:         os.Getenv("ENABLE_CROSS_ORIGIN_ISOLATION") == envValueTrue,
 				AllowedOrigins:                     os.Getenv("ALLOWED_ORIGINS"),
 				TLSCertFile:                        config.OAuth.TLSCertFile,
 				TLSKeyFile:                         config.OAuth.TLSKeyFile,


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/4185.

## Summary
- Makes COOP/COEP/CORP headers configurable via `ENABLE_CROSS_ORIGIN_ISOLATION` env var
- Disables cross-origin isolation headers by default to fix OAuth popup authentication flows

## Background
The strict COOP (`same-origin`) and COEP (`require-corp`) headers were breaking OAuth popup flows. The fix is to not set any cross-origin headers by default, allowing browser defaults which are compatible with OAuth popups.

## Test plan
- [x] Unit tests updated and passing
- [x] Manual test: OAuth popup flow works without `ENABLE_CROSS_ORIGIN_ISOLATION`
- [x] Manual test: Cross-origin isolation works when `ENABLE_CROSS_ORIGIN_ISOLATION=true`