### PR TITLE
fix: multiarch Dockerfile and faster CI with correct job ordering

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@6.13.0
+  architect: giantswarm/architect@6.14.0
 
 workflows:
   build:
@@ -9,23 +9,64 @@ workflows:
         name: go-build-mcp-kubernetes
         binary: mcp-kubernetes
         filters:
-            # Trigger the job also on git tag.
           tags:
             only: /^v.*/
 
-    - architect/push-to-registries:
+    # Branch builds: amd64 only for faster PR feedback
+    - architect/push-to-registries-multiarch:
         context: architect
         name: push-to-registries
+        platforms: "linux/amd64"
+        requires:
+        - go-build-mcp-kubernetes
+        filters:
+          branches:
+            ignore:
+            - main
+
+    # Tag builds: full multi-arch (amd64 + arm64)
+    - architect/push-to-registries-multiarch:
+        context: architect
+        name: push-to-registries-release
         requires:
         - go-build-mcp-kubernetes
         filters:
           tags:
             only: /^v.*/
+          branches:
+            ignore: /.*/
 
+    - architect/push-to-app-catalog:
+        executor: app-build-suite
+        context: architect
+        name: build-mcp-kubernetes-chart
+        app_catalog: giantswarm-catalog
+        app_catalog_test: giantswarm-test-catalog
+        chart: mcp-kubernetes
+        push_to_appcatalog: false
+        push_to_oci_registry: false
+        persist_chart_archive: true
+        requires:
+        - go-build-mcp-kubernetes
+        filters:
+          tags:
+            only: /^v.*/
           branches:
             ignore:
             - main
 
+    - architect/run-tests-with-ats:
+        name: execute chart tests
+        requires:
+        - build-mcp-kubernetes-chart
+        filters:
+          tags:
+            only: /^v.*/
+          branches:
+            ignore:
+            - main
+
+    # Branch: push chart after tests + amd64 image
     - architect/push-to-app-catalog:
         executor: app-build-suite
         context: architect
@@ -34,21 +75,26 @@ workflows:
         app_catalog_test: giantswarm-test-catalog
         chart: mcp-kubernetes
         requires:
+        - execute chart tests
         - push-to-registries
-        persist_chart_archive: true
+        filters:
+          branches:
+            ignore:
+            - main
+
+    # Tag: push chart after tests + multi-arch image
+    - architect/push-to-app-catalog:
+        executor: app-build-suite
+        context: architect
+        name: push-mcp-kubernetes-to-giantswarm-app-catalog-release
+        app_catalog: giantswarm-catalog
+        app_catalog_test: giantswarm-test-catalog
+        chart: mcp-kubernetes
+        requires:
+        - execute chart tests
+        - push-to-registries-release
         filters:
           tags:
             only: /^v.*/
-
           branches:
-            ignore:
-            - main
-
-    - architect/run-tests-with-ats:
-        name: execute chart tests
-        filters:
-          branches:
-            ignore:
-            - main
-        requires:
-        - push-mcp-kubernetes-to-giantswarm-app-catalog
+            ignore: /.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Updated CAPI Cluster discovery to use `cluster.x-k8s.io/v1beta2` API ([#253](https://github.com/giantswarm/mcp-kubernetes/issues/253))
+- Switch CI to `push-to-registries-multiarch` with amd64-only on branches
+  and full multi-arch on release tags for faster PR builds.
+- Run chart tests before pushing to the app catalog.
+- Update Dockerfile with multi-stage Go build for buildx multi-arch support.
 
 ### Fixed
 - Fixed `capi_cluster_health` reporting healthy clusters as UNHEALTHY due to CAPI v1beta2 schema changes ([#287](https://github.com/giantswarm/mcp-kubernetes/issues/287))


### PR DESCRIPTION
## Summary

- **Multiarch Dockerfile**: Add a multi-stage Go build using `FROM --platform=$BUILDPLATFORM` so buildx cross-compiles natively instead of under QEMU emulation. The previous Dockerfile relied on a pre-built binary (`ADD mcp-kubernetes /`) which only worked for single-arch builds.

- **Faster PR builds**: Switch to `push-to-registries-multiarch` (`architect-orb@6.14.0`) with `platforms: "linux/amd64"` on branches to avoid slow cross-compilation and Aliyun registry push timeouts. Full multi-arch builds (amd64 + arm64) only run on release tags.

- **Fix CI job ordering**: Chart tests now run *before* the chart is pushed to the app catalog, not after. The chart is first built/packaged without publishing, tested with ATS, and only pushed to the catalog once tests pass and the image is available.

## Test plan

- [ ] Verify branch CI build passes with amd64-only image push
- [ ] Verify chart tests execute before catalog push
- [ ] Create a test tag to verify full multi-arch release flow

Made with [Cursor](https://cursor.com)