### PR TITLE
chore(deps): update mcp-oauth to v0.2.68

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and full multi-arch on release tags for faster PR builds.
 - Run chart tests before pushing to the app catalog.
 - Update Dockerfile with multi-stage Go build for buildx multi-arch support.
+- Update `mcp-oauth` to v0.2.68.
 
 ### Fixed
 - Fixed `capi_cluster_health` reporting healthy clusters as UNHEALTHY due to CAPI v1beta2 schema changes ([#287](https://github.com/giantswarm/mcp-kubernetes/issues/287))

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.26.0
 
 require (
 	github.com/creativeprojects/go-selfupdate v1.5.2
-	github.com/giantswarm/mcp-oauth v0.2.67
+	github.com/giantswarm/mcp-oauth v0.2.68
 	github.com/mark3labs/mcp-go v0.44.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/giantswarm/mcp-oauth v0.2.67 h1:1JAdTzhb8+fsRmQtYO1guwLw39tU9yNABgGhyPRPKiM=
-github.com/giantswarm/mcp-oauth v0.2.67/go.mod h1:ESHnCKxnAGvvMHZIqh5f5uw01ggGxpGS330EnnVI62c=
+github.com/giantswarm/mcp-oauth v0.2.68 h1:oiFZng6BK0DGY1D3o31dLuWHFKl/kLOhWmeYQIyZcrE=
+github.com/giantswarm/mcp-oauth v0.2.68/go.mod h1:ESHnCKxnAGvvMHZIqh5f5uw01ggGxpGS330EnnVI62c=
 github.com/go-fed/httpsig v1.1.0 h1:9M+hb0jkEICD8/cAiNqEB66R87tTINszBRTjwjQzWcI=
 github.com/go-fed/httpsig v1.1.0/go.mod h1:RCMrTZvN1bJYtofsG4rd5NaO5obxQ5xBkdiS7xsT7bM=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=


### PR DESCRIPTION
## Summary
- Bump `github.com/giantswarm/mcp-oauth` from v0.2.67 to v0.2.68

## Test plan
- [ ] CI checks pass
- [ ] Build succeeds with updated dependency

Made with [Cursor](https://cursor.com)