### PR TITLE
Fix: Split release image push so China mirror failures don't block chart publication

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,10 +24,26 @@ workflows:
             ignore:
             - main
 
-    # Tag builds: full multi-arch (amd64 + arm64)
+    # Tag builds: push multi-arch image to gsoci (primary registry).
+    # Chart push depends on this completing successfully.
     - architect/push-to-registries-multiarch:
         context: architect
-        name: push-to-registries-release
+        name: push-to-gsoci-release
+        registries-data: "public gsoci.azurecr.io ACR_GSOCI_USERNAME ACR_GSOCI_PASSWORD true"
+        requires:
+        - go-build-mcp-kubernetes
+        filters:
+          tags:
+            only: /^v.*/
+          branches:
+            ignore: /.*/
+
+    # Tag builds: push multi-arch image to all registries (including China mirrors).
+    # Runs in parallel, does NOT block the chart push. If a mirror is unreachable,
+    # only mirror-dependent clusters are affected, not the primary delivery pipeline.
+    - architect/push-to-registries-multiarch:
+        context: architect
+        name: push-to-all-registries-release
         requires:
         - go-build-mcp-kubernetes
         filters:
@@ -82,7 +98,7 @@ workflows:
             ignore:
             - main
 
-    # Tag: push chart after tests + multi-arch image
+    # Tag: push chart after tests + gsoci image
     - architect/push-to-app-catalog:
         executor: app-build-suite
         context: architect
@@ -92,7 +108,7 @@ workflows:
         chart: mcp-kubernetes
         requires:
         - execute chart tests
-        - push-to-registries-release
+        - push-to-gsoci-release
         filters:
           tags:
             only: /^v.*/


### PR DESCRIPTION
## Summary

Split the release image push into two parallel jobs so that an unreachable China (Alibaba) registry no longer blocks Helm chart publication.

Same fix as https://github.com/giantswarm/muster/pull/385

## Problem

The `push-to-registries-release` job pushes the multi-arch container image to **all** registries (gsoci + China/Alibaba) in a single `docker buildx build --push` call. When the China registry is unreachable, the entire buildx command hangs until CircleCI's 10-minute no-output timeout kills it.

Because the chart push (`push-mcp-kubernetes-to-giantswarm-app-catalog-release`) depends on `push-to-registries-release`, the Helm chart is never published. This blocked Flux-managed deployments (e.g. gazelle) from picking up releases beyond v0.0.168.

## Fix

Split the single `push-to-registries-release` into two parallel jobs:

| Job | Registries | Chart depends on it? |
|-----|-----------|---------------------|
| `push-to-gsoci-release` | gsoci only (via `registries-data` override) | Yes |
| `push-to-all-registries-release` | all registries (default `REGISTRIES_DATA_BASE64`) | No |

If the China mirror is unreachable:
- `push-to-all-registries-release` fails (mirror push times out)
- `push-to-gsoci-release` succeeds (image is in gsoci)
- Chart is published (Flux picks it up)
- Clusters pulling from gsoci get the update
- China-based clusters are temporarily behind until the mirror recovers

## Test plan

- [x] `circleci config validate` passes
- [ ] Merge, tag a release, verify chart appears in `oci://gsoci.azurecr.io/charts/giantswarm/mcp-kubernetes` even if China push fails

Made with [Cursor](https://cursor.com)