### PR TITLE
fix(ci): prevent auto-release from conflicting with manual releases

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -14,7 +14,9 @@ permissions:
 jobs:
   auto_release:
     name: Auto Release
-    if: github.event.pull_request.merged
+    if: >-
+      github.event.pull_request.merged &&
+      !startsWith(github.event.pull_request.title, 'Release v')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -46,9 +48,13 @@ jobs:
         id: version
         run: |
           set -e
-          # Get the latest tag, defaulting to v0.0.0 if none exists
-          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null \
-            || echo "v0.0.0")
+          # Use version-aware sorting to find the semantically highest tag,
+          # not just the nearest reachable one. git describe can pick the
+          # wrong tag when multiple tags point to the same commit.
+          LATEST_TAG=$(git tag --sort=-version:refname | head -1)
+          if [ -z "$LATEST_TAG" ]; then
+            LATEST_TAG="v0.0.0"
+          fi
           # Remove 'v' prefix
           LATEST_VERSION=${LATEST_TAG#v}
           # Split into major, minor, patch


### PR DESCRIPTION
## Summary

- **Skip release PRs**: Added `!startsWith(github.event.pull_request.title, 'Release v')` condition so auto-release doesn't fire when a manual release PR is merged (those are handled by `zz_generated.create_release.yaml`).
- **Version-aware tag lookup**: Replaced `git describe --tags --abbrev=0` with `git tag --sort=-version:refname | head -1` to always find the semantically highest version tag, preventing `v0.0.171` from being preferred over `v0.1.0` due to lexicographic sorting.

## Context

When PR #298 "Release v0.1.0" was merged, both `auto-release.yaml` and `zz_generated.create_release.yaml` fired simultaneously. Auto-release created `v0.0.171` (incrementing from `v0.0.170`) while create_release created `v0.1.0` — both on the same commit. Subsequent merges continued producing `v0.0.172`–`v0.0.177` because `git describe` preferred `v0.0.171` over `v0.1.0` when both lightweight tags pointed to the same commit.

## Cleanup needed

After merging, the spurious tags `v0.0.171` through `v0.0.177` and their GitHub releases should be deleted manually.

## Test plan

- [ ] Verify next PR merge to main produces `v0.1.1` (not `v0.0.178`)
- [ ] Verify a future "Release v*" PR does not trigger auto-release

Made with [Cursor](https://cursor.com)