### PR TITLE
fix(deps): update mcp-oauth to v0.2.72 for VS Code state parameter compatibility

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.26.0
 
 require (
 	github.com/creativeprojects/go-selfupdate v1.5.2
-	github.com/giantswarm/mcp-oauth v0.2.71
+	github.com/giantswarm/mcp-oauth v0.2.72
 	github.com/mark3labs/mcp-go v0.44.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/giantswarm/mcp-oauth v0.2.71 h1:St4X8dpGJZPubLpAIv8UduJWCXmy6HuD7DqKnqvjjbM=
-github.com/giantswarm/mcp-oauth v0.2.71/go.mod h1:ESHnCKxnAGvvMHZIqh5f5uw01ggGxpGS330EnnVI62c=
+github.com/giantswarm/mcp-oauth v0.2.72 h1:YbkkAUENg/NgZKG+xNIBRE2tKd1hGagH52FXIFeOG3k=
+github.com/giantswarm/mcp-oauth v0.2.72/go.mod h1:ESHnCKxnAGvvMHZIqh5f5uw01ggGxpGS330EnnVI62c=
 github.com/go-fed/httpsig v1.1.0 h1:9M+hb0jkEICD8/cAiNqEB66R87tTINszBRTjwjQzWcI=
 github.com/go-fed/httpsig v1.1.0/go.mod h1:RCMrTZvN1bJYtofsG4rd5NaO5obxQ5xBkdiS7xsT7bM=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=


### PR DESCRIPTION
## Summary

- Updates `mcp-oauth` from v0.2.71 to v0.2.72
- Fixes authentication failure for VS Code MCP clients that send a state parameter shorter than 32 characters
- When `AllowNoStateParameter` is enabled, short state parameters are now accepted instead of only empty ones
- Adds WARN-level logging for state validation failures to improve debuggability

Fixes giantswarm/mcp-oauth#225

## Test plan

- [ ] Verify build passes CI
- [ ] Deploy to a test cluster and verify VS Code MCP client can authenticate successfully

Made with [Cursor](https://cursor.com)