### PR TITLE
Add MCP tool annotations (readOnlyHint, destructiveHint, idempotentHint, openWorldHint)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added MCP tool annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) to all tools to help clients and users assess tool behavior ([#36355](https://github.com/giantswarm/giantswarm/issues/36355)).
+
 ## [0.1.0] - 2026-02-27
 
 ### Changed

--- a/internal/tools/access/tools.go
+++ b/internal/tools/access/tools.go
@@ -16,6 +16,8 @@ import (
 var CanITool = mcp.NewTool("can_i",
 	mcp.WithDescription("Check if you have permission to perform an action on a Kubernetes resource. "+
 		"Use this before attempting operations to get clear feedback about permissions."),
+	mcp.WithReadOnlyHintAnnotation(true),
+	mcp.WithOpenWorldHintAnnotation(false),
 	mcp.WithString("verb",
 		mcp.Required(),
 		mcp.Description("The action to check (get, list, watch, create, update, patch, delete)"),

--- a/internal/tools/capi/tools.go
+++ b/internal/tools/capi/tools.go
@@ -25,6 +25,8 @@ func RegisterCAPITools(s *mcpserver.MCPServer, sc *server.ServerContext) error {
 	// capi_list_clusters tool
 	listClustersTool := mcp.NewTool("capi_list_clusters",
 		mcp.WithDescription("List all Workload Clusters managed by CAPI that you have access to. Returns cluster name, organization, provider, release version, status, and age. Results are limited by default; use filters or increase limit to see more."),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
 		mcp.WithString("organization",
 			mcp.Description("Filter by organization namespace (e.g., 'org-acme')"),
 		),
@@ -50,6 +52,8 @@ func RegisterCAPITools(s *mcpserver.MCPServer, sc *server.ServerContext) error {
 	// capi_get_cluster tool
 	getClusterTool := mcp.NewTool("capi_get_cluster",
 		mcp.WithDescription("Get detailed information about a specific CAPI cluster including metadata, status, labels, and annotations."),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
 		mcp.WithString("name",
 			mcp.Required(),
 			mcp.Description("The name of the cluster to get details for"),
@@ -61,6 +65,8 @@ func RegisterCAPITools(s *mcpserver.MCPServer, sc *server.ServerContext) error {
 	// capi_resolve_cluster tool
 	resolveClusterTool := mcp.NewTool("capi_resolve_cluster",
 		mcp.WithDescription("Resolve a partial cluster name pattern to its full identifier. Useful when you only know part of a cluster name."),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
 		mcp.WithString("pattern",
 			mcp.Required(),
 			mcp.Description("Partial cluster name or pattern to search for (e.g., 'prod' to find 'prod-wc-01')"),
@@ -72,6 +78,8 @@ func RegisterCAPITools(s *mcpserver.MCPServer, sc *server.ServerContext) error {
 	// capi_cluster_health tool
 	clusterHealthTool := mcp.NewTool("capi_cluster_health",
 		mcp.WithDescription("Check the health status of a CAPI cluster. Returns overall health, component status, and individual health checks."),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
 		mcp.WithString("name",
 			mcp.Required(),
 			mcp.Description("The name of the cluster to check health for"),

--- a/internal/tools/cluster/tools.go
+++ b/internal/tools/cluster/tools.go
@@ -16,6 +16,8 @@ func RegisterClusterTools(s *mcpserver.MCPServer, sc *server.ServerContext) erro
 	// kubernetes_api_resources tool
 	apiResourcesOpts := []mcp.ToolOption{
 		mcp.WithDescription("List available API resources in the cluster"),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
 	}
 	apiResourcesOpts = append(apiResourcesOpts, clusterContextParams...)
 	apiResourcesOpts = append(apiResourcesOpts,
@@ -42,6 +44,8 @@ func RegisterClusterTools(s *mcpserver.MCPServer, sc *server.ServerContext) erro
 	// kubernetes_cluster_health tool
 	clusterHealthOpts := []mcp.ToolOption{
 		mcp.WithDescription("Check the health status of cluster components"),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
 	}
 	clusterHealthOpts = append(clusterHealthOpts, clusterContextParams...)
 	clusterHealthTool := mcp.NewTool("kubernetes_cluster_health", clusterHealthOpts...)

--- a/internal/tools/context/tools.go
+++ b/internal/tools/context/tools.go
@@ -21,6 +21,8 @@ func RegisterContextTools(s *mcpserver.MCPServer, sc *server.ServerContext) erro
 	// kubernetes_context_list tool
 	listContextsTool := mcp.NewTool("kubernetes_context_list",
 		mcp.WithDescription("List all available Kubernetes contexts"),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
 		mcp.WithInputSchema[tools.EmptyRequest](),
 	)
 
@@ -29,6 +31,8 @@ func RegisterContextTools(s *mcpserver.MCPServer, sc *server.ServerContext) erro
 	// kubernetes_context_get_current tool
 	getCurrentContextTool := mcp.NewTool("kubernetes_context_get_current",
 		mcp.WithDescription("Get the current Kubernetes context"),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
 		mcp.WithInputSchema[tools.EmptyRequest](),
 	)
 
@@ -37,6 +41,10 @@ func RegisterContextTools(s *mcpserver.MCPServer, sc *server.ServerContext) erro
 	// kubernetes_context_use tool
 	useContextTool := mcp.NewTool("kubernetes_context_use",
 		mcp.WithDescription("Switch to a different Kubernetes context"),
+		mcp.WithReadOnlyHintAnnotation(false),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
 		mcp.WithString("contextName",
 			mcp.Required(),
 			mcp.Description("Name of the Kubernetes context to switch to"),

--- a/internal/tools/pod/tools.go
+++ b/internal/tools/pod/tools.go
@@ -16,6 +16,8 @@ func RegisterPodTools(s *mcpserver.MCPServer, sc *server.ServerContext) error {
 	// kubernetes_logs tool
 	logsOpts := []mcp.ToolOption{
 		mcp.WithDescription("Get logs from a pod container"),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
 	}
 	logsOpts = append(logsOpts, clusterContextParams...)
 	logsOpts = append(logsOpts,
@@ -56,6 +58,10 @@ func RegisterPodTools(s *mcpserver.MCPServer, sc *server.ServerContext) error {
 	// kubernetes_exec tool
 	execOpts := []mcp.ToolOption{
 		mcp.WithDescription("Execute a command inside a pod container"),
+		mcp.WithReadOnlyHintAnnotation(false),
+		mcp.WithDestructiveHintAnnotation(true),
+		mcp.WithIdempotentHintAnnotation(false),
+		mcp.WithOpenWorldHintAnnotation(false),
 	}
 	execOpts = append(execOpts, clusterContextParams...)
 	execOpts = append(execOpts,
@@ -89,6 +95,10 @@ func RegisterPodTools(s *mcpserver.MCPServer, sc *server.ServerContext) error {
 		// port_forward tool
 		portForwardOpts := []mcp.ToolOption{
 			mcp.WithDescription("Port-forward to a pod or service"),
+			mcp.WithReadOnlyHintAnnotation(false),
+			mcp.WithDestructiveHintAnnotation(false),
+			mcp.WithIdempotentHintAnnotation(false),
+			mcp.WithOpenWorldHintAnnotation(false),
 		}
 		portForwardOpts = append(portForwardOpts, clusterContextParams...)
 		portForwardOpts = append(portForwardOpts,
@@ -117,6 +127,8 @@ func RegisterPodTools(s *mcpserver.MCPServer, sc *server.ServerContext) error {
 		// list_port_forward_sessions tool
 		listSessionsTool := mcp.NewTool("list_port_forward_sessions",
 			mcp.WithDescription("List all active port forwarding sessions"),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithOpenWorldHintAnnotation(false),
 			mcp.WithInputSchema[tools.EmptyRequest](),
 		)
 
@@ -125,6 +137,10 @@ func RegisterPodTools(s *mcpserver.MCPServer, sc *server.ServerContext) error {
 		// stop_port_forward_session tool
 		stopSessionTool := mcp.NewTool("stop_port_forward_session",
 			mcp.WithDescription("Stop a specific port forwarding session by ID"),
+			mcp.WithReadOnlyHintAnnotation(false),
+			mcp.WithDestructiveHintAnnotation(true),
+			mcp.WithIdempotentHintAnnotation(false),
+			mcp.WithOpenWorldHintAnnotation(false),
 			mcp.WithString("sessionID",
 				mcp.Required(),
 				mcp.Description("ID of the port forwarding session to stop"),
@@ -136,6 +152,10 @@ func RegisterPodTools(s *mcpserver.MCPServer, sc *server.ServerContext) error {
 		// stop_all_port_forward_sessions tool
 		stopAllSessionsTool := mcp.NewTool("stop_all_port_forward_sessions",
 			mcp.WithDescription("Stop all active port forwarding sessions"),
+			mcp.WithReadOnlyHintAnnotation(false),
+			mcp.WithDestructiveHintAnnotation(true),
+			mcp.WithIdempotentHintAnnotation(true),
+			mcp.WithOpenWorldHintAnnotation(false),
 			mcp.WithInputSchema[tools.EmptyRequest](),
 		)
 

--- a/internal/tools/resource/tools.go
+++ b/internal/tools/resource/tools.go
@@ -99,6 +99,8 @@ Namespace Handling:
 - For namespaced resources (pods, services, deployments): Uses 'default' namespace if not specified
 - For cluster-scoped resources (nodes, namespaces, PVs, clusterroles): Namespace is automatically ignored
 - The tool automatically determines resource scope via Kubernetes API discovery`),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
 	}
 	getResourceOpts = append(getResourceOpts, clusterContextParams...)
 	getResourceOpts = append(getResourceOpts,
@@ -140,6 +142,8 @@ Examples:
 - List CAPI clusters: {"resourceType": "clusters", "apiGroup": "cluster.x-k8s.io"}
 
 Supports both server-side selectors (labelSelector, fieldSelector) and client-side filtering for advanced scenarios.`),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
 	}
 	listResourceOpts = append(listResourceOpts, clusterContextParams...)
 	listResourceOpts = append(listResourceOpts,
@@ -206,6 +210,8 @@ Namespace Handling:
 - For namespaced resources (pods, services, deployments): Uses 'default' namespace if not specified
 - For cluster-scoped resources (nodes, namespaces, PVs, clusterroles): Namespace is automatically ignored
 - The tool automatically determines resource scope via Kubernetes API discovery`),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
 	}
 	describeResourceOpts = append(describeResourceOpts, clusterContextParams...)
 	describeResourceOpts = append(describeResourceOpts,
@@ -232,6 +238,10 @@ For cluster-scoped resources (nodes, namespaces, PVs, clusterroles), this is ign
 	// kubernetes_create tool
 	createResourceOpts := []mcp.ToolOption{
 		mcp.WithDescription("Create a new Kubernetes resource from a manifest"),
+		mcp.WithReadOnlyHintAnnotation(false),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(false),
+		mcp.WithOpenWorldHintAnnotation(false),
 	}
 	createResourceOpts = append(createResourceOpts, clusterContextParams...)
 	createResourceOpts = append(createResourceOpts,
@@ -251,6 +261,10 @@ For cluster-scoped resources (nodes, namespaces, PVs, clusterroles), this is ign
 	// kubernetes_apply tool
 	applyResourceOpts := []mcp.ToolOption{
 		mcp.WithDescription("Apply a Kubernetes manifest (create or update)"),
+		mcp.WithReadOnlyHintAnnotation(false),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
 	}
 	applyResourceOpts = append(applyResourceOpts, clusterContextParams...)
 	applyResourceOpts = append(applyResourceOpts,
@@ -275,6 +289,10 @@ Namespace Handling:
 - For namespaced resources (pods, services, deployments): Uses 'default' namespace if not specified
 - For cluster-scoped resources (nodes, namespaces, PVs, clusterroles): Namespace is automatically ignored
 - The tool automatically determines resource scope via Kubernetes API discovery`),
+		mcp.WithReadOnlyHintAnnotation(false),
+		mcp.WithDestructiveHintAnnotation(true),
+		mcp.WithIdempotentHintAnnotation(false),
+		mcp.WithOpenWorldHintAnnotation(false),
 	}
 	deleteResourceOpts = append(deleteResourceOpts, clusterContextParams...)
 	deleteResourceOpts = append(deleteResourceOpts,
@@ -306,6 +324,10 @@ Namespace Handling:
 - For namespaced resources (pods, services, deployments): Uses 'default' namespace if not specified
 - For cluster-scoped resources (nodes, namespaces, PVs, clusterroles): Namespace is automatically ignored
 - The tool automatically determines resource scope via Kubernetes API discovery`),
+		mcp.WithReadOnlyHintAnnotation(false),
+		mcp.WithDestructiveHintAnnotation(true),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
 	}
 	patchResourceOpts = append(patchResourceOpts, clusterContextParams...)
 	patchResourceOpts = append(patchResourceOpts,
@@ -341,6 +363,10 @@ For cluster-scoped resources (nodes, namespaces, PVs, clusterroles), this is ign
 	// kubernetes_scale tool
 	scaleResourceOpts := []mcp.ToolOption{
 		mcp.WithDescription("Scale a Kubernetes resource (deployment, replicaset, etc.)"),
+		mcp.WithReadOnlyHintAnnotation(false),
+		mcp.WithDestructiveHintAnnotation(true),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
 	}
 	scaleResourceOpts = append(scaleResourceOpts, clusterContextParams...)
 	scaleResourceOpts = append(scaleResourceOpts,


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/36355

Follows the same approach used in https://github.com/giantswarm/search-mcp/pull/114.

## Summary

Annotates all 22 MCP tools with [MCP tool annotation hints](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#tool-annotations) so clients (e.g. MCP Inspector) and users can assess tool behavior at a glance.

`openWorldHint` is `false` for every tool — they interact with a bounded target Kubernetes cluster, not the open web. `destructiveHint` and `idempotentHint` are only meaningful when `readOnlyHint` is `false` and are omitted otherwise.

| Tool | readOnlyHint | destructiveHint | idempotentHint | openWorldHint |
| --- | :---: | :---: | :---: | :---: |
| `kubernetes_get` | true | — | — | false |
| `kubernetes_list` | true | — | — | false |
| `kubernetes_describe` | true | — | — | false |
| `kubernetes_api_resources` | true | — | — | false |
| `kubernetes_cluster_health` | true | — | — | false |
| `kubernetes_logs` | true | — | — | false |
| `kubernetes_context_list` | true | — | — | false |
| `kubernetes_context_get_current` | true | — | — | false |
| `list_port_forward_sessions` | true | — | — | false |
| `capi_list_clusters` | true | — | — | false |
| `capi_get_cluster` | true | — | — | false |
| `capi_resolve_cluster` | true | — | — | false |
| `capi_cluster_health` | true | — | — | false |
| `can_i` | true | — | — | false |
| `kubernetes_create` | false | false | false | false |
| `kubernetes_apply` | false | false | true | false |
| `kubernetes_patch` | false | true | true | false |
| `kubernetes_delete` | false | true | false | false |
| `kubernetes_scale` | false | true | true | false |
| `kubernetes_exec` | false | true | false | false |
| `kubernetes_context_use` | false | false | true | false |
| `port_forward` | false | false | false | false |
| `stop_port_forward_session` | false | true | false | false |
| `stop_all_port_forward_sessions` | false | true | true | false |

## Test plan

- [x] \`go build ./...\` passes
- [x] \`go test ./...\` passes
- [ ] Verify annotations appear in MCP Inspector

🤖 Generated with [Claude Code](https://claude.com/claude-code)