### PR TITLE
ci: finish pre-commit cleanup (golangci-lint gosec fixes)

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -72,7 +72,7 @@ func parseIntEnv(value, envName string) (int, bool) {
 	}
 	n, err := strconv.Atoi(value)
 	if err != nil {
-		slog.Warn("invalid integer for environment variable",
+		slog.Warn("invalid integer for environment variable", //nolint:gosec // G706: env var from operator, not end-user input
 			"env", envName,
 			"value", value,
 			"error", err)
@@ -90,7 +90,7 @@ func parseFloat64Env(value, envName string) (float64, bool) {
 	}
 	f, err := strconv.ParseFloat(value, 64)
 	if err != nil {
-		slog.Warn("invalid float for environment variable",
+		slog.Warn("invalid float for environment variable", //nolint:gosec // G706: env var from operator, not end-user input
 			"env", envName,
 			"value", value,
 			"error", err)
@@ -247,7 +247,7 @@ Downstream OAuth (--downstream-oauth):
 					if parsed, err := strconv.ParseBool(envVal); err == nil {
 						enableCIMD = parsed
 					} else {
-						slog.Warn("invalid ENABLE_CIMD value, using default",
+						slog.Warn("invalid ENABLE_CIMD value, using default", //nolint:gosec // G706: env var from operator, not end-user input
 							"value", envVal,
 							"default", enableCIMD,
 							"error", err)
@@ -261,7 +261,7 @@ Downstream OAuth (--downstream-oauth):
 					if parsed, err := strconv.ParseBool(envVal); err == nil {
 						cimdAllowPrivateIPs = parsed
 					} else {
-						slog.Warn("invalid CIMD_ALLOW_PRIVATE_IPS value, using default",
+						slog.Warn("invalid CIMD_ALLOW_PRIVATE_IPS value, using default", //nolint:gosec // G706: env var from operator, not end-user input
 							"value", envVal,
 							"default", cimdAllowPrivateIPs,
 							"error", err)
@@ -275,7 +275,7 @@ Downstream OAuth (--downstream-oauth):
 					if parsed, err := strconv.ParseBool(envVal); err == nil {
 						ssoAllowPrivateIPs = parsed
 					} else {
-						slog.Warn("invalid SSO_ALLOW_PRIVATE_IPS value, using default",
+						slog.Warn("invalid SSO_ALLOW_PRIVATE_IPS value, using default", //nolint:gosec // G706: env var from operator, not end-user input
 							"value", envVal,
 							"default", ssoAllowPrivateIPs,
 							"error", err)
@@ -1146,7 +1146,7 @@ func loadCAPIModeConfig(config *CAPIModeConfig) error {
 		}
 		if len(mappings) > 0 {
 			config.WorkloadClusterAuth.GroupMappings = mappings
-			slog.Info("Group mappings loaded from WC_GROUP_MAPPINGS",
+			slog.Info("Group mappings loaded from WC_GROUP_MAPPINGS", //nolint:gosec // G706: env var from operator, not end-user input
 				"mapping_count", len(mappings),
 				"summary", federation.FormatGroupMappingsForLog(mappings))
 		}

--- a/internal/federation/validation.go
+++ b/internal/federation/validation.go
@@ -100,7 +100,7 @@ func maxGroupCount() int {
 	if v := os.Getenv("MAX_GROUP_COUNT"); v != "" {
 		n, err := strconv.Atoi(v)
 		if err != nil || n <= 0 {
-			slog.Warn("invalid MAX_GROUP_COUNT value, using default",
+			slog.Warn("invalid MAX_GROUP_COUNT value, using default", //nolint:gosec // G706: env var from operator, not end-user input
 				"value", v,
 				"default", DefaultMaxGroupCount,
 			)

--- a/internal/logging/slog_test.go
+++ b/internal/logging/slog_test.go
@@ -140,7 +140,7 @@ func TestSanitizeToken(t *testing.T) {
 			token:    "abcd",
 			expected: "[token:4 chars]",
 		},
-		{
+		{ //nolint:gosec // G101: test fixture, not a real credential
 			name:     "normal token",
 			token:    "eyJhbGciOiJSUzI1NiIsImtpZCI6...",
 			expected: "[token:31 chars]",

--- a/internal/mcp/oauth/silent_auth_test.go
+++ b/internal/mcp/oauth/silent_auth_test.go
@@ -297,7 +297,7 @@ func TestAuthorizationURLOptions(t *testing.T) {
 
 	t.Run("all fields can be set", func(t *testing.T) {
 		maxAge := 3600
-		opts := AuthorizationURLOptions{
+		opts := AuthorizationURLOptions{ //nolint:gosec // G101: test fixture, not a real credential
 			Prompt:      "none",
 			LoginHint:   "user@example.com",
 			MaxAge:      &maxAge,

--- a/internal/server/oauth_http.go
+++ b/internal/server/oauth_http.go
@@ -864,7 +864,7 @@ func (s *OAuthHTTPServer) createAccessTokenInjectorMiddleware(next http.Handler)
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Log entry to confirm middleware is being called
-		slog.Debug("AccessTokenInjector: middleware entry",
+		slog.Debug("AccessTokenInjector: middleware entry", //nolint:gosec // G706: values emitted via structured slog handler which escapes control chars
 			slog.String("method", r.Method),
 			slog.String("path", r.URL.Path),
 			slog.String("content_type", r.Header.Get("Content-Type")))
@@ -921,7 +921,7 @@ func (s *OAuthHTTPServer) createAccessTokenInjectorMiddleware(next http.Handler)
 		// This is the same key used by mcp-oauth during token exchange and proactive refresh
 		token, err := s.tokenStore.GetToken(ctx, bearerToken)
 		if err != nil {
-			slog.Debug("AccessTokenInjector: failed to get token from store by access token",
+			slog.Debug("AccessTokenInjector: failed to get token from store by access token", //nolint:gosec // G706: email is hashed, err is internal
 				logging.UserHash(userInfo.Email), logging.Err(err))
 			// Fallback to email-based lookup for backwards compatibility
 			token, err = s.tokenStore.GetToken(ctx, userInfo.Email)
@@ -947,7 +947,7 @@ func (s *OAuthHTTPServer) createAccessTokenInjectorMiddleware(next http.Handler)
 		// Kubernetes OIDC validates the ID token, not the access token
 		idToken := mcpoauth.GetIDToken(token)
 		if idToken == "" {
-			slog.Debug("AccessTokenInjector: no ID token in stored token",
+			slog.Debug("AccessTokenInjector: no ID token in stored token", //nolint:gosec // G706: email is hashed, other values are bools
 				logging.UserHash(userInfo.Email),
 				slog.Bool("has_access_token", token.AccessToken != ""),
 				slog.Bool("has_refresh_token", token.RefreshToken != ""))

--- a/internal/server/oauth_http_test.go
+++ b/internal/server/oauth_http_test.go
@@ -24,7 +24,7 @@ func TestExtractBearerToken(t *testing.T) {
 		wantToken   string
 		wantSuccess bool
 	}{
-		{
+		{ //nolint:gosec // G101: test fixture, not a real credential
 			name:        "valid bearer token",
 			authHeader:  "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
 			wantToken:   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",

--- a/internal/server/oauth_metrics_integration_test.go
+++ b/internal/server/oauth_metrics_integration_test.go
@@ -142,7 +142,7 @@ func TestOAuthServerMetricsIntegration(t *testing.T) {
 // match what the code expects to expose.
 func TestOAuthMetricNamesConsistency(t *testing.T) {
 	// These are the metric names from security-dashboard.json that rely on mcp-oauth
-	dashboardMetrics := map[string]string{
+	dashboardMetrics := map[string]string{ //nolint:gosec // G101: metric names, not credentials
 		"oauth_rate_limit_exceeded_total":            "Rate limit violations panel",
 		"oauth_redirect_uri_security_rejected_total": "Redirect URI rejections panel",
 		"oauth_code_reuse_detected_total":            "Code reuse detection panel",

--- a/internal/tools/output/helpers_test.go
+++ b/internal/tools/output/helpers_test.go
@@ -92,7 +92,7 @@ func TestProcessRuntimeObjects(t *testing.T) {
 					"name":          "test-secret",
 					"managedFields": []interface{}{"field"},
 				},
-				"data": map[string]interface{}{
+				"data": map[string]interface{}{ //nolint:gosec // G101: test fixture, not a real credential
 					"password": "c2VjcmV0",
 				},
 			},
@@ -170,7 +170,7 @@ func TestProcessSingleRuntimeObject(t *testing.T) {
 				"name":          "test-secret",
 				"managedFields": []interface{}{"field"},
 			},
-			"data": map[string]interface{}{
+			"data": map[string]interface{}{ //nolint:gosec // G101: test fixture, not a real credential
 				"password": "c2VjcmV0",
 			},
 		},

--- a/internal/tools/output/processor_test.go
+++ b/internal/tools/output/processor_test.go
@@ -41,7 +41,7 @@ func TestProcessor_Process(t *testing.T) {
 				"name":          "test-secret",
 				"managedFields": []interface{}{"field"},
 			},
-			"data": map[string]interface{}{
+			"data": map[string]interface{}{ //nolint:gosec // G101: test fixture, not a real credential
 				"password": "c2VjcmV0",
 			},
 		},

--- a/internal/tools/output/secrets_test.go
+++ b/internal/tools/output/secrets_test.go
@@ -34,7 +34,7 @@ func TestMaskSecrets(t *testing.T) {
 				"metadata": map[string]interface{}{
 					"name": "test-secret",
 				},
-				"data": map[string]interface{}{
+				"data": map[string]interface{}{ //nolint:gosec // G101: test fixture, not a real credential
 					"username": "dXNlcm5hbWU=",
 					"password": "cGFzc3dvcmQ=",
 				},

--- a/internal/tools/pod/handlers.go
+++ b/internal/tools/pod/handlers.go
@@ -251,12 +251,12 @@ func handleExec(ctx context.Context, request mcp.CallToolRequest, sc *server.Ser
 
 	// Format the result
 	var output strings.Builder
-	output.WriteString(fmt.Sprintf("Exit Code: %d\n", result.ExitCode))
+	fmt.Fprintf(&output, "Exit Code: %d\n", result.ExitCode)
 	if result.Stdout != "" {
-		output.WriteString(fmt.Sprintf("Stdout:\n%s\n", result.Stdout))
+		fmt.Fprintf(&output, "Stdout:\n%s\n", result.Stdout)
 	}
 	if result.Stderr != "" {
-		output.WriteString(fmt.Sprintf("Stderr:\n%s\n", result.Stderr))
+		fmt.Fprintf(&output, "Stderr:\n%s\n", result.Stderr)
 	}
 
 	return mcp.NewToolResultText(output.String()), nil
@@ -407,14 +407,14 @@ func handleListPortForwardSessions(ctx context.Context, request mcp.CallToolRequ
 	}
 
 	var output strings.Builder
-	output.WriteString(fmt.Sprintf("Active port forwarding sessions (%d):\n\n", len(sessions)))
+	fmt.Fprintf(&output, "Active port forwarding sessions (%d):\n\n", len(sessions))
 
 	for sessionID, session := range sessions {
-		output.WriteString(fmt.Sprintf("Session ID: %s\n", sessionID))
+		fmt.Fprintf(&output, "Session ID: %s\n", sessionID)
 		output.WriteString("Port mappings:\n")
 		for i, localPort := range session.LocalPorts {
 			if i < len(session.RemotePorts) {
-				output.WriteString(fmt.Sprintf("  Local port %d -> Remote port %d\n", localPort, session.RemotePorts[i]))
+				fmt.Fprintf(&output, "  Local port %d -> Remote port %d\n", localPort, session.RemotePorts[i])
 			}
 		}
 		output.WriteString("\n")


### PR DESCRIPTION
## Summary

PR #376 only ran the auto-formatting hooks (`trailing-whitespace`, `end-of-file-fixer`, `mixed-line-ending`) and was merged with `pre-commit` still red. As a result, `main`'s `golangci-lint` hook has been failing on every push since, flagging real `gosec` and `staticcheck` violations.

This PR finishes the cleanup so `pre-commit run --all-files` exits 0 on `main`.

## Changes

- **gosec G706 (Log injection via taint analysis)** — values logged from operator-supplied env vars (`cmd/serve.go`, `internal/federation/validation.go`) and HTTP request fields already emitted via structured slog attributes (`internal/server/oauth_http.go`) are marked with line-local `//nolint:gosec` comments with reason.
- **gosec G101 (Potential hardcoded credentials)** in test fixtures (`internal/logging/slog_test.go`, `internal/mcp/oauth/silent_auth_test.go`, `internal/server/oauth_http_test.go`, `internal/server/oauth_metrics_integration_test.go`, `internal/tools/output/{helpers,processor,secrets}_test.go`) marked `//nolint:gosec` — fake JWT prefixes, base64 test strings, and a metric-name map, not real credentials.
- **staticcheck QF1012** — `output.WriteString(fmt.Sprintf(...))` rewritten to `fmt.Fprintf(&output, ...)` in `internal/tools/pod/handlers.go`.

No changes to `.pre-commit-config.yaml` or `.golangci.yml` — all suppressions are file/line-local.

## Test plan

- [x] `golangci-lint run -E=gosec -E=goconst -E=govet --timeout=300s --max-same-issues=0 --max-issues-per-linter=0 ./...` exits 0 locally with the exact args from `.pre-commit-config.yaml`.
- [x] `gofmt -l .` and `goimports -l -local github.com/giantswarm/mcp-kubernetes .` produce no output.
- [x] `go build ./...` and `go vet ./...` succeed.
- [x] `go test ./internal/...` for touched packages passes (`pod`, `logging`, `federation`, `tools/output`, `server`, `mcp/oauth`).
- [ ] `pre-commit` workflow on this PR goes green. **Do NOT `--admin`-merge until it does.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)