### PR TITLE
Limit kubernetes_cluster_health output

### DIFF
--- a/internal/tools/cluster/handlers.go
+++ b/internal/tools/cluster/handlers.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 
+	"github.com/giantswarm/mcp-kubernetes/internal/k8s"
 	"github.com/giantswarm/mcp-kubernetes/internal/server"
 	"github.com/giantswarm/mcp-kubernetes/internal/tools"
 )
@@ -76,6 +77,18 @@ func handleGetClusterHealth(ctx context.Context, request mcp.CallToolRequest, sc
 
 	kubeContext, _ := args["kubeContext"].(string)
 
+	// Parse output-shaping params. The schema enforces range via mcp.Min/Max,
+	// but we validate again as defense-in-depth for non-compliant clients.
+	nodesLimit := DefaultNodesLimit
+	if v, ok := args["nodesLimit"].(float64); ok {
+		val := int(v)
+		if val < 1 || val > MaxNodesLimit {
+			return mcp.NewToolResultError(fmt.Sprintf("nodesLimit must be between 1 and %d", MaxNodesLimit)), nil
+		}
+		nodesLimit = val
+	}
+	includeNodeConditions, _ := args["includeNodeConditions"].(bool)
+
 	// Get the appropriate k8s client (local or federated)
 	client, errMsg := tools.GetClusterClient(ctx, sc, clusterName)
 	if errMsg != "" {
@@ -87,11 +100,53 @@ func handleGetClusterHealth(ctx context.Context, request mcp.CallToolRequest, sc
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to get cluster health: %v", err)), nil
 	}
 
-	// Convert health to JSON for output
-	jsonData, err := json.MarshalIndent(health, "", "  ")
+	output := buildClusterHealthOutput(health, nodesLimit, includeNodeConditions)
+
+	jsonData, err := json.MarshalIndent(output, "", "  ")
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to marshal cluster health: %v", err)), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonData)), nil
+}
+
+// buildClusterHealthOutput shapes the raw ClusterHealth into the tool-level
+// ClusterHealthOutput, applying nodesLimit and conditionally stripping the
+// per-node conditions array. ReadyNodes is computed across the full node
+// list before truncation.
+func buildClusterHealthOutput(health *k8s.ClusterHealth, nodesLimit int, includeNodeConditions bool) ClusterHealthOutput {
+	out := ClusterHealthOutput{
+		Status:     health.Status,
+		Components: health.Components,
+	}
+
+	totalNodes := len(health.Nodes)
+	out.TotalNodes = totalNodes
+
+	for _, n := range health.Nodes {
+		if n.Ready {
+			out.ReadyNodes++
+		}
+	}
+
+	end := totalNodes
+	if nodesLimit > 0 && nodesLimit < totalNodes {
+		end = nodesLimit
+		out.NodesTruncated = true
+	}
+
+	out.Nodes = make([]NodeHealthOutput, 0, end)
+	for _, n := range health.Nodes[:end] {
+		entry := NodeHealthOutput{
+			Name:  n.Name,
+			Ready: n.Ready,
+		}
+		if includeNodeConditions {
+			entry.Conditions = n.Conditions
+		}
+		out.Nodes = append(out.Nodes, entry)
+	}
+	out.ReturnedNodes = len(out.Nodes)
+
+	return out
 }

--- a/internal/tools/cluster/handlers_test.go
+++ b/internal/tools/cluster/handlers_test.go
@@ -1,0 +1,184 @@
+package cluster
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/giantswarm/mcp-kubernetes/internal/k8s"
+	"github.com/giantswarm/mcp-kubernetes/internal/server"
+	"github.com/giantswarm/mcp-kubernetes/internal/tools/resource/testdata"
+)
+
+// healthMock wraps testdata.MockK8sClient and returns a configurable
+// ClusterHealth from GetClusterHealth so tests can drive the handler.
+type healthMock struct {
+	*testdata.MockK8sClient
+	health *k8s.ClusterHealth
+}
+
+func (m *healthMock) GetClusterHealth(_ context.Context, _ string) (*k8s.ClusterHealth, error) {
+	return m.health, nil
+}
+
+func newClusterHealthTestServer(t *testing.T, health *k8s.ClusterHealth) *server.ServerContext {
+	t.Helper()
+	mock := &healthMock{
+		MockK8sClient: &testdata.MockK8sClient{},
+		health:        health,
+	}
+	sc, err := server.NewServerContext(context.Background(),
+		server.WithK8sClient(mock),
+		server.WithLogger(&testdata.MockLogger{}),
+	)
+	require.NoError(t, err)
+	return sc
+}
+
+func makeNodes(n int, readyEvery int) []k8s.NodeHealth {
+	out := make([]k8s.NodeHealth, 0, n)
+	for i := range n {
+		ready := readyEvery > 0 && i%readyEvery == 0
+		status := corev1.ConditionFalse
+		if ready {
+			status = corev1.ConditionTrue
+		}
+		out = append(out, k8s.NodeHealth{
+			Name:  fmt.Sprintf("node-%02d", i),
+			Ready: ready,
+			Conditions: []corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: status},
+				{Type: corev1.NodeMemoryPressure, Status: corev1.ConditionFalse},
+			},
+		})
+	}
+	return out
+}
+
+func unmarshalHealth(t *testing.T, result *mcp.CallToolResult) ClusterHealthOutput {
+	t.Helper()
+	require.False(t, result.IsError, "expected success result")
+	require.NotEmpty(t, result.Content)
+	tc, ok := result.Content[0].(mcp.TextContent)
+	require.True(t, ok)
+	var out ClusterHealthOutput
+	require.NoError(t, json.Unmarshal([]byte(tc.Text), &out))
+	return out
+}
+
+func TestClusterHealth_DefaultsOmitConditionsAndCapAt20(t *testing.T) {
+	health := &k8s.ClusterHealth{
+		Status:     "Healthy",
+		Components: []k8s.ComponentHealth{{Name: "API Server", Status: "Healthy"}},
+		Nodes:      makeNodes(30, 1), // all 30 ready
+	}
+	sc := newClusterHealthTestServer(t, health)
+
+	result, err := handleGetClusterHealth(context.Background(), mcp.CallToolRequest{}, sc)
+	require.NoError(t, err)
+
+	out := unmarshalHealth(t, result)
+	assert.Equal(t, 30, out.TotalNodes)
+	assert.Equal(t, 20, out.ReturnedNodes)
+	assert.Equal(t, 30, out.ReadyNodes, "ReadyNodes must reflect the full set, not the truncated slice")
+	assert.True(t, out.NodesTruncated)
+	assert.Len(t, out.Nodes, 20)
+	for _, n := range out.Nodes {
+		assert.Nil(t, n.Conditions, "conditions must be omitted by default")
+	}
+}
+
+func TestClusterHealth_NodesLimitOverride(t *testing.T) {
+	health := &k8s.ClusterHealth{
+		Status: "Healthy",
+		Nodes:  makeNodes(10, 2), // 5 ready, 5 not ready
+	}
+	sc := newClusterHealthTestServer(t, health)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"nodesLimit": float64(5)}
+
+	result, err := handleGetClusterHealth(context.Background(), req, sc)
+	require.NoError(t, err)
+
+	out := unmarshalHealth(t, result)
+	assert.Equal(t, 10, out.TotalNodes)
+	assert.Equal(t, 5, out.ReturnedNodes)
+	assert.Equal(t, 5, out.ReadyNodes, "ReadyNodes counts the full list, regardless of truncation")
+	assert.True(t, out.NodesTruncated)
+}
+
+func TestClusterHealth_NoTruncationWhenWithinLimit(t *testing.T) {
+	health := &k8s.ClusterHealth{
+		Status: "Healthy",
+		Nodes:  makeNodes(3, 1),
+	}
+	sc := newClusterHealthTestServer(t, health)
+
+	result, err := handleGetClusterHealth(context.Background(), mcp.CallToolRequest{}, sc)
+	require.NoError(t, err)
+
+	out := unmarshalHealth(t, result)
+	assert.Equal(t, 3, out.TotalNodes)
+	assert.Equal(t, 3, out.ReturnedNodes)
+	assert.False(t, out.NodesTruncated, "nodesTruncated must be false when total <= nodesLimit")
+}
+
+func TestClusterHealth_NoTruncationWhenLimitEqualsTotal(t *testing.T) {
+	health := &k8s.ClusterHealth{
+		Status: "Healthy",
+		Nodes:  makeNodes(20, 1),
+	}
+	sc := newClusterHealthTestServer(t, health)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"nodesLimit": float64(20)}
+
+	result, err := handleGetClusterHealth(context.Background(), req, sc)
+	require.NoError(t, err)
+
+	out := unmarshalHealth(t, result)
+	assert.Equal(t, 20, out.TotalNodes)
+	assert.Equal(t, 20, out.ReturnedNodes)
+	assert.False(t, out.NodesTruncated, "nodesTruncated must be false when limit == total")
+}
+
+func TestClusterHealth_IncludeNodeConditions(t *testing.T) {
+	health := &k8s.ClusterHealth{
+		Status: "Healthy",
+		Nodes:  makeNodes(2, 1),
+	}
+	sc := newClusterHealthTestServer(t, health)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"includeNodeConditions": true}
+
+	result, err := handleGetClusterHealth(context.Background(), req, sc)
+	require.NoError(t, err)
+
+	out := unmarshalHealth(t, result)
+	require.Len(t, out.Nodes, 2)
+	for _, n := range out.Nodes {
+		assert.Len(t, n.Conditions, 2, "conditions should be present when requested")
+	}
+}
+
+func TestClusterHealth_NodesLimitOutOfRangeReturnsError(t *testing.T) {
+	health := &k8s.ClusterHealth{Status: "Healthy"}
+	sc := newClusterHealthTestServer(t, health)
+
+	for _, val := range []float64{0, -1, float64(MaxNodesLimit + 1)} {
+		req := mcp.CallToolRequest{}
+		req.Params.Arguments = map[string]any{"nodesLimit": val}
+
+		result, err := handleGetClusterHealth(context.Background(), req, sc)
+		require.NoError(t, err)
+		assert.True(t, result.IsError, "nodesLimit=%v must be rejected", val)
+	}
+}

--- a/internal/tools/cluster/tools.go
+++ b/internal/tools/cluster/tools.go
@@ -43,11 +43,21 @@ func RegisterClusterTools(s *mcpserver.MCPServer, sc *server.ServerContext) erro
 
 	// kubernetes_cluster_health tool
 	clusterHealthOpts := []mcp.ToolOption{
-		mcp.WithDescription("Check the health status of cluster components"),
+		mcp.WithDescription("Check the health status of cluster components. Returns overall status, component health, and a node list (capped by nodesLimit). Per-node conditions are omitted by default; set includeNodeConditions=true to include them."),
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithOpenWorldHintAnnotation(false),
 	}
 	clusterHealthOpts = append(clusterHealthOpts, clusterContextParams...)
+	clusterHealthOpts = append(clusterHealthOpts,
+		mcp.WithNumber("nodesLimit",
+			mcp.Min(1),
+			mcp.Max(MaxNodesLimit),
+			mcp.Description("Maximum number of nodes to include in the response. Default: 20. Maximum: 1000. Use readyNodes/totalNodes to detect readiness issues even when truncated."),
+		),
+		mcp.WithBoolean("includeNodeConditions",
+			mcp.Description("Include the full per-node conditions array in the response (default: false). The Ready field on each node already conveys overall readiness."),
+		),
+	)
 	clusterHealthTool := mcp.NewTool("kubernetes_cluster_health", clusterHealthOpts...)
 
 	s.AddTool(clusterHealthTool, tools.WrapWithAuditLogging("kubernetes_cluster_health", handleGetClusterHealth, sc))

--- a/internal/tools/cluster/types.go
+++ b/internal/tools/cluster/types.go
@@ -1,0 +1,54 @@
+package cluster
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/giantswarm/mcp-kubernetes/internal/k8s"
+)
+
+// Default and maximum values for the kubernetes_cluster_health nodesLimit param.
+const (
+	// DefaultNodesLimit is the default cap on the number of nodes returned.
+	DefaultNodesLimit = 20
+
+	// MaxNodesLimit is the absolute maximum allowed for nodesLimit.
+	MaxNodesLimit = 1000
+)
+
+// ClusterHealthOutput is the response shape for kubernetes_cluster_health.
+// It wraps k8s.ClusterHealth so the tool layer can apply truncation and
+// expose summary counters without changing the k8s.ClusterManager interface.
+type ClusterHealthOutput struct {
+	// Status is the overall cluster health status.
+	Status string `json:"status"`
+
+	// Components contains the per-component health entries.
+	Components []k8s.ComponentHealth `json:"components"`
+
+	// Nodes contains node health entries, possibly truncated to nodesLimit.
+	Nodes []NodeHealthOutput `json:"nodes"`
+
+	// TotalNodes is the total node count before truncation.
+	TotalNodes int `json:"totalNodes"`
+
+	// ReturnedNodes is the number of nodes returned in this response.
+	ReturnedNodes int `json:"returnedNodes"`
+
+	// ReadyNodes is the number of nodes with Ready=true across the full
+	// node list (computed before truncation), so callers can detect
+	// readiness issues even when results are truncated.
+	ReadyNodes int `json:"readyNodes"`
+
+	// NodesTruncated is true when the node list was clipped by nodesLimit.
+	// When true, increase nodesLimit to see more.
+	NodesTruncated bool `json:"nodesTruncated,omitempty"`
+}
+
+// NodeHealthOutput is the per-node health entry in the response.
+// Conditions are omitted by default; set includeNodeConditions=true to
+// include them.
+type NodeHealthOutput struct {
+	Name       string                 `json:"name"`
+	Ready      bool                   `json:"ready"`
+	Conditions []corev1.NodeCondition `json:"conditions,omitempty"`
+}


### PR DESCRIPTION
The `kubernetes_cluster_health` tool returned every node with its full `status.conditions` array, with no caller-controlled limit. On large clusters this scales linearly and risks overloading the model context.

This PR changes `kubernetes_cluster_health` as follows:

- New parameter `nodesLimit` (default 20, max 1000) caps the node list.
- New parameter `includeNodeConditions` (default false) controls whether the per-node conditions array is included. The existing per-node `ready` field already conveys overall readiness.
- Response now exposes `totalNodes`, `returnedNodes`, `readyNodes`, and `nodesTruncated`. `readyNodes` is computed across the full node list before truncation, so callers can detect readiness issues even when the list is truncated.

The truncation/shape pattern mirrors `capi_list_clusters` (`TotalCount`/`ReturnedCount`/`Truncated`). Truncation happens at the handler layer; the `k8s.ClusterManager.GetClusterHealth` interface is unchanged.

## Test plan

- [x] `go test ./...` passes
- [x] New unit tests cover defaults, override, no-truncation, limit-equals-total boundary, `includeNodeConditions=true`, and out-of-range rejection
- [x] Manual smoke test against a real cluster (e.g. `kubernetes_cluster_health` with default params, then with `nodesLimit=5`, then with `includeNodeConditions=true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)