### PR TITLE
Limit kubernetes_describe events output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Breaking:** `kubernetes_logs` parameter surface simplified. `tailLines` now defaults to `100`, is bounded to `[1, 1000]`, and is enforced server-side via `corev1.PodLogOptions.TailLines`, bounding both response size and gateway memory. The `sinceLines` and `maxLines` parameters have been removed; for time-based filtering, the new `sinceTime` parameter accepts an RFC3339 timestamp and is also applied server-side.
+- `kubernetes_describe` now caps the embedded event list and returns events newest-first. New parameter `eventsLimit` (default 50, range 1–1000) controls the cap; the response gains `totalEvents`, `returnedEvents`, and `eventsTruncated` fields so callers can detect that the event history was clipped. `metadata.managedFields` is now stripped from each returned event.
 
 ## [0.1.0] - 2026-02-27
 

--- a/internal/tools/resource/handlers.go
+++ b/internal/tools/resource/handlers.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"sort"
 	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -318,6 +320,17 @@ func handleDescribeResource(ctx context.Context, request mcp.CallToolRequest, sc
 		return mcp.NewToolResultError("name is required"), nil
 	}
 
+	// Parse output-shaping params. The schema enforces range via mcp.Min/Max,
+	// but we validate again as defense-in-depth for non-compliant clients.
+	eventsLimit := DefaultEventsLimit
+	if v, ok := args["eventsLimit"].(float64); ok {
+		val := int(v)
+		if val < 1 || val > MaxEventsLimit {
+			return mcp.NewToolResultError(fmt.Sprintf("eventsLimit must be between 1 and %d", MaxEventsLimit)), nil
+		}
+		eventsLimit = val
+	}
+
 	// Get the appropriate k8s client (local or federated)
 	client, errMsg := tools.GetClusterClient(ctx, sc, clusterName)
 	if errMsg != "" {
@@ -343,25 +356,80 @@ func handleDescribeResource(ctx context.Context, request mcp.CallToolRequest, sc
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to process resource: %v", err)), nil
 	}
 
-	// Build response with processed resource
-	response := map[string]interface{}{
-		"resource": processedResource,
-		"metadata": description.Metadata,
-		"_meta":    description.Meta,
-	}
+	result := buildDescribeOutput(processedResource, description.Metadata, description.Meta, description.Events, eventsLimit)
 
-	// Include events if present
-	if len(description.Events) > 0 {
-		response["events"] = description.Events
-	}
-
-	// Convert the response to JSON for output
-	jsonData, err := json.MarshalIndent(response, "", "  ")
+	jsonData, err := json.MarshalIndent(result, "", "  ")
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to marshal description: %v", err)), nil
 	}
 
 	return mcp.NewToolResultText(string(jsonData)), nil
+}
+
+// buildDescribeOutput shapes the raw describe response into a DescribeOutput,
+// sorting events newest-first, truncating to eventsLimit, and stripping
+// metadata.managedFields from each returned event. TotalEvents reflects the
+// full pre-truncation count so callers can detect that the history was clipped.
+func buildDescribeOutput(
+	resource any,
+	metadata map[string]any,
+	meta *k8s.ResponseMeta,
+	events []corev1.Event,
+	limit int,
+) DescribeOutput {
+	out := DescribeOutput{
+		Resource:    resource,
+		Metadata:    metadata,
+		Meta:        meta,
+		TotalEvents: len(events),
+		Events:      []map[string]any{},
+	}
+
+	if len(events) == 0 {
+		return out
+	}
+
+	sorted := make([]corev1.Event, len(events))
+	copy(sorted, events)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return effectiveEventTime(sorted[i]).After(effectiveEventTime(sorted[j]))
+	})
+
+	end := len(sorted)
+	if limit < end {
+		end = limit
+	}
+
+	slimmed := make([]map[string]any, 0, end)
+	for i := range sorted[:end] {
+		raw, err := json.Marshal(&sorted[i])
+		if err != nil {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal(raw, &m); err != nil {
+			continue
+		}
+		slimmed = append(slimmed, output.SlimResource(m, []string{"metadata.managedFields"}))
+	}
+	out.Events = slimmed
+	out.ReturnedEvents = len(slimmed)
+	// EventsTruncated reflects any reduction (eventsLimit or marshal failure),
+	// so callers cannot read EventsTruncated=false while ReturnedEvents<TotalEvents.
+	out.EventsTruncated = out.TotalEvents > out.ReturnedEvents
+	return out
+}
+
+// effectiveEventTime returns the best available timestamp for sorting:
+// LastTimestamp, then EventTime, then FirstTimestamp.
+func effectiveEventTime(ev corev1.Event) time.Time {
+	if !ev.LastTimestamp.IsZero() {
+		return ev.LastTimestamp.Time
+	}
+	if !ev.EventTime.IsZero() {
+		return ev.EventTime.Time
+	}
+	return ev.FirstTimestamp.Time
 }
 
 // handleCreateResource handles kubectl create operations

--- a/internal/tools/resource/handlers_describe_test.go
+++ b/internal/tools/resource/handlers_describe_test.go
@@ -1,0 +1,209 @@
+package resource
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/mcp-kubernetes/internal/server"
+	"github.com/giantswarm/mcp-kubernetes/internal/tools/resource/testdata"
+)
+
+// makeEvent builds a corev1.Event whose ObjectMeta carries managedFields, so
+// every test exercises the slim path.
+func makeEvent(name string, last time.Time) corev1.Event {
+	return corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			ManagedFields: []metav1.ManagedFieldsEntry{
+				{Manager: "kubelet", Operation: metav1.ManagedFieldsOperationUpdate},
+			},
+		},
+		LastTimestamp: metav1.NewTime(last),
+		Reason:        "Synthetic",
+		Type:          corev1.EventTypeNormal,
+	}
+}
+
+// makeEvents returns n events with strictly increasing LastTimestamp so a
+// stable sort newest-first yields the input order reversed.
+func makeEvents(n int) []corev1.Event {
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	events := make([]corev1.Event, 0, n)
+	for i := range n {
+		events = append(events, makeEvent("ev-"+strconv.Itoa(i), base.Add(time.Duration(i)*time.Minute)))
+	}
+	return events
+}
+
+func TestBuildDescribeOutput_DefaultsApplied(t *testing.T) {
+	events := makeEvents(60)
+
+	out := buildDescribeOutput(nil, nil, nil, events, DefaultEventsLimit)
+
+	assert.Equal(t, 60, out.TotalEvents)
+	assert.Equal(t, DefaultEventsLimit, out.ReturnedEvents)
+	assert.True(t, out.EventsTruncated)
+	assert.Len(t, out.Events, DefaultEventsLimit)
+}
+
+func TestBuildDescribeOutput_OverrideLimit(t *testing.T) {
+	events := makeEvents(10)
+
+	out := buildDescribeOutput(nil, nil, nil, events, 5)
+
+	assert.Equal(t, 10, out.TotalEvents)
+	assert.Equal(t, 5, out.ReturnedEvents)
+	assert.True(t, out.EventsTruncated)
+}
+
+func TestBuildDescribeOutput_NoTruncation(t *testing.T) {
+	events := makeEvents(5)
+
+	out := buildDescribeOutput(nil, nil, nil, events, DefaultEventsLimit)
+
+	assert.Equal(t, 5, out.TotalEvents)
+	assert.Equal(t, 5, out.ReturnedEvents)
+	assert.False(t, out.EventsTruncated, "eventsTruncated must be false when total <= limit")
+}
+
+func TestBuildDescribeOutput_LimitEqualsTotal(t *testing.T) {
+	events := makeEvents(10)
+
+	out := buildDescribeOutput(nil, nil, nil, events, 10)
+
+	assert.Equal(t, 10, out.TotalEvents)
+	assert.Equal(t, 10, out.ReturnedEvents)
+	assert.False(t, out.EventsTruncated, "eventsTruncated must be false when limit == total")
+}
+
+func TestBuildDescribeOutput_SortsNewestFirst(t *testing.T) {
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	// Insert in arbitrary order; expect newest LastTimestamp first.
+	events := []corev1.Event{
+		makeEvent("middle", base.Add(5*time.Minute)),
+		makeEvent("oldest", base),
+		makeEvent("newest", base.Add(10*time.Minute)),
+	}
+
+	out := buildDescribeOutput(nil, nil, nil, events, 10)
+
+	require.Len(t, out.Events, 3)
+	assert.Equal(t, "newest", out.Events[0]["metadata"].(map[string]any)["name"])
+	assert.Equal(t, "middle", out.Events[1]["metadata"].(map[string]any)["name"])
+	assert.Equal(t, "oldest", out.Events[2]["metadata"].(map[string]any)["name"])
+}
+
+func TestBuildDescribeOutput_SortFallsBackToEventTime(t *testing.T) {
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	// Both events lack LastTimestamp; sort must fall through to EventTime.
+	older := corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{Name: "older"},
+		EventTime:  metav1.NewMicroTime(base),
+	}
+	newer := corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{Name: "newer"},
+		EventTime:  metav1.NewMicroTime(base.Add(time.Hour)),
+	}
+
+	out := buildDescribeOutput(nil, nil, nil, []corev1.Event{older, newer}, 10)
+
+	require.Len(t, out.Events, 2)
+	assert.Equal(t, "newer", out.Events[0]["metadata"].(map[string]any)["name"])
+	assert.Equal(t, "older", out.Events[1]["metadata"].(map[string]any)["name"])
+}
+
+func TestBuildDescribeOutput_SortFallsBackToFirstTimestamp(t *testing.T) {
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	// Both events lack LastTimestamp and EventTime; sort must fall through
+	// to FirstTimestamp (the most common timestamp on classic core/v1 events).
+	older := corev1.Event{
+		ObjectMeta:     metav1.ObjectMeta{Name: "older"},
+		FirstTimestamp: metav1.NewTime(base),
+	}
+	newer := corev1.Event{
+		ObjectMeta:     metav1.ObjectMeta{Name: "newer"},
+		FirstTimestamp: metav1.NewTime(base.Add(time.Hour)),
+	}
+
+	out := buildDescribeOutput(nil, nil, nil, []corev1.Event{older, newer}, 10)
+
+	require.Len(t, out.Events, 2)
+	assert.Equal(t, "newer", out.Events[0]["metadata"].(map[string]any)["name"])
+	assert.Equal(t, "older", out.Events[1]["metadata"].(map[string]any)["name"])
+}
+
+func TestBuildDescribeOutput_StripsManagedFields(t *testing.T) {
+	events := makeEvents(1)
+	require.NotEmpty(t, events[0].ManagedFields, "precondition: input event must carry managedFields")
+
+	out := buildDescribeOutput(nil, nil, nil, events, 10)
+
+	require.Len(t, out.Events, 1)
+	meta, ok := out.Events[0]["metadata"].(map[string]any)
+	require.True(t, ok)
+	_, hasManagedFields := meta["managedFields"]
+	assert.False(t, hasManagedFields, "metadata.managedFields must be stripped from each event")
+}
+
+func TestBuildDescribeOutput_NoEvents(t *testing.T) {
+	out := buildDescribeOutput(nil, nil, nil, nil, DefaultEventsLimit)
+
+	assert.Equal(t, 0, out.TotalEvents)
+	assert.Equal(t, 0, out.ReturnedEvents)
+	assert.False(t, out.EventsTruncated)
+	require.NotNil(t, out.Events, "events should be a non-nil empty slice for stable shape")
+	assert.Empty(t, out.Events)
+}
+
+func TestBuildDescribeOutput_AlwaysEmitsCountFields(t *testing.T) {
+	// totalEvents, returnedEvents, and eventsTruncated must always be present
+	// in the marshaled output, even at zero/false values, so callers can rely
+	// on a stable wire shape.
+	out := buildDescribeOutput(nil, nil, nil, nil, DefaultEventsLimit)
+
+	raw, err := json.Marshal(out)
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+
+	for _, field := range []string{"totalEvents", "returnedEvents", "eventsTruncated"} {
+		_, present := decoded[field]
+		assert.True(t, present, "%q must be present in the marshaled output", field)
+	}
+	assert.Equal(t, false, decoded["eventsTruncated"])
+}
+
+func TestDescribeResource_EventsLimitOutOfRangeRejected(t *testing.T) {
+	ctx := context.Background()
+
+	sc, err := server.NewServerContext(ctx,
+		server.WithK8sClient(&testdata.MockK8sClient{}),
+		server.WithLogger(&testdata.MockLogger{}),
+	)
+	require.NoError(t, err)
+
+	for _, val := range []float64{0, -1, float64(MaxEventsLimit + 1)} {
+		req := mcp.CallToolRequest{}
+		req.Params.Arguments = map[string]any{
+			"resourceType": "pods",
+			"name":         "my-pod",
+			"eventsLimit":  val,
+		}
+
+		result, err := handleDescribeResource(ctx, req, sc)
+		require.NoError(t, err)
+		require.True(t, result.IsError, "eventsLimit=%v must be rejected", val)
+		assert.Contains(t, getErrorText(t, result), "eventsLimit must be between")
+	}
+}

--- a/internal/tools/resource/tools.go
+++ b/internal/tools/resource/tools.go
@@ -1,6 +1,8 @@
 package resource
 
 import (
+	"fmt"
+
 	"github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
 
@@ -229,6 +231,11 @@ For cluster-scoped resources (nodes, namespaces, PVs, clusterroles), this is ign
 		mcp.WithString("name",
 			mcp.Required(),
 			mcp.Description("Name of the resource to describe"),
+		),
+		mcp.WithNumber("eventsLimit",
+			mcp.Min(1),
+			mcp.Max(MaxEventsLimit),
+			mcp.Description(fmt.Sprintf("Maximum number of events to return, sorted newest-first by lastTimestamp. Default: %d. Range: [1, %d]. Use totalEvents/eventsTruncated in the response to detect clipping.", DefaultEventsLimit, MaxEventsLimit)),
 		),
 	)
 	describeResourceTool := mcp.NewTool("kubernetes_describe", describeResourceOpts...)

--- a/internal/tools/resource/types_describe.go
+++ b/internal/tools/resource/types_describe.go
@@ -1,0 +1,49 @@
+package resource
+
+import (
+	"github.com/giantswarm/mcp-kubernetes/internal/k8s"
+)
+
+// Default and maximum values for the kubernetes_describe eventsLimit param.
+const (
+	// DefaultEventsLimit is the default cap on the number of events returned
+	// by kubernetes_describe.
+	DefaultEventsLimit = 50
+
+	// MaxEventsLimit is the absolute maximum allowed for eventsLimit.
+	MaxEventsLimit = 1000
+)
+
+// DescribeOutput is the response shape for kubernetes_describe.
+//
+// The structure mirrors the original map-based response: Resource, Metadata,
+// and Meta come from k8s.ResourceDescription, while Events is the slimmed,
+// sorted, and truncated event list. TotalEvents/ReturnedEvents/EventsTruncated
+// let callers detect that the event history was clipped.
+type DescribeOutput struct {
+	// Resource is the slimmed, masked top-level resource object.
+	Resource any `json:"resource"`
+
+	// Metadata is the convenience metadata map populated by the k8s layer
+	// (kind, apiVersion, labels, annotations, etc.). Omitted when empty.
+	Metadata map[string]any `json:"metadata,omitempty"`
+
+	// Meta carries operation transparency info (resource scope, hints).
+	Meta *k8s.ResponseMeta `json:"_meta,omitempty"`
+
+	// Events contains the per-event maps after sort+truncate+slim. Always
+	// emitted (possibly empty) so callers see a stable shape.
+	Events []map[string]any `json:"events"`
+
+	// TotalEvents is the total number of events for the object before
+	// truncation.
+	TotalEvents int `json:"totalEvents"`
+
+	// ReturnedEvents is the number of events included in this response.
+	ReturnedEvents int `json:"returnedEvents"`
+
+	// EventsTruncated is true when the event list was clipped (by eventsLimit
+	// or otherwise reduced from TotalEvents). Always emitted so callers can
+	// rely on a stable response shape.
+	EventsTruncated bool `json:"eventsTruncated"`
+}


### PR DESCRIPTION
The `kubernetes_describe` tool returned the entire event history for the described object with no caller-controlled limit, and `metadata.managedFields` was not stripped from event objects (only from the main resource). On flapping pods or busy controllers this scales linearly and risks overloading the model context.

This PR changes `kubernetes_describe` as follows:

- New parameter `eventsLimit` (default 50, range 1–1000, validated server-side) caps the event list.
- Events are sorted newest-first by `lastTimestamp`, falling back to `eventTime`, then `firstTimestamp`, before truncation.
- Response gains `totalEvents`, `returnedEvents`, and `eventsTruncated` fields so callers can detect that the event history was clipped. All three are emitted unconditionally for a stable wire shape.
- `metadata.managedFields` is now stripped from each returned event.

The truncation/shape pattern mirrors `kubernetes_cluster_health` from #387 (`TotalNodes`/`ReturnedNodes`/`NodesTruncated`). All transformation happens in the handler layer; the `k8s.ResourceManager.Describe` interface is unchanged. `EventsTruncated` is computed from the actual outcome (`TotalEvents > ReturnedEvents`), so callers cannot read `false` while events are missing.

## Test plan

- [x] `go test ./...` passes
- [x] New unit tests cover defaults, override, no-truncation, limit-equals-total boundary, sort order (newest-first + fallbacks to eventTime and firstTimestamp), `managedFields` stripping, no-events shape, always-emitted count fields, and out-of-range rejection
- [x] Manual smoke test against a real cluster: described object with default params, then `eventsLimit=5`, verified `eventsTruncated`/`totalEvents` are sensible

🤖 Generated with [Claude Code](https://claude.com/claude-code)