### PR TITLE
Plumb --non-destructive and --dry-run flags into ServerContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.73] - 2026-05-05
-
 ### Fixed
 
 - The `--non-destructive` and `--dry-run` CLI flags now correctly propagate to the server context. Previously, the values were only applied to the Kubernetes client layer, so the runtime safety check in `CheckMutatingOperation` always read the default values regardless of CLI input.
+
+## [0.1.73] - 2026-05-05
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added MCP tool annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) to all tools to help clients and users assess tool behavior ([#36355](https://github.com/giantswarm/giantswarm/issues/36355)).
 
+### Fixed
+
+- The `--non-destructive` and `--dry-run` CLI flags now correctly propagate to the server context. Previously, the values were only applied to the Kubernetes client layer, so the runtime safety check in `CheckMutatingOperation` always read the default values regardless of CLI input.
+
 ### Changed
 
 - **Breaking:** `kubernetes_logs` parameter surface simplified. `tailLines` now defaults to `100`, is bounded to `[1, 1000]`, and is enforced server-side via `corev1.PodLogOptions.TailLines`, bounding both response size and gateway memory. The `sinceLines` and `maxLines` parameters have been removed; for time-based filtering, the new `sinceTime` parameter accepts an RFC3339 timestamp and is also applied server-side.

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -458,16 +458,6 @@ func validateEncryptionKey(key []byte) error {
 	return nil
 }
 
-// modeServerContextOptions returns the ServerContext options that derive from
-// the safety-related fields of ServeConfig (--non-destructive, --dry-run).
-// Extracted to make CLI-to-ServerContext plumbing independently testable.
-func modeServerContextOptions(config ServeConfig) []server.Option {
-	return []server.Option{
-		server.WithNonDestructiveMode(config.NonDestructiveMode),
-		server.WithDryRun(config.DryRun),
-	}
-}
-
 // runServe contains the main server logic with support for multiple transports
 func runServe(config ServeConfig) error {
 	// Configure default slog logger level based on debug mode
@@ -538,7 +528,8 @@ func runServe(config ServeConfig) error {
 	var serverContextOptions []server.Option
 	serverContextOptions = append(serverContextOptions, server.WithK8sClient(k8sClient))
 	serverContextOptions = append(serverContextOptions, server.WithInstrumentationProvider(instrumentationProvider))
-	serverContextOptions = append(serverContextOptions, modeServerContextOptions(config)...)
+	serverContextOptions = append(serverContextOptions, server.WithNonDestructiveMode(config.NonDestructiveMode))
+	serverContextOptions = append(serverContextOptions, server.WithDryRun(config.DryRun))
 
 	// Set in-cluster mode flag
 	if config.InCluster {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -458,6 +458,16 @@ func validateEncryptionKey(key []byte) error {
 	return nil
 }
 
+// modeServerContextOptions returns the ServerContext options that derive from
+// the safety-related fields of ServeConfig (--non-destructive, --dry-run).
+// Extracted to make CLI-to-ServerContext plumbing independently testable.
+func modeServerContextOptions(config ServeConfig) []server.Option {
+	return []server.Option{
+		server.WithNonDestructiveMode(config.NonDestructiveMode),
+		server.WithDryRun(config.DryRun),
+	}
+}
+
 // runServe contains the main server logic with support for multiple transports
 func runServe(config ServeConfig) error {
 	// Configure default slog logger level based on debug mode
@@ -528,6 +538,7 @@ func runServe(config ServeConfig) error {
 	var serverContextOptions []server.Option
 	serverContextOptions = append(serverContextOptions, server.WithK8sClient(k8sClient))
 	serverContextOptions = append(serverContextOptions, server.WithInstrumentationProvider(instrumentationProvider))
+	serverContextOptions = append(serverContextOptions, modeServerContextOptions(config)...)
 
 	// Set in-cluster mode flag
 	if config.InCluster {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"bytes"
-	"context"
 	"os"
 	"strings"
 	"testing"
@@ -10,14 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/giantswarm/mcp-kubernetes/internal/k8s"
-	"github.com/giantswarm/mcp-kubernetes/internal/server"
 )
-
-// stubK8sClient satisfies k8s.Client for tests that only need a non-nil client.
-// Method calls would panic — tests using this must avoid invoking k8s operations.
-type stubK8sClient struct{ k8s.Client }
 
 func TestNewServeCmd(t *testing.T) {
 	cmd := newServeCmd()
@@ -121,62 +113,6 @@ func TestInClusterFlagParsing(t *testing.T) {
 					assert.False(t, capturedNonDestructive)
 				}
 			}
-		})
-	}
-}
-
-// TestModeServerContextOptions verifies that the safety-mode CLI flags
-// (--non-destructive, --dry-run) are correctly threaded into the
-// ServerContext configuration when serve options are built. This guards
-// the bug where flag values were dropped before reaching CheckMutatingOperation.
-func TestModeServerContextOptions(t *testing.T) {
-	tests := []struct {
-		name                   string
-		nonDestructive         bool
-		dryRun                 bool
-		wantNonDestructiveMode bool
-		wantDryRun             bool
-	}{
-		{
-			name:                   "non-destructive on, dry-run off (default)",
-			nonDestructive:         true,
-			dryRun:                 false,
-			wantNonDestructiveMode: true,
-			wantDryRun:             false,
-		},
-		{
-			name:                   "non-destructive off",
-			nonDestructive:         false,
-			dryRun:                 false,
-			wantNonDestructiveMode: false,
-			wantDryRun:             false,
-		},
-		{
-			name:                   "dry-run on",
-			nonDestructive:         true,
-			dryRun:                 true,
-			wantNonDestructiveMode: true,
-			wantDryRun:             true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			opts := modeServerContextOptions(ServeConfig{
-				NonDestructiveMode: tt.nonDestructive,
-				DryRun:             tt.dryRun,
-			})
-
-			contextOpts := append([]server.Option{
-				server.WithK8sClient(&stubK8sClient{}),
-				server.WithLogger(server.NewDefaultLogger()),
-			}, opts...)
-
-			sc, err := server.NewServerContext(context.Background(), contextOpts...)
-			require.NoError(t, err)
-
-			assert.Equal(t, tt.wantNonDestructiveMode, sc.Config().NonDestructiveMode)
-			assert.Equal(t, tt.wantDryRun, sc.Config().DryRun)
 		})
 	}
 }

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"strings"
 	"testing"
@@ -9,7 +10,14 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/giantswarm/mcp-kubernetes/internal/k8s"
+	"github.com/giantswarm/mcp-kubernetes/internal/server"
 )
+
+// stubK8sClient satisfies k8s.Client for tests that only need a non-nil client.
+// Method calls would panic — tests using this must avoid invoking k8s operations.
+type stubK8sClient struct{ k8s.Client }
 
 func TestNewServeCmd(t *testing.T) {
 	cmd := newServeCmd()
@@ -113,6 +121,62 @@ func TestInClusterFlagParsing(t *testing.T) {
 					assert.False(t, capturedNonDestructive)
 				}
 			}
+		})
+	}
+}
+
+// TestModeServerContextOptions verifies that the safety-mode CLI flags
+// (--non-destructive, --dry-run) are correctly threaded into the
+// ServerContext configuration when serve options are built. This guards
+// the bug where flag values were dropped before reaching CheckMutatingOperation.
+func TestModeServerContextOptions(t *testing.T) {
+	tests := []struct {
+		name                   string
+		nonDestructive         bool
+		dryRun                 bool
+		wantNonDestructiveMode bool
+		wantDryRun             bool
+	}{
+		{
+			name:                   "non-destructive on, dry-run off (default)",
+			nonDestructive:         true,
+			dryRun:                 false,
+			wantNonDestructiveMode: true,
+			wantDryRun:             false,
+		},
+		{
+			name:                   "non-destructive off",
+			nonDestructive:         false,
+			dryRun:                 false,
+			wantNonDestructiveMode: false,
+			wantDryRun:             false,
+		},
+		{
+			name:                   "dry-run on",
+			nonDestructive:         true,
+			dryRun:                 true,
+			wantNonDestructiveMode: true,
+			wantDryRun:             true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := modeServerContextOptions(ServeConfig{
+				NonDestructiveMode: tt.nonDestructive,
+				DryRun:             tt.dryRun,
+			})
+
+			contextOpts := append([]server.Option{
+				server.WithK8sClient(&stubK8sClient{}),
+				server.WithLogger(server.NewDefaultLogger()),
+			}, opts...)
+
+			sc, err := server.NewServerContext(context.Background(), contextOpts...)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantNonDestructiveMode, sc.Config().NonDestructiveMode)
+			assert.Equal(t, tt.wantDryRun, sc.Config().DryRun)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- The `--non-destructive` and `--dry-run` CLI flags were only applied to the Kubernetes client layer; they never reached the `ServerContext`. As a result, the runtime safety check in `CheckMutatingOperation` always read the default `NonDestructiveMode` value regardless of CLI input.
- Threads both flags through `ServerContext` options in `cmd/serve.go`, so the runtime gate honours user configuration.

This is a prerequisite for [#4296](https://github.com/giantswarm/roadmap/issues/4296) (hiding destructive tools in non-destructive mode), but it's a standalone bug fix that's worth landing on its own.