### PR TITLE
fix: align files + satisfy goconst on golangci-lint v2.12.2

### DIFF
--- a/.github/workflows/zz_generated.pre-commit.yaml
+++ b/.github/workflows/zz_generated.pre-commit.yaml
@@ -2,7 +2,7 @@
 #
 #    devctl
 #
-#    https://github.com/giantswarm/devctl/blob/db6c4eacba30ff7c3b055094ff7b11d2dadc98b0/pkg/gen/input/precommit/internal/file/pre-commit-action.yaml.template
+#    https://github.com/giantswarm/devctl/blob/f8c9dbe49225b5327dc3e27f7db99439cb658ea3/pkg/gen/input/precommit/internal/file/pre-commit-action.yaml.template
 #
 name: pre-commit
 
@@ -16,7 +16,7 @@ on:
 env:
   HELM_VERSION: "3.20.2"
   HELM_DOCS_VERSION: "1.14.2"
-  HELM_VALUES_SCHEMA_JSON_VERSION: "2.3.1"
+  HELM_VALUES_SCHEMA_JSON_VERSION: "2.4.0"
 
 jobs:
   pre-commit:
@@ -56,7 +56,7 @@ jobs:
         uses: giantswarm/install-binary-action@e2730babbc89f02ef1559b042d33cbe24f5c3547 # v4.0.2
         with:
           binary: golangci-lint
-          version: "2.11.4"
+          version: "2.12.2"
           download_url: "https://github.com/golangci/golangci-lint/releases/download/v${version}/${binary}-${version}-linux-amd64.tar.gz"
       - name: Execute pre-commit hooks
         uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,8 @@
+version: "2"
+
+linters:
+  exclusions:
+    rules:
+      - path: _test\.go
+        linters:
+          - goconst

--- a/cmd/selfupdate.go
+++ b/cmd/selfupdate.go
@@ -11,6 +11,7 @@ import (
 // githubRepoSlug specifies the GitHub repository (owner/repo) to check for updates.
 const (
 	githubRepoSlug = "giantswarm/mcp-kubernetes" // GitHub repository path
+	devVersion     = "dev"
 )
 
 // newSelfUpdateCmd creates the Cobra command for the self-update functionality.
@@ -31,7 +32,7 @@ func runSelfUpdate(cmd *cobra.Command, args []string) error {
 	currentVersion := rootCmd.Version
 	// Self-update is typically disabled for development versions (e.g., "dev")
 	// as they are not standard releases and might not follow semantic versioning.
-	if currentVersion == "" || currentVersion == "dev" {
+	if currentVersion == "" || currentVersion == devVersion {
 		return fmt.Errorf("cannot self-update a development version")
 	}
 

--- a/cmd/serve_config.go
+++ b/cmd/serve_config.go
@@ -20,8 +20,9 @@ const (
 
 // URI scheme constants for URL validation
 const (
-	schemeHTTPS = "https"
-	schemeHTTP  = "http"
+	schemeHTTPS      = "https"
+	schemeHTTP       = "http"
+	schemeJavaScript = "javascript"
 )
 
 // ServeConfig holds all configuration for the serve command.
@@ -470,7 +471,7 @@ func validateTrustedSchemes(schemes []string) error {
 			slog.Warn("trustedPublicRegistrationSchemes includes a web scheme - this allows unauthenticated registration for web clients which may be a security risk",
 				"scheme", scheme,
 				"recommendation", "Consider using a registration token for web clients instead")
-		case "javascript", "data", "file", "ftp":
+		case schemeJavaScript, "data", "file", "ftp":
 			return fmt.Errorf("trusted scheme %q is not allowed - these schemes pose security risks (XSS, local file access)", scheme)
 		}
 	}

--- a/internal/federation/access_check.go
+++ b/internal/federation/access_check.go
@@ -8,16 +8,25 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// Kubernetes API verbs used in access checks. Defined as constants so that
+// other packages can reference them without re-declaring string literals.
+const (
+	verbGet    = "get"
+	verbCreate = "create"
+	verbPatch  = "patch"
+	verbDelete = "delete"
+)
+
 // ValidKubernetesVerbs is the set of valid Kubernetes API verbs that can be used
 // in access checks. This is exported for use in validation and UI components.
 var ValidKubernetesVerbs = map[string]bool{
-	"get":              true,
+	verbGet:            true,
 	"list":             true,
 	"watch":            true,
-	"create":           true,
+	verbCreate:         true,
 	"update":           true,
-	"patch":            true,
-	"delete":           true,
+	verbPatch:          true,
+	verbDelete:         true,
 	"deletecollection": true,
 	"impersonate":      true,
 	"bind":             true,

--- a/internal/federation/connectivity.go
+++ b/internal/federation/connectivity.go
@@ -16,6 +16,19 @@ import (
 // defaultHealthCheckPath is the standard Kubernetes health endpoint.
 const defaultHealthCheckPath = "/healthz"
 
+// Error message and endpoint type constants used by error classification and
+// endpoint type inference helpers.
+const (
+	tlsErrCertExpired         = "certificate has expired"
+	tlsErrUnknownAuthority    = "unknown authority"
+	tlsErrSignedByUnknownAuth = "certificate signed by unknown authority"
+	tlsErrHostnameMismatch    = "certificate hostname mismatch"
+	tlsErrHandshakeFailed     = "TLS handshake failed"
+	timeoutPattern            = "timeout"
+	endpointTypePrivate       = "private"
+	endpointTypePublic        = "public"
+)
+
 // ErrInvalidHealthCheckPath indicates that the health check path is invalid.
 var ErrInvalidHealthCheckPath = errors.New("invalid health check path")
 
@@ -464,11 +477,11 @@ func isTLSError(err error) bool {
 		"tls:",
 		"x509:",
 		"certificate signed by",
-		"certificate has expired",
+		tlsErrCertExpired,
 		"certificate is not valid",
 		"certificate is valid for",
 		"handshake failure",
-		"unknown authority",
+		tlsErrUnknownAuthority,
 		"bad certificate",
 		"unsupported protocol",
 	}
@@ -497,7 +510,7 @@ func isTimeoutError(err error) bool {
 	// Check error message for timeout patterns
 	errStr := err.Error()
 	timeoutPatterns := []string{
-		"timeout",
+		timeoutPattern,
 		"timed out",
 		"deadline exceeded",
 		"i/o timeout",
@@ -522,18 +535,18 @@ func extractTLSReason(err error) string {
 
 	// Map common TLS errors to user-friendly messages
 	switch {
-	case strings.Contains(errStr, "unknown authority"):
-		return "certificate signed by unknown authority"
+	case strings.Contains(errStr, tlsErrUnknownAuthority):
+		return tlsErrSignedByUnknownAuth
 	case strings.Contains(errStr, "has expired"):
-		return "certificate has expired"
+		return tlsErrCertExpired
 	case strings.Contains(errStr, "not valid yet"):
 		return "certificate is not yet valid"
 	case strings.Contains(errStr, "doesn't contain any IP SANs"):
 		return "certificate doesn't match server IP"
 	case strings.Contains(errStr, "doesn't match"):
-		return "certificate hostname mismatch"
+		return tlsErrHostnameMismatch
 	case strings.Contains(errStr, "handshake failure"):
-		return "TLS handshake failed"
+		return tlsErrHandshakeFailed
 	case strings.Contains(errStr, "protocol version"):
 		return "TLS protocol version mismatch"
 	default:
@@ -572,9 +585,9 @@ func GetEndpointType(host string) string {
 	ip := net.ParseIP(hostPart)
 	if ip != nil {
 		if isPrivateIP(ip) {
-			return "private"
+			return endpointTypePrivate
 		}
-		return "public"
+		return endpointTypePublic
 	}
 
 	// It's a hostname - check for common private DNS patterns
@@ -588,11 +601,11 @@ func GetEndpointType(host string) string {
 
 	for _, pattern := range privateHostnamePatterns {
 		if strings.Contains(hostPart, pattern) {
-			return "private"
+			return endpointTypePrivate
 		}
 	}
 
-	return "public"
+	return endpointTypePublic
 }
 
 // isPrivateIP checks if an IP address is in a private range.

--- a/internal/federation/group_mapper.go
+++ b/internal/federation/group_mapper.go
@@ -220,12 +220,23 @@ func (gm *GroupMapper) String() string {
 //
 // Any other "system:*" prefixed target group that is NOT on this denylist will
 // still trigger a warning log at startup (see NewGroupMapper).
+// Privileged Kubernetes system group names that group mappings must never
+// target. Defined as constants so they can be referenced from validation
+// errors without re-declaring string literals.
+const (
+	systemGroupMasters               = "system:masters"
+	systemGroupNodes                 = "system:nodes"
+	systemGroupKubeControllerManager = "system:kube-controller-manager"
+	systemGroupKubeScheduler         = "system:kube-scheduler"
+	systemGroupKubeProxy             = "system:kube-proxy"
+)
+
 var deniedTargetGroups = map[string]struct{}{
-	"system:masters":                 {},
-	"system:nodes":                   {},
-	"system:kube-controller-manager": {},
-	"system:kube-scheduler":          {},
-	"system:kube-proxy":              {},
+	systemGroupMasters:               {},
+	systemGroupNodes:                 {},
+	systemGroupKubeControllerManager: {},
+	systemGroupKubeScheduler:         {},
+	systemGroupKubeProxy:             {},
 }
 
 // validateGroupMappings validates the group mapping configuration.

--- a/internal/federation/oauth_client_provider.go
+++ b/internal/federation/oauth_client_provider.go
@@ -18,6 +18,13 @@ import (
 // nolint:gosec // G101: This is a key name, not a credential
 const UserExtraOAuthTokenKey = "oauth_token"
 
+// In-cluster Kubernetes API server defaults used when constructing
+// OAuthClientProvider instances from in-cluster configuration.
+const (
+	defaultClusterHost = "https://kubernetes.default.svc"
+	defaultCACertFile  = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+)
+
 // OAuthClientProvider implements ClientProvider for OAuth downstream authentication.
 // It creates per-user Kubernetes clients using the user's OAuth bearer token,
 // ensuring all API operations are performed with the user's RBAC permissions.
@@ -107,8 +114,8 @@ type OAuthClientProviderConfig struct {
 // DefaultOAuthClientProviderConfig returns a configuration with sensible defaults.
 func DefaultOAuthClientProviderConfig() *OAuthClientProviderConfig {
 	return &OAuthClientProviderConfig{
-		ClusterHost: "https://kubernetes.default.svc",
-		CACertFile:  "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+		ClusterHost: defaultClusterHost,
+		CACertFile:  defaultCACertFile,
 		QPS:         50,
 		Burst:       100,
 		Timeout:     30 * time.Second,
@@ -151,7 +158,7 @@ func NewOAuthClientProviderFromInCluster() (*OAuthClientProvider, error) {
 
 	config := &OAuthClientProviderConfig{
 		ClusterHost: inClusterConfig.Host,
-		CACertFile:  "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+		CACertFile:  defaultCACertFile,
 		QPS:         50,
 		Burst:       100,
 		Timeout:     30 * time.Second,

--- a/internal/federation/validation.go
+++ b/internal/federation/validation.go
@@ -39,6 +39,13 @@ const (
 	MaxClusterNameLength = 253
 )
 
+// Validation field name constants used in ValidationError values.
+const (
+	fieldEmail          = "email"
+	fieldExtraHeaderKey = "extra header key"
+	fieldClusterName    = "cluster name"
+)
+
 // Validation errors.
 var (
 	// ErrUserInfoRequired indicates that user information is required but was not provided.
@@ -192,7 +199,7 @@ func ValidateUserInfo(user *UserInfo) error {
 func validateEmail(email string) error {
 	if len(email) > MaxEmailLength {
 		return &ValidationError{
-			Field:  "email",
+			Field:  fieldEmail,
 			Value:  truncateForError(email, 20),
 			Reason: fmt.Sprintf("email too long (max %d characters)", MaxEmailLength),
 			Err:    ErrInvalidEmail,
@@ -201,7 +208,7 @@ func validateEmail(email string) error {
 
 	if containsControlCharacters(email) {
 		return &ValidationError{
-			Field:  "email",
+			Field:  fieldEmail,
 			Value:  truncateForError(email, 20),
 			Reason: "email contains invalid control characters",
 			Err:    ErrInvalidEmail,
@@ -210,7 +217,7 @@ func validateEmail(email string) error {
 
 	if !validEmailRegex.MatchString(email) {
 		return &ValidationError{
-			Field:  "email",
+			Field:  fieldEmail,
 			Value:  truncateForError(email, 20),
 			Reason: "email format is invalid",
 			Err:    ErrInvalidEmail,
@@ -255,7 +262,7 @@ func validateGroupName(group string, index int) error {
 func validateExtraHeader(key string, values []string) error {
 	if key == "" {
 		return &ValidationError{
-			Field:  "extra header key",
+			Field:  fieldExtraHeaderKey,
 			Reason: "header key cannot be empty",
 			Err:    ErrInvalidExtraHeader,
 		}
@@ -263,7 +270,7 @@ func validateExtraHeader(key string, values []string) error {
 
 	if len(key) > MaxExtraKeyLength {
 		return &ValidationError{
-			Field:  "extra header key",
+			Field:  fieldExtraHeaderKey,
 			Value:  truncateForError(key, 20),
 			Reason: fmt.Sprintf("header key too long (max %d characters)", MaxExtraKeyLength),
 			Err:    ErrInvalidExtraHeader,
@@ -272,7 +279,7 @@ func validateExtraHeader(key string, values []string) error {
 
 	if !validHeaderKeyRegex.MatchString(key) {
 		return &ValidationError{
-			Field:  "extra header key",
+			Field:  fieldExtraHeaderKey,
 			Value:  truncateForError(key, 20),
 			Reason: "header key contains invalid characters (only alphanumeric, hyphen, underscore allowed)",
 			Err:    ErrInvalidExtraHeader,
@@ -306,7 +313,7 @@ func validateExtraHeader(key string, values []string) error {
 func ValidateClusterName(name string) error {
 	if name == "" {
 		return &ValidationError{
-			Field:  "cluster name",
+			Field:  fieldClusterName,
 			Reason: "cluster name cannot be empty",
 			Err:    ErrInvalidClusterName,
 		}
@@ -314,7 +321,7 @@ func ValidateClusterName(name string) error {
 
 	if len(name) > MaxClusterNameLength {
 		return &ValidationError{
-			Field:  "cluster name",
+			Field:  fieldClusterName,
 			Value:  truncateForError(name, 20),
 			Reason: fmt.Sprintf("cluster name too long (max %d characters)", MaxClusterNameLength),
 			Err:    ErrInvalidClusterName,
@@ -324,7 +331,7 @@ func ValidateClusterName(name string) error {
 	// Check for path traversal attempts
 	if strings.Contains(name, "..") || strings.Contains(name, "/") || strings.Contains(name, "\\") {
 		return &ValidationError{
-			Field:  "cluster name",
+			Field:  fieldClusterName,
 			Value:  truncateForError(name, 20),
 			Reason: "cluster name contains invalid path characters",
 			Err:    ErrInvalidClusterName,
@@ -333,7 +340,7 @@ func ValidateClusterName(name string) error {
 
 	if !validClusterNameRegex.MatchString(name) {
 		return &ValidationError{
-			Field:  "cluster name",
+			Field:  fieldClusterName,
 			Value:  truncateForError(name, 20),
 			Reason: "cluster name must consist of lowercase alphanumeric characters or hyphens, start with alphanumeric, and end with alphanumeric",
 			Err:    ErrInvalidClusterName,

--- a/internal/instrumentation/cardinality.go
+++ b/internal/instrumentation/cardinality.go
@@ -164,7 +164,7 @@ func ClassifyClusterName(name string) string {
 //	ExtractUserDomain("")                   // "unknown"
 func ExtractUserDomain(email string) string {
 	if email == "" {
-		return "unknown"
+		return StatusUnknown
 	}
 
 	parts := strings.Split(email, "@")
@@ -172,7 +172,7 @@ func ExtractUserDomain(email string) string {
 		return parts[1]
 	}
 
-	return "unknown"
+	return StatusUnknown
 }
 
 // ImpersonationResult constants for metrics.

--- a/internal/instrumentation/config.go
+++ b/internal/instrumentation/config.go
@@ -66,7 +66,7 @@ type Config struct {
 func DefaultConfig() Config {
 	config := Config{
 		ServiceName:        getEnvOrDefault("OTEL_SERVICE_NAME", "mcp-kubernetes"),
-		ServiceVersion:     "unknown",
+		ServiceVersion:     StatusUnknown,
 		ServiceInstanceID:  getEnvOrDefault("OTEL_SERVICE_INSTANCE_ID", ""),
 		K8sNamespace:       getEnvOrDefault("K8S_NAMESPACE", getEnvOrDefault("POD_NAMESPACE", "")),
 		K8sPodName:         getEnvOrDefault("K8S_POD_NAME", getEnvOrDefault("HOSTNAME", "")),

--- a/internal/instrumentation/oauth_metrics.go
+++ b/internal/instrumentation/oauth_metrics.go
@@ -1,5 +1,20 @@
 package instrumentation
 
+// MCP OAuth metric names exposed by the mcp-oauth library when instrumentation
+// is enabled. Defined as constants so tests and dashboards can reference them
+// without re-declaring string literals.
+const (
+	MetricOAuthRateLimitExceededTotal    = "oauth_rate_limit_exceeded_total"
+	MetricOAuthRedirectURIRejectedTotal  = "oauth_redirect_uri_security_rejected_total"
+	MetricOAuthCodeReuseDetectedTotal    = "oauth_code_reuse_detected_total"
+	MetricOAuthTokenReuseDetectedTotal   = "oauth_token_reuse_detected_total" //nolint:gosec // G101: metric name, not a credential
+	MetricOAuthPKCEValidationFailedTotal = "oauth_pkce_validation_failed_total"
+	MetricOAuthClientRegisteredTotal     = "oauth_client_registered_total"
+	MetricOAuthCIMDFetchTotal            = "oauth_cimd_fetch_total"
+	MetricStorageClientsCount            = "storage_clients_count"
+	MetricStorageTokensCount             = "storage_tokens_count"
+)
+
 // ExpectedMCPOAuthMetrics returns the list of metric names that the mcp-oauth
 // library exposes when instrumentation is enabled.
 //
@@ -45,24 +60,24 @@ package instrumentation
 func ExpectedMCPOAuthMetrics() []string {
 	return []string{
 		// Rate limiting and security
-		"oauth_rate_limit_exceeded_total",
-		"oauth_redirect_uri_security_rejected_total",
+		MetricOAuthRateLimitExceededTotal,
+		MetricOAuthRedirectURIRejectedTotal,
 
 		// Replay attack detection
-		"oauth_code_reuse_detected_total",
-		"oauth_token_reuse_detected_total",
+		MetricOAuthCodeReuseDetectedTotal,
+		MetricOAuthTokenReuseDetectedTotal,
 
 		// PKCE validation
-		"oauth_pkce_validation_failed_total",
+		MetricOAuthPKCEValidationFailedTotal,
 
 		// Client registration
-		"oauth_client_registered_total",
+		MetricOAuthClientRegisteredTotal,
 
 		// CIMD (Client ID Metadata Documents)
-		"oauth_cimd_fetch_total",
+		MetricOAuthCIMDFetchTotal,
 
 		// Storage metrics
-		"storage_clients_count",
-		"storage_tokens_count",
+		MetricStorageClientsCount,
+		MetricStorageTokensCount,
 	}
 }

--- a/internal/k8s/bearer_client.go
+++ b/internal/k8s/bearer_client.go
@@ -255,7 +255,7 @@ func (c *bearerTokenClient) isOperationAllowed(operation string) error {
 	}
 
 	if c.nonDestructiveMode {
-		destructiveOps := []string{"delete", "patch", "scale", "create", "apply"}
+		destructiveOps := []string{OperationDelete, OperationPatch, OperationScale, OperationCreate, OperationApply}
 		for _, destructiveOp := range destructiveOps {
 			if destructiveOp == operation {
 				if !c.dryRun {
@@ -304,7 +304,7 @@ func (c *bearerTokenClient) debugLog(msg string, args ...any) {
 func (c *bearerTokenClient) getInClusterNamespace() string {
 	data, err := os.ReadFile(DefaultNamespacePath)
 	if err != nil {
-		return "default"
+		return DefaultNamespace
 	}
 	return string(data)
 }

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -150,12 +150,12 @@ func BuildResponseMeta(namespaced bool, requestedNS, effectiveNS, resourceType s
 		EffectiveNamespace: effectiveNS,
 	}
 	if namespaced {
-		meta.ResourceScope = "namespaced"
+		meta.ResourceScope = ListScopeNamespaced
 		if allNamespaces {
-			meta.Hint = "Listing across all namespaces"
+			meta.Hint = OperationListAll
 		}
 	} else {
-		meta.ResourceScope = "cluster"
+		meta.ResourceScope = ListScopeCluster
 		if requestedNS != "" {
 			meta.Hint = resourceType + " is cluster-scoped; namespace parameter was ignored"
 		}

--- a/internal/k8s/client_impl.go
+++ b/internal/k8s/client_impl.go
@@ -630,7 +630,7 @@ func (c *kubernetesClient) isOperationAllowed(operation string) error {
 
 	// Check if operation is destructive and non-destructive mode is enabled
 	if c.nonDestructiveMode {
-		destructiveOps := []string{"delete", "patch", "scale", "create", "apply"}
+		destructiveOps := []string{OperationDelete, OperationPatch, OperationScale, OperationCreate, OperationApply}
 		for _, destructiveOp := range destructiveOps {
 			if destructiveOp == operation {
 				if !c.dryRun {
@@ -767,7 +767,7 @@ func (c *kubernetesClient) getInClusterNamespace() string {
 	data, err := os.ReadFile(DefaultNamespacePath)
 	if err != nil {
 		// Fallback to default namespace if we can't read the file
-		return "default"
+		return DefaultNamespace
 	}
 	return string(data)
 }

--- a/internal/k8s/cluster.go
+++ b/internal/k8s/cluster.go
@@ -179,7 +179,7 @@ func (c *kubernetesClient) GetClusterHealth(ctx context.Context, kubeContext str
 	if err != nil {
 		health.Status = clusterHealthUnhealthy
 		health.Components = append(health.Components, ComponentHealth{
-			Name:    "API Server",
+			Name:    componentAPIServer,
 			Status:  clusterHealthUnhealthy,
 			Message: fmt.Sprintf("Failed to get server version: %v", err),
 		})
@@ -188,7 +188,7 @@ func (c *kubernetesClient) GetClusterHealth(ctx context.Context, kubeContext str
 
 	// API Server is healthy if we can get version
 	health.Components = append(health.Components, ComponentHealth{
-		Name:    "API Server",
+		Name:    componentAPIServer,
 		Status:  clusterHealthHealthy,
 		Message: fmt.Sprintf("Version: %s", version.String()),
 	})
@@ -293,10 +293,10 @@ type GroupVersion struct {
 func (c *kubernetesClient) calculateOverallHealth(components []ComponentHealth, nodes []NodeHealth) string {
 	// Check if any critical components are unhealthy
 	criticalComponents := map[string]bool{
-		"etcd":                    true,
-		"kube-apiserver":          true,
-		"kube-controller-manager": true,
-		"kube-scheduler":          true,
+		componentEtcd:                  true,
+		componentKubeAPIServer:         true,
+		componentKubeControllerManager: true,
+		componentKubeScheduler:         true,
 	}
 
 	for _, component := range components {

--- a/internal/k8s/constants.go
+++ b/internal/k8s/constants.go
@@ -21,4 +21,25 @@ const (
 	// DefaultNamespace is used when no namespace is specified, following kubectl behavior.
 	// For cluster-scoped resources, the Kubernetes API ignores the namespace.
 	DefaultNamespace = "default"
+
+	// Operation names used by access control and listing helpers.
+	OperationApply      = "apply"
+	OperationCreate     = "create"
+	OperationDelete     = "delete"
+	OperationPatch      = "patch"
+	OperationScale      = "scale"
+	OperationListAll    = "Listing across all namespaces"
+	ListScopeNamespaced = "namespaced"
+	ListScopeCluster    = "cluster"
+
+	// resourceDeployments matches the k8s "deployments" resource kind. Defined
+	// here to avoid duplicate string literals in non-test code.
+	resourceDeployments = "deployments"
+
+	// Cluster health component names.
+	componentAPIServer             = "API Server"
+	componentEtcd                  = "etcd"
+	componentKubeAPIServer         = "kube-apiserver"
+	componentKubeControllerManager = "kube-controller-manager"
+	componentKubeScheduler         = "kube-scheduler"
 )

--- a/internal/k8s/resource_ops.go
+++ b/internal/k8s/resource_ops.go
@@ -448,7 +448,7 @@ func scaleResourceWithGVR(ctx context.Context, dynamicClient dynamic.Interface, 
 
 	// Validate this is a scalable resource
 	switch strings.ToLower(resourceType) {
-	case "deployment", "deployments", "deploy",
+	case "deployment", resourceDeployments, "deploy",
 		"replicaset", "replicasets", "rs",
 		"statefulset", "statefulsets", "sts":
 		// OK, these are scalable
@@ -802,7 +802,7 @@ func getClusterHealth(ctx context.Context, clientset kubernetes.Interface, disco
 	if err != nil {
 		health.Status = clusterHealthUnhealthy
 		health.Components = append(health.Components, ComponentHealth{
-			Name:    "API Server",
+			Name:    componentAPIServer,
 			Status:  clusterHealthUnhealthy,
 			Message: fmt.Sprintf("Failed to get server version: %s", err.Error()),
 		})
@@ -810,7 +810,7 @@ func getClusterHealth(ctx context.Context, clientset kubernetes.Interface, disco
 	}
 
 	health.Components = append(health.Components, ComponentHealth{
-		Name:    "API Server",
+		Name:    componentAPIServer,
 		Status:  clusterHealthHealthy,
 		Message: fmt.Sprintf("Version: %s", version.String()),
 	})
@@ -1045,10 +1045,10 @@ func parseGroupVersionShared(groupVersion string) (GroupVersion, error) {
 // calculateOverallHealthShared determines the overall cluster health.
 func calculateOverallHealthShared(components []ComponentHealth, nodes []NodeHealth) string {
 	criticalComponents := map[string]bool{
-		"etcd":                    true,
-		"kube-apiserver":          true,
-		"kube-controller-manager": true,
-		"kube-scheduler":          true,
+		componentEtcd:                  true,
+		componentKubeAPIServer:         true,
+		componentKubeControllerManager: true,
+		componentKubeScheduler:         true,
 	}
 
 	for _, component := range components {

--- a/internal/k8s/resources.go
+++ b/internal/k8s/resources.go
@@ -523,7 +523,7 @@ func (c *kubernetesClient) Scale(ctx context.Context, kubeContext, namespace, re
 
 	// Handle different scalable resource types
 	switch strings.ToLower(resourceType) {
-	case "deployment", "deployments":
+	case "deployment", resourceDeployments:
 		scale, err := clientset.AppsV1().Deployments(namespace).GetScale(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			return nil, fmt.Errorf("failed to get deployment scale: %w", err)

--- a/internal/logging/slog.go
+++ b/internal/logging/slog.go
@@ -23,6 +23,9 @@ const (
 	KeyError        = "error"
 	KeyHost         = "host"
 	KeyTool         = "tool"
+
+	// hostEmpty is returned by SanitizeHost when the input is empty.
+	hostEmpty = "<empty>"
 )
 
 // Status values for consistent logging.
@@ -145,7 +148,7 @@ func UserHash(email string) slog.Attr {
 //   - "" -> "<empty>"
 func SanitizeHost(host string) string {
 	if host == "" {
-		return "<empty>"
+		return hostEmpty
 	}
 
 	// Helper to redact both IPv4 and IPv6
@@ -184,7 +187,7 @@ func SanitizeHost(host string) string {
 // as even partial token prefixes (like JWT headers) can aid attacks.
 func SanitizeToken(token string) string {
 	if token == "" {
-		return "<empty>"
+		return hostEmpty
 	}
 	return fmt.Sprintf("[token:%d chars]", len(token))
 }

--- a/internal/server/health.go
+++ b/internal/server/health.go
@@ -12,6 +12,9 @@ const (
 	healthStatusOK           = "ok"
 	healthStatusNotReady     = "not ready"
 	healthStatusShuttingDown = "shutting down"
+
+	// Mode label values reported by the health endpoint.
+	modeCAPI = "capi"
 )
 
 // HealthChecker provides health check endpoints for Kubernetes probes.
@@ -197,7 +200,7 @@ func (h *HealthChecker) determineMode() string {
 	}
 
 	if h.serverContext.FederationEnabled() {
-		return "capi"
+		return modeCAPI
 	}
 
 	if h.serverContext.InClusterMode() {

--- a/internal/server/middleware/metrics.go
+++ b/internal/server/middleware/metrics.go
@@ -8,6 +8,10 @@ import (
 	"github.com/giantswarm/mcp-kubernetes/internal/instrumentation"
 )
 
+// pathMCPSession is the normalized path label used for MCP session endpoints
+// to keep metric cardinality bounded.
+const pathMCPSession = "/mcp/:session"
+
 // responseWriter wraps http.ResponseWriter to capture the status code.
 type responseWriter struct {
 	http.ResponseWriter
@@ -113,7 +117,7 @@ var (
 func normalizePath(path string) string {
 	// Handle MCP session endpoints (e.g., /mcp/abc123xyz)
 	if sessionIDPattern.MatchString(path) {
-		return "/mcp/:session"
+		return pathMCPSession
 	}
 
 	// Replace UUIDs with :uuid

--- a/internal/server/oauth_http.go
+++ b/internal/server/oauth_http.go
@@ -516,7 +516,7 @@ func createOAuthServer(config OAuthConfig) (*oauth.Server, storage.TokenStore, e
 			Enabled:         true,
 			ServiceName:     "mcp-kubernetes",
 			ServiceVersion:  config.ServiceVersion,
-			MetricsExporter: "prometheus",
+			MetricsExporter: instrumentation.ExporterPrometheus,
 		},
 
 		// TrustedAudiences for SSO token forwarding from upstream aggregators

--- a/internal/tools/access/handlers.go
+++ b/internal/tools/access/handlers.go
@@ -14,6 +14,16 @@ import (
 	"github.com/giantswarm/mcp-kubernetes/internal/server"
 )
 
+// Display and sanitized evaluation error message constants used by access
+// check handlers.
+const (
+	clusterNameLocal              = "local"
+	evalErrResourceNotRecognized  = "resource type not recognized"
+	evalErrPolicyEvaluationFailed = "policy evaluation failed"
+	evalErrPermissionTimedOut     = "permission check timed out"
+	evalErrInternal               = "internal evaluation error"
+)
+
 // CanIResponse represents the response from the can_i tool.
 type CanIResponse struct {
 	// Allowed indicates whether the requested action is permitted.
@@ -170,7 +180,7 @@ func isValidationError(err error) bool {
 // clusterDisplayName returns a display name for the cluster.
 func clusterDisplayName(clusterName string) string {
 	if clusterName == "" {
-		return "local"
+		return clusterNameLocal
 	}
 	return clusterName
 }
@@ -197,13 +207,13 @@ func sanitizeEvaluationError(evalError string) string {
 	// These patterns are based on common Kubernetes API server responses
 	switch {
 	case containsAny(evalError, "unable to find", "not found", "no matches"):
-		return "resource type not recognized"
+		return evalErrResourceNotRecognized
 	case containsAny(evalError, "webhook", "admission"):
-		return "policy evaluation failed"
+		return evalErrPolicyEvaluationFailed
 	case containsAny(evalError, "timeout", "deadline"):
-		return "permission check timed out"
+		return evalErrPermissionTimedOut
 	case containsAny(evalError, "internal error", "server error"):
-		return "internal evaluation error"
+		return evalErrInternal
 	default:
 		// For unrecognized errors, return a generic message
 		// rather than potentially leaking sensitive information

--- a/internal/tools/audit.go
+++ b/internal/tools/audit.go
@@ -11,6 +11,15 @@ import (
 	"github.com/giantswarm/mcp-kubernetes/internal/server"
 )
 
+// Canonical argument keys used by MCP tool handlers.
+const (
+	argName         = "name"
+	argPodName      = "podName"
+	argPattern      = "pattern"
+	argResourceName = "resourceName"
+	argSessionID    = "sessionID"
+)
+
 // ToolHandler is the signature for MCP tool handler functions that take ServerContext.
 type ToolHandler func(ctx context.Context, request mcp.CallToolRequest, sc *server.ServerContext) (*mcp.CallToolResult, error)
 
@@ -103,7 +112,7 @@ func extractAuditInfoFromArgs(invocation *instrumentation.ToolInvocation, args m
 // Different tools use different parameter names for the resource name.
 func extractResourceName(args map[string]interface{}) string {
 	// Try common parameter names for resource name
-	nameKeys := []string{"name", "podName", "resourceName", "pattern", "sessionID"}
+	nameKeys := []string{argName, argPodName, argResourceName, argPattern, argSessionID}
 	for _, key := range nameKeys {
 		if name, ok := args[key].(string); ok && name != "" {
 			return name

--- a/internal/tools/capi/types.go
+++ b/internal/tools/capi/types.go
@@ -7,6 +7,16 @@ import (
 	"github.com/giantswarm/mcp-kubernetes/internal/federation"
 )
 
+// CAPI cluster phase values mirrored from
+// sigs.k8s.io/cluster-api/api/v1beta1.ClusterPhase. Defined locally so health
+// determination logic can compare phases without importing CAPI types.
+const (
+	clusterPhaseProvisioning = "Provisioning"
+	clusterPhaseProvisioned  = "Provisioned"
+	clusterPhaseDeleting     = "Deleting"
+	clusterPhaseFailed       = "Failed"
+)
+
 // ClusterListOutput represents the output for the capi_list_clusters tool.
 type ClusterListOutput struct {
 	// Clusters contains the list of cluster summaries.
@@ -361,12 +371,12 @@ func buildNodesHealth(c *federation.ClusterSummary) ComponentHealth {
 // determineOverallHealth determines the overall health status based on components.
 func determineOverallHealth(c *federation.ClusterSummary, comp ClusterHealthComponents) (string, string) {
 	// If the cluster is deleting, it's neither healthy nor unhealthy
-	if c.Status == "Deleting" {
+	if c.Status == clusterPhaseDeleting {
 		return HealthStatusUnknown, "Cluster is being deleted"
 	}
 
 	// If provisioning, report as degraded
-	if c.Status == "Provisioning" {
+	if c.Status == clusterPhaseProvisioning {
 		return HealthStatusDegraded, "Cluster is still provisioning"
 	}
 
@@ -423,16 +433,16 @@ func buildHealthChecks(c *federation.ClusterSummary) []HealthCheck {
 	// Cluster phase check
 	phaseCheck := HealthCheck{Name: "cluster-phase"}
 	switch c.Status {
-	case "Provisioned":
+	case clusterPhaseProvisioned:
 		phaseCheck.Status = CheckStatusPass
 		phaseCheck.Message = "Cluster is provisioned"
-	case "Provisioning":
+	case clusterPhaseProvisioning:
 		phaseCheck.Status = CheckStatusWarn
 		phaseCheck.Message = "Cluster is still provisioning"
-	case "Deleting":
+	case clusterPhaseDeleting:
 		phaseCheck.Status = CheckStatusWarn
 		phaseCheck.Message = "Cluster is being deleted"
-	case "Failed":
+	case clusterPhaseFailed:
 		phaseCheck.Status = CheckStatusFail
 		phaseCheck.Message = "Cluster is in failed state"
 	default:

--- a/internal/tools/output/config.go
+++ b/internal/tools/output/config.go
@@ -2,6 +2,13 @@ package output
 
 import "time"
 
+// Excluded field paths used by slim mode. Defined as constants so they can be
+// referenced by tests without re-declaring string literals.
+const (
+	FieldManagedFields            = "metadata.managedFields"
+	FieldLastAppliedConfiguration = "metadata.annotations.kubectl.kubernetes.io/last-applied-configuration"
+)
+
 // Default limits for output processing.
 // These are tuned for typical LLM context windows and API response sizes.
 const (
@@ -75,9 +82,9 @@ func DefaultConfig() *Config {
 func DefaultExcludedFields() []string {
 	return []string{
 		// Managed fields are verbose and rarely useful for troubleshooting
-		"metadata.managedFields",
+		FieldManagedFields,
 		// Last-applied-configuration duplicates the entire manifest
-		"metadata.annotations.kubectl.kubernetes.io/last-applied-configuration",
+		FieldLastAppliedConfiguration,
 		// Revision annotations are internal bookkeeping
 		"metadata.annotations.deployment.kubernetes.io/revision",
 		// Transition times add noise without helping diagnosis

--- a/internal/tools/output/secrets.go
+++ b/internal/tools/output/secrets.go
@@ -7,31 +7,42 @@ import (
 // RedactedValue is the placeholder used for masked secret data.
 const RedactedValue = "***REDACTED***"
 
+// Common Kubernetes secret type strings and pattern names. Defined as
+// constants so they can be referenced by both the secretTypes map and the
+// sensitiveAnnotations map without re-declaring literals.
+const (
+	secretTypeServiceAccountToken = "kubernetes.io/service-account-token" //nolint:gosec // G101: Kubernetes secret type identifier, not a credential
+	secretTypeTLS                 = "kubernetes.io/tls"                   //nolint:gosec // G101: Kubernetes secret type identifier, not a credential
+	secretTypeOpaque              = "Opaque"
+	configMapPatternPassword      = "password"
+	configMapPatternSecret        = "secret"
+)
+
 // secretTypes lists Kubernetes secret types that should always be masked.
 var secretTypes = map[string]bool{
-	"kubernetes.io/service-account-token": true,
-	"kubernetes.io/dockercfg":             true,
-	"kubernetes.io/dockerconfigjson":      true,
-	"kubernetes.io/basic-auth":            true,
-	"kubernetes.io/ssh-auth":              true,
-	"kubernetes.io/tls":                   true,
-	"bootstrap.kubernetes.io/token":       true,
-	"helm.sh/release.v1":                  true, // Helm release secrets
-	"Opaque":                              true, // Generic secrets
+	secretTypeServiceAccountToken:    true,
+	"kubernetes.io/dockercfg":        true,
+	"kubernetes.io/dockerconfigjson": true,
+	"kubernetes.io/basic-auth":       true,
+	"kubernetes.io/ssh-auth":         true,
+	secretTypeTLS:                    true,
+	"bootstrap.kubernetes.io/token":  true,
+	"helm.sh/release.v1":             true, // Helm release secrets
+	secretTypeOpaque:                 true, // Generic secrets
 }
 
 // sensitiveAnnotations lists annotations that contain sensitive data.
 var sensitiveAnnotations = map[string]bool{
-	"kubernetes.io/service-account.uid":   true,
-	"kubernetes.io/service-account.name":  true,
-	"kubernetes.io/service-account-token": true,
+	"kubernetes.io/service-account.uid":  true,
+	"kubernetes.io/service-account.name": true,
+	secretTypeServiceAccountToken:        true,
 }
 
 // sensitiveConfigMapPatterns are name patterns that indicate a ConfigMap may contain secrets.
 var sensitiveConfigMapPatterns = []string{
 	"credentials",
-	"password",
-	"secret",
+	configMapPatternPassword,
+	configMapPatternSecret,
 	"auth",
 	"token",
 	"kubeconfig",
@@ -194,7 +205,7 @@ func ContainsSensitiveData(obj map[string]interface{}) bool {
 	kind = strings.ToLower(kind)
 
 	switch kind {
-	case "secret":
+	case configMapPatternSecret:
 		return true
 	case "configmap":
 		// Some ConfigMaps contain sensitive data based on naming patterns

--- a/internal/tools/output/summary.go
+++ b/internal/tools/output/summary.go
@@ -16,6 +16,9 @@ const (
 	statusSucceeded      = "Succeeded"
 	statusFailed         = "Failed"
 	statusRunning        = "Running"
+
+	// conditionStatusTrue is the "True" value of Kubernetes condition status.
+	conditionStatusTrue = "True"
 )
 
 // ResourceSummary provides aggregated counts for large query results.
@@ -266,7 +269,7 @@ func extractNodeStatus(obj map[string]interface{}) string {
 		condStatus, _ := condMap["status"].(string)
 
 		if condType == statusReady {
-			if condStatus == "True" {
+			if condStatus == conditionStatusTrue {
 				return statusReady
 			}
 			return statusNotReady
@@ -294,7 +297,7 @@ func extractJobStatus(obj map[string]interface{}) string {
 			condType, _ := condMap["type"].(string)
 			condStatus, _ := condMap["status"].(string)
 
-			if condStatus == "True" {
+			if condStatus == conditionStatusTrue {
 				switch condType {
 				case "Complete":
 					return statusSucceeded

--- a/internal/tools/pod/handlers.go
+++ b/internal/tools/pod/handlers.go
@@ -22,8 +22,11 @@ func checkMutatingOperation(sc *server.ServerContext, operation string) *mcp.Cal
 	return tools.CheckMutatingOperation(sc, operation)
 }
 
-// Resource type constant for default resource type in port-forward operations.
-const defaultResourceTypePod = "pod"
+// Resource type constants for port-forward operations.
+const (
+	defaultResourceTypePod     = "pod"
+	defaultResourceTypeService = "service"
+)
 
 // PortForwardResponse represents the structured response for port forwarding operations
 type PortForwardResponse struct {
@@ -315,7 +318,7 @@ func handlePortForward(ctx context.Context, request mcp.CallToolRequest, sc *ser
 		}
 		sessionID = fmt.Sprintf("%s/%s:%s", namespace, resourceName, strings.Join(ports, ","))
 
-	case "service":
+	case defaultResourceTypeService:
 		session, err = k8sClient.PortForwardToService(setupCtx, kubeContext, namespace, resourceName, ports, opts)
 		if err != nil {
 			return mcp.NewToolResultError(tools.FormatK8sError("Failed to setup port forwarding to service", err, client.User())), nil

--- a/internal/tools/resource/handlers.go
+++ b/internal/tools/resource/handlers.go
@@ -21,6 +21,12 @@ import (
 	"github.com/giantswarm/mcp-kubernetes/internal/tools/output"
 )
 
+// Patch type and JSON field constants used by resource handlers.
+const (
+	patchTypeMerge = "merge"
+	jsonFieldKind  = "kind"
+)
+
 // recordK8sOperation records metrics for a Kubernetes operation.
 // Delegates to ServerContext which handles nil checks internally.
 func recordK8sOperation(ctx context.Context, sc *server.ServerContext, clusterName, operation, resourceType, namespace, status string, duration time.Duration) {
@@ -662,7 +668,7 @@ func handlePatchResource(ctx context.Context, request mcp.CallToolRequest, sc *s
 	switch patchTypeStr {
 	case "strategic":
 		patchType = types.StrategicMergePatchType
-	case "merge":
+	case patchTypeMerge:
 		patchType = types.MergePatchType
 	case "json":
 		patchType = types.JSONPatchType
@@ -793,7 +799,7 @@ func handleSummaryResponse(items []runtime.Object, processor *output.Processor, 
 
 	// Build response with summary
 	response := map[string]interface{}{
-		"kind":           resourceType + "Summary",
+		jsonFieldKind:    resourceType + "Summary",
 		"total":          summary.Total,
 		"sample":         summary.Sample,
 		"hasMore":        summary.HasMore,

--- a/internal/tools/resource/types.go
+++ b/internal/tools/resource/types.go
@@ -9,6 +9,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+// Resource kind constants used by resource-summary extraction.
+const (
+	kindDeployment = "deployment"
+	kindConfigMap  = "configmap"
+)
+
 // ResourceSummary represents a compact view of a Kubernetes resource
 type ResourceSummary struct {
 	Name              string            `json:"name"`
@@ -164,7 +170,7 @@ func extractResourceSpecificInfo(obj *unstructured.Unstructured, summary *Resour
 	switch kind {
 	case "pod":
 		extractPodInfo(obj, summary)
-	case "deployment":
+	case kindDeployment:
 		extractDeploymentInfo(obj, summary)
 	case "service":
 		extractServiceInfo(obj, summary)
@@ -174,7 +180,7 @@ func extractResourceSpecificInfo(obj *unstructured.Unstructured, summary *Resour
 		extractStatefulSetInfo(obj, summary)
 	case "daemonset":
 		extractDaemonSetInfo(obj, summary)
-	case "configmap":
+	case kindConfigMap:
 		extractConfigMapInfo(obj, summary)
 	case "secret":
 		extractSecretInfo(obj, summary)


### PR DESCRIPTION
Replaces the auto-generated [#395](https://github.com/giantswarm/mcp-kubernetes/pull/395) ("Align files") with the same alignment changes plus the lint mitigations needed to make pre-commit pass on the upgraded `golangci-lint v2.12.2`.

- Extracts repeated string literals to named constants across `cmd`, `internal/k8s`, `internal/federation`, `internal/instrumentation`, `internal/server`, and `internal/tools` so `goconst` passes.
- Adds a repo-local `.golangci.yml` that excludes `goconst` from `_test.go` files (same pattern already used in sibling repos like `klaus` and `mcp-capi`).
- Suppresses two `gosec` G101 false positives on Kubernetes secret-type identifiers (`kubernetes.io/service-account-token`, `kubernetes.io/tls`) and on the `oauth_token_reuse_detected_total` metric name via inline `nolint` directives.