### PR TITLE
ci: relax yamllint line-length to 120

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,6 @@
+---
+extends: default
+
+rules:
+  line-length:
+    max: 120


### PR DESCRIPTION
## Summary
- Adds `.yamllint.yaml` extending the default config with `line-length.max = 120`.
- Unblocks the `Lint and Test` CI job, which fails on `make check` because pinned action references (commit SHA + `# v…` comment) exceed the default 80-character limit in `.github/workflows/auto-release.yaml` and `.github/workflows/ci.yaml`.

## Why
The failure pre-exists Renovate PR #431 (e.g. main run [26557899193](https://github.com/giantswarm/mcp-kubernetes/actions/runs/26557899193)) and blocks every PR until landed. Wrapping pinned actions would harm readability for a single-token value, so the config knob is the right lever.

## Test plan
- [ ] `Lint and Test` GHA job passes on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)