### PR TITLE
ci: restore six-binary release matrix dropped by the auto-release migration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,20 +9,12 @@ workflows:
         name: go-build-mcp-kubernetes
         binary: mcp-kubernetes
         context: architect
-        # Six binaries shipped to the GitHub Release via upload-release-assets
-        # below. Matches the matrix the previous .goreleaser.yaml produced
-        # (deleted in #450); the migration to auto-release.yaml inadvertently
-        # dropped to the architect default (linux/amd64 only).
         # yamllint disable-line rule:line-length
         architectures: "linux/amd64,linux/arm64,darwin/amd64,darwin/arm64,windows/amd64,windows/arm64"
         filters:
           tags:
             only: /^v.*/
 
-    # Tag releases: attach the six per-platform binaries built above to the
-    # GitHub Release created by .github/workflows/auto-release.yaml. Restores
-    # the binary-distribution channel users of v0.1.120 and earlier got via
-    # the goreleaser flow. Branches: ignored — only fires on tag push.
     - architect/upload-release-assets:
         context: architect
         name: upload-release-assets

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,13 @@ workflows:
     - architect/push-to-registries:
         context: architect
         name: push-to-registries
+        # Cap docker buildx to the two linux platforms. Without this, the orb
+        # auto-derives --platform from go-build's .platforms file, which now
+        # contains all six binary targets (darwin/* and windows/* included).
+        # buildx then tries to produce darwin and windows manifests under
+        # QEMU emulation and hangs past the 10-minute no_output_timeout.
+        # Match the muster / mcp-prometheus / 10 other repos pattern.
+        platforms: "linux/amd64,linux/arm64"
         requires:
         - go-build-mcp-kubernetes
         filters:
@@ -55,6 +62,8 @@ workflows:
         context: architect
         name: push-to-registries-release
         split-china-push: true
+        # See note on the branch-build job above -- same reason.
+        platforms: "linux/amd64,linux/arm64"
         requires:
         - go-build-mcp-kubernetes
         filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,9 +9,31 @@ workflows:
         name: go-build-mcp-kubernetes
         binary: mcp-kubernetes
         context: architect
+        # Six binaries shipped to the GitHub Release via upload-release-assets
+        # below. Matches the matrix the previous .goreleaser.yaml produced
+        # (deleted in #450); the migration to auto-release.yaml inadvertently
+        # dropped to the architect default (linux/amd64 only).
+        # yamllint disable-line rule:line-length
+        architectures: "linux/amd64,linux/arm64,darwin/amd64,darwin/arm64,windows/amd64,windows/arm64"
         filters:
           tags:
             only: /^v.*/
+
+    # Tag releases: attach the six per-platform binaries built above to the
+    # GitHub Release created by .github/workflows/auto-release.yaml. Restores
+    # the binary-distribution channel users of v0.1.120 and earlier got via
+    # the goreleaser flow. Branches: ignored — only fires on tag push.
+    - architect/upload-release-assets:
+        context: architect
+        name: upload-release-assets
+        binary: mcp-kubernetes
+        requires:
+        - go-build-mcp-kubernetes
+        filters:
+          tags:
+            only: /^v.*/
+          branches:
+            ignore: /.*/
 
     # Branch builds: multi-arch image to gsoci for PR validation. v9's
     # push-to-registries always uses buildx and derives the platforms from


### PR DESCRIPTION
## Summary

Restores the six-platform binary distribution channel that the goreleaser → auto-release migration (#450) silently dropped.

## Background

Before #450, this repo released via goreleaser with the following matrix:

| OS | Arches |
|---|---|
| linux | amd64, arm64 |
| darwin | amd64, arm64 |
| windows | amd64, arm64 |

Every \`v*\` tag produced six binaries attached to the GitHub Release.

PR #450 migrated to the push-based \`auto-release.yaml\` flow (git-cliff for tag + release notes, architect orb for CircleCI publishing). That migration deleted the goreleaser config but the replacement \`architect/go-build\` job landed without an \`architectures:\` directive — so it fell back to the architect orb default, \`linux/amd64\` only. Consumers of v0.1.121, v0.1.122, v0.1.123 (and any later release) silently stopped receiving darwin and windows builds.

This was also caught by an audit comparing \`muster\`, \`mcp-prometheus\`, and \`mcp-kubernetes\` — the three repos that went goreleaser → git-cliff during this round of migrations. muster and mcp-prometheus carry the full six-arch matrix and an \`architect/upload-release-assets\` job. mcp-kubernetes was the outlier.

## What this PR does

Two changes inside the existing \`build\` workflow in \`.circleci/config.yml\`:

1. **Set \`architectures:\` on \`architect/go-build\`** to the same matrix the goreleaser config produced:

   \`\`\`yaml
   architectures: \"linux/amd64,linux/arm64,darwin/amd64,darwin/arm64,windows/amd64,windows/arm64\"
   \`\`\`

   A \`# yamllint disable-line rule:line-length\` annotation above keeps the existing yamllint config happy with the 132-char value.

2. **Add an \`architect/upload-release-assets\` job** filtered to \`/^v.*/\` tag pushes only (branches ignored):

   \`\`\`yaml
   - architect/upload-release-assets:
       context: architect
       name: upload-release-assets
       binary: mcp-kubernetes
       requires:
       - go-build-mcp-kubernetes
       filters:
         tags:
           only: /^v.*/
         branches:
           ignore: /.*/
   \`\`\`

   Without this second job, go-build would build the six binaries but they'd go nowhere. \`auto-release.yaml\` already creates the GitHub Release on tag push; this job attaches the binaries to it. Same shape muster uses.

## Test plan

- [ ] CI green on this PR (lint workflows only; the new architect jobs don't fire on non-tag branches).
- [ ] After merge: next \`feat:\`/\`fix:\` lands on \`main\` → auto-release tags \`v0.1.124\` → CircleCI fires on the tag → go-build produces six binaries → upload-release-assets attaches them to the GitHub Release for v0.1.124.
- [ ] Verify the Release page shows six \`mcp-kubernetes-<os>-<arch>\` assets, matching the v0.1.120 release page.