### PR TITLE
fix(m2m): close six security issues from PR #439 review

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -577,6 +577,8 @@ func runServe(config ServeConfig) error {
 		if !config.InCluster {
 			return fmt.Errorf("trusted issuers require in-cluster mode (--in-cluster)")
 		}
+		seenIssuers := make(map[string]struct{}, len(config.OAuth.TrustedIssuers))
+		seenAliases := make(map[string]struct{}, len(config.OAuth.TrustedIssuers))
 		for _, ti := range config.OAuth.TrustedIssuers {
 			if ti.Issuer == "" {
 				return fmt.Errorf("trusted issuer entry has empty issuer URL")
@@ -589,10 +591,19 @@ func runServe(config ServeConfig) error {
 					"(lowercase alphanumeric and hyphens, must start/end with alphanumeric, max 63 chars)",
 					ti.Issuer, ti.Alias)
 			}
-			if _, hasSub := ti.AllowedClaims["sub"]; !hasSub {
-				return fmt.Errorf("trusted issuer %q: allowedClaims.sub is required to prevent "+
-					"any service account from the issuer being impersonated", ti.Issuer)
+			subPattern, hasSub := ti.AllowedClaims["sub"]
+			if !hasSub || subPattern == "" || subPattern == "*" {
+				return fmt.Errorf("trusted issuer %q: allowedClaims.sub must be a non-empty pattern "+
+					"that is not bare '*' (prevents any service account from being impersonated)", ti.Issuer)
 			}
+			if _, seen := seenIssuers[ti.Issuer]; seen {
+				return fmt.Errorf("duplicate trusted issuer URL %q", ti.Issuer)
+			}
+			seenIssuers[ti.Issuer] = struct{}{}
+			if _, seen := seenAliases[ti.Alias]; seen {
+				return fmt.Errorf("trusted issuer %q: alias %q is already used by another issuer", ti.Issuer, ti.Alias)
+			}
+			seenAliases[ti.Alias] = struct{}{}
 		}
 		impersonationFactory, err := k8s.NewInClusterImpersonationFactory(k8sConfig)
 		if err != nil {

--- a/internal/k8s/impersonation.go
+++ b/internal/k8s/impersonation.go
@@ -19,6 +19,12 @@ type ImpersonationIdentity struct {
 	// AllowedTargetClusters from the matched TrustedIssuerConfig.
 	// Empty means any cluster is permitted.
 	AllowedTargetClusters []string
+
+	// Actor is the JWT sub of the intermediary making the request on behalf of
+	// UserName (RFC 8693 act claim). When non-empty it is injected into
+	// Impersonate-Extra-actor so the kube-apiserver audit log records both
+	// the target subject and the acting party.
+	Actor string
 }
 
 // ImpersonationClientFactory creates Kubernetes clients that authenticate as

--- a/internal/k8s/impersonation_client.go
+++ b/internal/k8s/impersonation_client.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"slices"
+	"sync"
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -31,6 +32,9 @@ type InClusterImpersonationFactory struct {
 	allowedOperations    []string
 	restrictedNamespaces []string
 	logger               Logger
+	// cache stores one Client per (UserName+Actor) key; M2M identities are
+	// config-bounded so unbounded growth is not a concern.
+	cache sync.Map
 }
 
 // NewInClusterImpersonationFactory builds the factory from in-cluster config.
@@ -84,6 +88,21 @@ func (f *InClusterImpersonationFactory) CreateImpersonationClient(identity Imper
 		return nil, fmt.Errorf("impersonation identity requires a non-empty UserName")
 	}
 
+	cacheKey := identity.UserName + "\x00" + identity.Actor
+	if cached, ok := f.cache.Load(cacheKey); ok {
+		return cached.(Client), nil
+	}
+
+	extra := identity.Extra
+	if identity.Actor != "" {
+		merged := make(map[string][]string, len(extra)+1)
+		for k, v := range extra {
+			merged[k] = v
+		}
+		merged["actor"] = []string{identity.Actor}
+		extra = merged
+	}
+
 	cfg := &rest.Config{
 		Host: f.clusterHost,
 		TLSClientConfig: rest.TLSClientConfig{
@@ -98,11 +117,11 @@ func (f *InClusterImpersonationFactory) CreateImpersonationClient(identity Imper
 		Impersonate: rest.ImpersonationConfig{
 			UserName: identity.UserName,
 			Groups:   identity.Groups,
-			Extra:    identity.Extra,
+			Extra:    extra,
 		},
 	}
 
-	return &impersonationClient{
+	client := &impersonationClient{
 		restConfig:           cfg,
 		namespace:            f.namespace,
 		nonDestructiveMode:   f.nonDestructiveMode,
@@ -110,7 +129,9 @@ func (f *InClusterImpersonationFactory) CreateImpersonationClient(identity Imper
 		allowedOperations:    f.allowedOperations,
 		restrictedNamespaces: f.restrictedNamespaces,
 		logger:               f.logger,
-	}, nil
+	}
+	actual, _ := f.cache.LoadOrStore(cacheKey, Client(client))
+	return actual.(Client), nil
 }
 
 // impersonationClient implements Client using the server's in-cluster SA with

--- a/internal/k8s/impersonation_client_test.go
+++ b/internal/k8s/impersonation_client_test.go
@@ -1,0 +1,68 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateImpersonationClient_ActorInjectedIntoExtra(t *testing.T) {
+	factory := &InClusterImpersonationFactory{
+		clusterHost: "https://k8s.example.com",
+		logger:      &testLogger{},
+	}
+
+	t.Run("Actor non-empty: injected as Extra[actor], original map not mutated", func(t *testing.T) {
+		original := map[string][]string{
+			"issuer": {"https://oidc.example.com"},
+			"agent":  {"mcp-kubernetes"},
+		}
+		identity := ImpersonationIdentity{
+			UserName: "human@example.com",
+			Extra:    original,
+			Actor:    "system:serviceaccount:agent-ns:agent-sa",
+		}
+
+		client, err := factory.CreateImpersonationClient(identity)
+		require.NoError(t, err)
+		require.NotNil(t, client)
+
+		ic, ok := client.(*impersonationClient)
+		require.True(t, ok)
+		cfg := ic.restConfig
+
+		require.Equal(t, "human@example.com", cfg.Impersonate.UserName)
+		require.Equal(t, []string{"system:serviceaccount:agent-ns:agent-sa"}, cfg.Impersonate.Extra["actor"])
+		require.Equal(t, []string{"https://oidc.example.com"}, cfg.Impersonate.Extra["issuer"])
+
+		// original map must not be mutated
+		require.Nil(t, original["actor"], "CreateImpersonationClient must not mutate the caller's Extra map")
+	})
+
+	t.Run("Actor empty: Extra[actor] absent, original map preserved", func(t *testing.T) {
+		original := map[string][]string{
+			"issuer": {"https://oidc.example.com"},
+			"agent":  {"mcp-kubernetes"},
+		}
+		identity := ImpersonationIdentity{
+			UserName: "system:serviceaccount:glean:bot",
+			Extra:    original,
+			// Actor is zero value
+		}
+
+		client, err := factory.CreateImpersonationClient(identity)
+		require.NoError(t, err)
+
+		ic, ok := client.(*impersonationClient)
+		require.True(t, ok)
+
+		require.Nil(t, ic.restConfig.Impersonate.Extra["actor"])
+		require.Equal(t, original, ic.restConfig.Impersonate.Extra)
+	})
+
+	t.Run("empty UserName returns error", func(t *testing.T) {
+		_, err := factory.CreateImpersonationClient(ImpersonationIdentity{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "non-empty UserName")
+	})
+}

--- a/internal/server/context.go
+++ b/internal/server/context.go
@@ -127,23 +127,24 @@ func (sc *ServerContext) K8sClientForContext(ctx context.Context) (k8s.Client, e
 
 	// External-issuer (M2M) path: the middleware resolved an ImpersonationIdentity.
 	// Use the in-cluster SA + impersonation instead of bearer-token passthrough.
-	if sc.impersonationFactory != nil {
-		if identity, ok := ImpersonationIdentityFromContext(ctx); ok {
-			client, err := sc.impersonationFactory.CreateImpersonationClient(identity)
-			if err != nil {
-				sc.logger.Warn("Failed to create impersonation client", "error", err)
-				if sc.instrumentationProvider != nil && sc.instrumentationProvider.Enabled() {
-					sc.instrumentationProvider.Metrics().RecordOAuthDownstreamAuth(ctx, instrumentation.OAuthResultDenied)
-				}
-				return nil, fmt.Errorf("%w: %v", ErrOAuthClientFailed, err)
-			}
-			sc.logger.Debug("Created impersonation client for M2M request",
-				"user", identity.UserName)
-			if sc.instrumentationProvider != nil && sc.instrumentationProvider.Enabled() {
-				sc.instrumentationProvider.Metrics().RecordOAuthDownstreamAuth(ctx, instrumentation.OAuthResultSuccess)
-			}
-			return client, nil
+	if identity, ok := ImpersonationIdentityFromContext(ctx); ok {
+		if sc.impersonationFactory == nil {
+			return nil, fmt.Errorf("impersonation identity present but no factory configured: check WithImpersonationFactory option")
 		}
+		client, err := sc.impersonationFactory.CreateImpersonationClient(identity)
+		if err != nil {
+			sc.logger.Warn("Failed to create impersonation client", "error", err)
+			if sc.instrumentationProvider != nil && sc.instrumentationProvider.Enabled() {
+				sc.instrumentationProvider.Metrics().RecordOAuthDownstreamAuth(ctx, instrumentation.OAuthResultDenied)
+			}
+			return nil, fmt.Errorf("%w: %v", ErrOAuthClientFailed, err)
+		}
+		sc.logger.Debug("Created impersonation client for M2M request",
+			"user", identity.UserName)
+		if sc.instrumentationProvider != nil && sc.instrumentationProvider.Enabled() {
+			sc.instrumentationProvider.Metrics().RecordOAuthDownstreamAuth(ctx, instrumentation.OAuthResultSuccess)
+		}
+		return client, nil
 	}
 
 	// Try to get the ID token from context

--- a/internal/server/oauth_http.go
+++ b/internal/server/oauth_http.go
@@ -305,7 +305,8 @@ func isDNS1123Label(s string) bool {
 // Only a trailing * wildcard is supported (prefix match).
 func matchesSubGlob(pattern, s string) bool {
 	if strings.HasSuffix(pattern, "*") {
-		return strings.HasPrefix(s, pattern[:len(pattern)-1])
+		prefix := pattern[:len(pattern)-1]
+		return prefix != "" && strings.HasPrefix(s, prefix)
 	}
 	return pattern == s
 }
@@ -490,12 +491,14 @@ func createOAuthServer(config OAuthConfig) (*oauth.Server, storage.TokenStore, e
 				return nil, nil, fmt.Errorf("failed to create encryptor for Valkey storage: %w", err)
 			}
 			valkeyOpts = append(valkeyOpts, valkey.WithEncryptor(encryptor))
-			logger.Info("Token encryption at rest enabled for Valkey storage (AES-256-GCM)")
 		}
 
 		valkeyStore, err := valkey.New(valkeyConfig, valkeyOpts...)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to create Valkey storage: %w", err)
+		}
+		if len(config.EncryptionKey) > 0 {
+			logger.Info("Token encryption at rest enabled for Valkey storage (AES-256-GCM)")
 		}
 
 		// Valkey store implements all required interfaces

--- a/internal/tools/federation.go
+++ b/internal/tools/federation.go
@@ -189,7 +189,13 @@ func GetClusterClient(ctx context.Context, sc *server.ServerContext, clusterName
 		}, ""
 	}
 
-	// No cluster specified - use local client
+	// No cluster specified - use local client (management cluster).
+	// M2M identities with AllowedTargetClusters restrictions cannot access the MC.
+	if identity, ok := server.ImpersonationIdentityFromContext(ctx); ok {
+		if len(identity.AllowedTargetClusters) > 0 {
+			return nil, "management cluster access is not permitted for this identity (restricted to specific workload clusters)"
+		}
+	}
 	k8sClient, err := sc.K8sClientForContext(ctx)
 	if err != nil {
 		// Authentication failed in strict mode


### PR DESCRIPTION
Fixes found during review of #439 (already merged). Clean rebase on current main.

## Changes

**`cmd/serve.go`** — startup validation
- Reject `allowedClaims.sub` values that are empty or bare `"*"` (previously only checked key presence; a bare wildcard lets any service account from the issuer be impersonated)
- Detect duplicate issuer URLs and duplicate aliases before server start (duplicates cause name collisions in Helm RBAC resources)

**`internal/server/oauth_http.go`**
- `matchesSubGlob`: add `prefix != ""` guard so a `"*"` pattern never matches (empty-prefix `HasPrefix` returns true for any string)
- Move Valkey encryption-at-rest log to after `valkey.New()` succeeds; previously fired before the store was created, producing a false positive on creation failure

**`internal/server/context.go`** — `K8sClientForContext`
- Check for `ImpersonationIdentity` in context before the factory nil-check; when identity is present but factory is nil, return an explicit error instead of silently falling through to the bearer-token path with a confusing `ErrOAuthTokenMissing`

**`internal/tools/federation.go`** — `GetClusterClient`
- Enforce `AllowedTargetClusters` on the management-cluster path (`clusterName == ""`), not only the workload-cluster path; an M2M identity restricted to specific WCs could otherwise still reach the MC

**`internal/k8s/impersonation.go` + `impersonation_client.go`**
- Add `Actor` field to `ImpersonationIdentity`; inject into `Impersonate-Extra-actor` without mutating the caller's map (copy-on-write)
- Add `sync.Map` cache to `InClusterImpersonationFactory` keyed on `UserName+Actor`; avoids reallocating `rest.Config` and transport on every request