### PR TITLE
feat(obo): OBO Phase 2 — human-via-agent impersonation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+* OBO (Phase 2): external-issuer tokens carrying an RFC 8693 `act` claim now take the OBO impersonation branch. `Impersonate-User` is set to the human subject; `Impersonate-Extra-actor` is set to the agent SA sub, so the kube-apiserver audit log records both parties. Tokens without an `act` claim continue to use the existing M2M path unchanged.
+* `trustedIssuers[].allowedSubjects` and `trustedIssuers[].allowedActors` Helm values gate the `impersonate users` and `userextras/actor` ClusterRole rules. Both default to empty (no grant); populate narrowly to keep the `impersonate users` blast radius bounded.
+
 ## [0.1.113](https://github.com/giantswarm/mcp-kubernetes/compare/v0.1.112...v0.1.113) (2026-06-03)
 
 

--- a/helm/mcp-kubernetes/templates/rbac.yaml
+++ b/helm/mcp-kubernetes/templates/rbac.yaml
@@ -596,6 +596,26 @@ rules:
     resources: ["userextras/issuer"]
     verbs: ["impersonate"]
     resourceNames: [{{ .issuer | quote }}]
+{{- /*
+OBO (Phase 2) rules: only emitted when allowedSubjects is non-empty.
+impersonate users is a crown-jewel verb — never grant it unrestricted.
+Populate allowedSubjects narrowly; prefer out-of-band shared-configs
+bindings for human populations that change frequently.
+*/}}
+{{- if .allowedSubjects }}
+  - apiGroups: [""]
+    resources: ["users"]
+    verbs: ["impersonate"]
+    resourceNames:
+      {{- toYaml .allowedSubjects | nindent 6 }}
+{{- end }}
+{{- if .allowedActors }}
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["userextras/actor"]
+    verbs: ["impersonate"]
+    resourceNames:
+      {{- toYaml .allowedActors | nindent 6 }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/helm/mcp-kubernetes/values.schema.json
+++ b/helm/mcp-kubernetes/values.schema.json
@@ -598,6 +598,22 @@
                     "type": "boolean",
                     "description": "Allow the JWKS endpoint to resolve to a private/loopback IP. Required when the issuer runs on an internal network.",
                     "default": false
+                  },
+                  "allowedSubjects": {
+                    "type": "array",
+                    "description": "OBO (Phase 2): human subject values permitted for `impersonate users`. SECURITY: `impersonate users` is a crown-jewel verb — populate narrowly. Empty (default) emits no `impersonate users` grant at all. For large or frequently-changing human populations, use out-of-band RoleBindings via shared-configs instead.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "default": []
+                  },
+                  "allowedActors": {
+                    "type": "array",
+                    "description": "OBO (Phase 2): agent SA sub values permitted as the OBO actor (act.sub claim). Scoped via resourceNames on userextras/actor. Empty (default) emits no userextras/actor grant.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "default": []
                   }
                 }
               },

--- a/helm/mcp-kubernetes/values.yaml
+++ b/helm/mcp-kubernetes/values.yaml
@@ -524,17 +524,35 @@ mcpKubernetes:
     #   acceptedTypHeaders:     accepted `typ` header values (empty = any)
     #   allowPrivateIPJWKS:     true when the JWKS endpoint is on a private network
     #
+    # OBO (on-behalf-of) fields — only needed when agents carry a delegated human token
+    # (RFC 8693 act claim). Leave empty for pure M2M (autonomous agent) deployments.
+    #
+    #   allowedSubjects:  human subject values permitted for `impersonate users`.
+    #                     SECURITY: `impersonate users` is a crown-jewel verb. This list
+    #                     must stay narrow. Empty (default) = no `impersonate users` grant
+    #                     emitted at all. For large/dynamic human populations prefer
+    #                     out-of-band RoleBindings via shared-configs instead.
+    #   allowedActors:    agent SA sub values permitted as the OBO actor (act.sub claim).
+    #                     Scoped via resourceNames on userextras/actor. Empty = no grant.
+    #
     # Each alias generates: a <alias> namespace, a namespaced Role granting
     # `impersonate serviceaccounts` in that namespace, and a ClusterRole granting
     # `impersonate groups/extras` scoped to the alias. Per-alias RBAC is only
     # generated when serviceAccount.create and rbac.create are both true.
     #
-    # Example:
+    # Example (M2M only):
     #   - issuer: "https://oidc.example.com/glean"
     #     jwksURL: "https://oidc.example.com/glean/.well-known/jwks.json"
     #     alias: "glean"
     #     allowedAudiences: ["https://mcp.example.com"]
     #     allowedTargetClusters: ["cluster-a", "cluster-b"]
+    #
+    # Example (M2M + OBO):
+    #   - issuer: "https://oidc.example.com/glean"
+    #     jwksURL: "https://oidc.example.com/glean/.well-known/jwks.json"
+    #     alias: "glean"
+    #     allowedSubjects: ["alice@example.com", "bob@example.com"]
+    #     allowedActors: ["system:serviceaccount:kagent:my-agent"]
     #
     # Default: [] (no external issuers trusted)
     trustedIssuers: []

--- a/internal/server/oauth_http.go
+++ b/internal/server/oauth_http.go
@@ -1011,6 +1011,29 @@ func (s *OAuthHTTPServer) createAccessTokenInjectorMiddleware(next http.Handler)
 				return
 			}
 
+			// OBO path (Phase 2): sub=human, act.sub=agent SA.
+			// Impersonate the human subject; record the agent SA as the actor so the
+			// kube-apiserver audit log shows "human X via agent Z".
+			if userInfo.IsDelegated() {
+				identity := k8s.ImpersonationIdentity{
+					UserName: userInfo.ID,
+					// No groups: user-only impersonation. kube-apiserver auto-adds
+					// system:authenticated. Human access is governed by RoleBindings
+					// to the user subject on each target cluster.
+					Extra: map[string][]string{
+						"issuer": {userInfo.Issuer},
+						"agent":  {"mcp-kubernetes"},
+					},
+					Actor:                 userInfo.ActorSubject,
+					AllowedTargetClusters: tiConfig.AllowedTargetClusters,
+				}
+				ctx = ContextWithImpersonationIdentity(ctx, identity)
+				r = r.WithContext(ctx)
+				recordMetric(ctx, "obo_success")
+				next.ServeHTTP(w, r)
+				return
+			}
+
 			// M2M path (Phase 1B): sub=agent SA, no act claim.
 			// K8s SA token sub: "system:serviceaccount:<ns>:<name>" → extract <name>.
 			saName := userInfo.ID

--- a/internal/server/oauth_http_test.go
+++ b/internal/server/oauth_http_test.go
@@ -900,3 +900,102 @@ func TestAccessTokenInjectorMiddleware_M2MToken(t *testing.T) {
 		require.Equal(t, http.StatusInternalServerError, rr.Code)
 	})
 }
+
+func TestAccessTokenInjectorMiddleware_OBOToken(t *testing.T) {
+	const (
+		testIssuer    = "https://oidc.example.com"
+		testAlias     = "glean"
+		humanSubject  = "quentin@example.com"
+		agentSASub    = "system:serviceaccount:kagent:my-agent"
+		agentSAIssuer = "https://k8s.example.com"
+	)
+	issuerMap := map[string]TrustedIssuerConfig{
+		testIssuer: {
+			Issuer:                testIssuer,
+			JwksURL:               "https://oidc.example.com/.well-known/jwks.json",
+			Alias:                 testAlias,
+			AllowedTargetClusters: []string{"cluster-a"},
+			// matchesSubGlob supports prefix* patterns only; use exact match for human subjects.
+			AllowedClaims: map[string]string{"sub": humanSubject},
+		},
+	}
+
+	newOBOReq := func(humanSub, actorSub string) *http.Request {
+		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		req.Header.Set("Authorization", "Bearer fake-obo-token") //nolint:gosec // G101: test fixture
+		userInfo := &providers.UserInfo{
+			ID:            humanSub,
+			Issuer:        testIssuer,
+			TokenSource:   providers.TokenSourceTrustedIssuer,
+			ActorSubject:  actorSub,
+			ActorIssuer:   agentSAIssuer,
+		}
+		return req.WithContext(handler.ContextWithUserInfo(req.Context(), userInfo))
+	}
+
+	t.Run("OBO token: human sub becomes UserName, agent becomes Actor, no Groups", func(t *testing.T) {
+		var capturedCtx context.Context
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedCtx = r.Context()
+			w.WriteHeader(http.StatusOK)
+		})
+		s := &OAuthHTTPServer{trustedIssuersByIssuer: issuerMap}
+
+		rr := httptest.NewRecorder()
+		s.createAccessTokenInjectorMiddleware(next).ServeHTTP(rr, newOBOReq(humanSubject, agentSASub))
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		identity, ok := ImpersonationIdentityFromContext(capturedCtx)
+		require.True(t, ok)
+		require.Equal(t, humanSubject, identity.UserName)
+		require.Empty(t, identity.Groups, "OBO impersonates user-only; no groups must be set")
+		require.Equal(t, agentSASub, identity.Actor)
+		require.Equal(t, []string{testIssuer}, identity.Extra["issuer"])
+		require.Equal(t, []string{"mcp-kubernetes"}, identity.Extra["agent"])
+		require.Equal(t, []string{"cluster-a"}, identity.AllowedTargetClusters)
+	})
+
+	t.Run("M2M token (no act) still takes M2M path unchanged", func(t *testing.T) {
+		var capturedCtx context.Context
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedCtx = r.Context()
+			w.WriteHeader(http.StatusOK)
+		})
+		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		req.Header.Set("Authorization", "Bearer fake-m2m-token") //nolint:gosec // G101: test fixture
+		userInfo := &providers.UserInfo{
+			ID:          "system:serviceaccount:kagent:bot",
+			Issuer:      testIssuer,
+			TokenSource: providers.TokenSourceTrustedIssuer,
+			// ActorSubject intentionally absent
+		}
+		req = req.WithContext(handler.ContextWithUserInfo(req.Context(), userInfo))
+
+		m2mMap := map[string]TrustedIssuerConfig{
+			testIssuer: {
+				Issuer:        testIssuer,
+				JwksURL:       "https://oidc.example.com/.well-known/jwks.json",
+				Alias:         testAlias,
+				AllowedClaims: map[string]string{"sub": "system:serviceaccount:kagent:*"},
+			},
+		}
+		s := &OAuthHTTPServer{trustedIssuersByIssuer: m2mMap}
+		rr := httptest.NewRecorder()
+		s.createAccessTokenInjectorMiddleware(next).ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		identity, ok := ImpersonationIdentityFromContext(capturedCtx)
+		require.True(t, ok)
+		require.Equal(t, "system:serviceaccount:glean:bot", identity.UserName)
+		require.Empty(t, identity.Actor, "M2M path must not set Actor")
+	})
+
+	t.Run("OBO human sub not matching allowedClaims.sub returns 403", func(t *testing.T) {
+		s := &OAuthHTTPServer{trustedIssuersByIssuer: issuerMap}
+		rr := httptest.NewRecorder()
+		s.createAccessTokenInjectorMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})).ServeHTTP(rr, newOBOReq("attacker@evil.com", agentSASub))
+		require.Equal(t, http.StatusForbidden, rr.Code)
+	})
+}

--- a/internal/server/oauth_http_test.go
+++ b/internal/server/oauth_http_test.go
@@ -924,11 +924,11 @@ func TestAccessTokenInjectorMiddleware_OBOToken(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
 		req.Header.Set("Authorization", "Bearer fake-obo-token") //nolint:gosec // G101: test fixture
 		userInfo := &providers.UserInfo{
-			ID:            humanSub,
-			Issuer:        testIssuer,
-			TokenSource:   providers.TokenSourceTrustedIssuer,
-			ActorSubject:  actorSub,
-			ActorIssuer:   agentSAIssuer,
+			ID:           humanSub,
+			Issuer:       testIssuer,
+			TokenSource:  providers.TokenSourceTrustedIssuer,
+			ActorSubject: actorSub,
+			ActorIssuer:  agentSAIssuer,
 		}
 		return req.WithContext(handler.ContextWithUserInfo(req.Context(), userInfo))
 	}


### PR DESCRIPTION
## What

Implements the OBO (on-behalf-of) branch in the access-token injector middleware, closing #477.

External-issuer tokens carrying an RFC 8693 `act` claim (minted by muster when a human delegates to an agent) now take a distinct impersonation path:

- `Impersonate-User` → human subject (`userInfo.ID`)
- `Impersonate-Extra-actor` → agent SA sub (`userInfo.ActorSubject`)
- No groups — user-only impersonation; kube-apiserver adds `system:authenticated`

Tokens without an `act` claim continue through the existing M2M path unchanged. The `IsDelegated()` check from mcp-oauth v0.7.1 is the branch selector.

## RBAC

`impersonate users` is a crown-jewel verb. Two new Helm values gate it:

- `trustedIssuers[].allowedSubjects` — human subjects permitted for `impersonate users`; scoped via `resourceNames`. **Defaults to `[]` → no grant emitted.**
- `trustedIssuers[].allowedActors` — agent SA subs permitted as the OBO actor; scoped via `resourceNames` on `userextras/actor`. **Defaults to `[]` → no grant emitted.**

Both must be populated for the OBO path to reach the kube-apiserver. For large or frequently-changing human populations, prefer out-of-band RoleBindings via shared-configs.

## What's not in this PR

Live end-to-end testing is deferred pending muster#851 (the token producer that mints OBO JWTs with the `act` claim). Unit tests drive the full branch via fabricated `providers.UserInfo` with `ActorSubject` set.

## Audit trail

Before (M2M): `impersonatedUser: system:serviceaccount:glean:my-agent`
After (OBO): `impersonatedUser: alice@example.com` + `Impersonate-Extra-actor: system:serviceaccount:kagent:my-agent`