### PR TITLE
feat(obo): per-actor subject scoping + unrestricted users grant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * OBO (Phase 2): external-issuer tokens carrying an RFC 8693 `act` claim now take the OBO impersonation branch. `Impersonate-User` is set to the human subject; `Impersonate-Extra-actor` is set to the agent SA sub, so the kube-apiserver audit log records both parties. Tokens without an `act` claim continue to use the existing M2M path unchanged.
-* `trustedIssuers[].allowedSubjects` and `trustedIssuers[].allowedActors` Helm values gate the `impersonate users` and `userextras/actor` ClusterRole rules. Both default to empty (no grant); populate narrowly to keep the `impersonate users` blast radius bounded.
+* `trustedIssuers[].allowedActors` is now a list of objects: each entry specifies an agent SA `sub` and an optional `allowedSubjects` list of human subject patterns. Per-actor subject enforcement runs in-process before any impersonation call reaches the kube-apiserver. Subject patterns support a single leading (`*@domain.com`) or trailing (`system:serviceaccount:ns:*`) wildcard. An empty `allowedSubjects` list permits any subject that passes `allowedClaims.sub`.
+* The `impersonate users` ClusterRole rule is now emitted unrestricted (no `resourceNames`) whenever `allowedActors` is non-empty. K8s RBAC cannot couple `impersonate-users` to `impersonate-userextras/actor` (independent verbs) or express wildcard subjects in `resourceNames`; the RBAC grant is the outer bound and the inner enforcement is in code.
+* `matchesSubGlob` now supports a single leading `*` as a suffix match (e.g. `*@giantswarm.io`) in addition to the existing trailing `*` prefix match.
+
+### Removed
+
+* `trustedIssuers[].allowedSubjects` Helm value removed. Subject restrictions now live per-actor in `allowedActors[].allowedSubjects`.
+
+### Changed
+
+* `trustedIssuers[].allowedActors` is now a list of objects (`{sub, allowedSubjects}`) instead of a flat list of strings. This is a breaking values change. OBO is disabled for an issuer when `allowedActors` is empty or omitted.
 
 ## [0.1.113](https://github.com/giantswarm/mcp-kubernetes/compare/v0.1.112...v0.1.113) (2026-06-03)
 

--- a/helm/mcp-kubernetes/templates/rbac.yaml
+++ b/helm/mcp-kubernetes/templates/rbac.yaml
@@ -596,6 +596,11 @@ rules:
     resources: ["userextras/issuer"]
     verbs: ["impersonate"]
     resourceNames: [{{ .issuer | quote }}]
+{{- /*
+impersonate users is granted unrestricted because K8s RBAC cannot couple it to
+impersonate-userextras/actor (independent verbs) and resourceNames has no wildcard
+support for glob subjects. Per-actor subject scoping is enforced in-process.
+*/}}
 {{- if .allowedActors }}
   - apiGroups: ["authentication.k8s.io"]
     resources: ["userextras/actor"]

--- a/helm/mcp-kubernetes/templates/rbac.yaml
+++ b/helm/mcp-kubernetes/templates/rbac.yaml
@@ -597,24 +597,27 @@ rules:
     verbs: ["impersonate"]
     resourceNames: [{{ .issuer | quote }}]
 {{- /*
-OBO (Phase 2) rules: only emitted when allowedSubjects is non-empty.
-impersonate users is a crown-jewel verb — never grant it unrestricted.
-Populate allowedSubjects narrowly; prefer out-of-band shared-configs
-bindings for human populations that change frequently.
+OBO (Phase 2) rules: emitted when allowedActors is non-empty.
+impersonate users is granted unrestricted here because:
+  1. K8s RBAC cannot couple impersonate-users to impersonate-userextras/actor
+     (they are independent verbs checked independently).
+  2. Glob subject patterns (e.g. "*@example.com") cannot be expressed in
+     resourceNames (no wildcards supported).
+mcp-kubernetes enforces per-actor subject scoping in-process in the OBO branch
+of the access-token injector middleware. The RBAC grant is the outer bound;
+the inner enforcement is in code.
 */}}
-{{- if .allowedSubjects }}
-  - apiGroups: [""]
-    resources: ["users"]
-    verbs: ["impersonate"]
-    resourceNames:
-      {{- toYaml .allowedSubjects | nindent 6 }}
-{{- end }}
 {{- if .allowedActors }}
   - apiGroups: ["authentication.k8s.io"]
     resources: ["userextras/actor"]
     verbs: ["impersonate"]
     resourceNames:
-      {{- toYaml .allowedActors | nindent 6 }}
+      {{- range .allowedActors }}
+      - {{ .sub | quote }}
+      {{- end }}
+  - apiGroups: [""]
+    resources: ["users"]
+    verbs: ["impersonate"]
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/mcp-kubernetes/templates/rbac.yaml
+++ b/helm/mcp-kubernetes/templates/rbac.yaml
@@ -596,17 +596,6 @@ rules:
     resources: ["userextras/issuer"]
     verbs: ["impersonate"]
     resourceNames: [{{ .issuer | quote }}]
-{{- /*
-OBO (Phase 2) rules: emitted when allowedActors is non-empty.
-impersonate users is granted unrestricted here because:
-  1. K8s RBAC cannot couple impersonate-users to impersonate-userextras/actor
-     (they are independent verbs checked independently).
-  2. Glob subject patterns (e.g. "*@example.com") cannot be expressed in
-     resourceNames (no wildcards supported).
-mcp-kubernetes enforces per-actor subject scoping in-process in the OBO branch
-of the access-token injector middleware. The RBAC grant is the outer bound;
-the inner enforcement is in code.
-*/}}
 {{- if .allowedActors }}
   - apiGroups: ["authentication.k8s.io"]
     resources: ["userextras/actor"]

--- a/helm/mcp-kubernetes/tests/rbac_test.yaml
+++ b/helm/mcp-kubernetes/tests/rbac_test.yaml
@@ -800,3 +800,113 @@ tests:
           path: metadata.annotations["mcp-kubernetes.giantswarm.io/wc-auth-mode"]
           value: "impersonation"
         documentIndex: 4
+
+  # ==========================================
+  # OBO / per-actor trustedIssuers RBAC Tests
+  # ==========================================
+
+  - it: should create M2M ClusterRole and Namespace when trustedIssuers is set with alias
+    set:
+      serviceAccount.create: true
+      rbac.create: true
+      mcpKubernetes.oauth.enabled: true
+      mcpKubernetes.oauth.trustedIssuers:
+        - issuer: "https://oidc.example.com"
+          jwksURL: "https://oidc.example.com/jwks"
+          alias: "test-alias"
+    asserts:
+      # base ClusterRole + ClusterRoleBinding + Namespace + Role + RoleBinding + M2M ClusterRole + ClusterRoleBinding
+      - hasDocuments:
+          count: 7
+      - isKind:
+          of: Namespace
+        documentIndex: 2
+      - equal:
+          path: metadata.name
+          value: test-alias
+        documentIndex: 2
+      - isKind:
+          of: ClusterRole
+        documentIndex: 5
+      - equal:
+          path: metadata.annotations["mcp-kubernetes.giantswarm.io/m2m-alias"]
+          value: "test-alias"
+        documentIndex: 5
+      # No users impersonate rule without allowedActors
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["users"]
+            verbs: ["impersonate"]
+        documentIndex: 5
+      # No userextras/actor rule without allowedActors
+      - notContains:
+          path: rules
+          content:
+            apiGroups: ["authentication.k8s.io"]
+            resources: ["userextras/actor"]
+            verbs: ["impersonate"]
+        documentIndex: 5
+
+  - it: should emit userextras/actor and unrestricted users rules when allowedActors is set
+    set:
+      serviceAccount.create: true
+      rbac.create: true
+      mcpKubernetes.oauth.enabled: true
+      mcpKubernetes.oauth.trustedIssuers:
+        - issuer: "https://oidc.example.com"
+          jwksURL: "https://oidc.example.com/jwks"
+          alias: "test-alias"
+          allowedActors:
+            - sub: "system:serviceaccount:kagent:my-agent"
+              allowedSubjects:
+                - "*@example.com"
+    asserts:
+      - isKind:
+          of: ClusterRole
+        documentIndex: 5
+      # userextras/actor scoped to the actor sub
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["authentication.k8s.io"]
+            resources: ["userextras/actor"]
+            verbs: ["impersonate"]
+            resourceNames: ["system:serviceaccount:kagent:my-agent"]
+        documentIndex: 5
+      # users impersonate emitted unrestricted (per-actor subject enforcement is in-process)
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["users"]
+            verbs: ["impersonate"]
+        documentIndex: 5
+
+  - it: should include all actor subs in resourceNames when multiple allowedActors set
+    set:
+      serviceAccount.create: true
+      rbac.create: true
+      mcpKubernetes.oauth.enabled: true
+      mcpKubernetes.oauth.trustedIssuers:
+        - issuer: "https://oidc.example.com"
+          jwksURL: "https://oidc.example.com/jwks"
+          alias: "test-alias"
+          allowedActors:
+            - sub: "system:serviceaccount:kagent:agent-one"
+            - sub: "system:serviceaccount:kagent:agent-two"
+    asserts:
+      - isKind:
+          of: ClusterRole
+        documentIndex: 5
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["authentication.k8s.io"]
+            resources: ["userextras/actor"]
+            verbs: ["impersonate"]
+            resourceNames:
+              - "system:serviceaccount:kagent:agent-one"
+              - "system:serviceaccount:kagent:agent-two"
+        documentIndex: 5

--- a/helm/mcp-kubernetes/values.schema.json
+++ b/helm/mcp-kubernetes/values.schema.json
@@ -599,19 +599,27 @@
                     "description": "Allow the JWKS endpoint to resolve to a private/loopback IP. Required when the issuer runs on an internal network.",
                     "default": false
                   },
-                  "allowedSubjects": {
-                    "type": "array",
-                    "description": "OBO (Phase 2): human subject values permitted for `impersonate users`. SECURITY: `impersonate users` is a crown-jewel verb — populate narrowly. Empty (default) emits no `impersonate users` grant at all. For large or frequently-changing human populations, use out-of-band RoleBindings via shared-configs instead.",
-                    "items": {
-                      "type": "string"
-                    },
-                    "default": []
-                  },
                   "allowedActors": {
                     "type": "array",
-                    "description": "OBO (Phase 2): agent SA sub values permitted as the OBO actor (act.sub claim). Scoped via resourceNames on userextras/actor. Empty (default) emits no userextras/actor grant.",
+                    "description": "OBO (Phase 2): list of actor entries. Each entry names an agent SA (act.sub) and optionally restricts the human subjects it may impersonate. Empty (default) disables OBO for this issuer. The chart emits an unrestricted `impersonate users` grant when this list is non-empty; per-actor subject scoping is enforced in-process by mcp-kubernetes.",
                     "items": {
-                      "type": "string"
+                      "type": "object",
+                      "additionalProperties": false,
+                      "required": ["sub"],
+                      "properties": {
+                        "sub": {
+                          "type": "string",
+                          "description": "Agent SA JWT subject (act.sub claim), e.g. 'system:serviceaccount:kagent:my-agent'."
+                        },
+                        "allowedSubjects": {
+                          "type": "array",
+                          "description": "Human subject patterns this actor may impersonate. Supports a single leading (*@domain.com) or trailing (system:serviceaccount:ns:*) wildcard. Empty means any subject is allowed, bounded by allowedClaims.sub.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "default": []
+                        }
+                      }
                     },
                     "default": []
                   }

--- a/helm/mcp-kubernetes/values.yaml
+++ b/helm/mcp-kubernetes/values.yaml
@@ -527,13 +527,21 @@ mcpKubernetes:
     # OBO (on-behalf-of) fields — only needed when agents carry a delegated human token
     # (RFC 8693 act claim). Leave empty for pure M2M (autonomous agent) deployments.
     #
-    #   allowedSubjects:  human subject values permitted for `impersonate users`.
-    #                     SECURITY: `impersonate users` is a crown-jewel verb. This list
-    #                     must stay narrow. Empty (default) = no `impersonate users` grant
-    #                     emitted at all. For large/dynamic human populations prefer
-    #                     out-of-band RoleBindings via shared-configs instead.
-    #   allowedActors:    agent SA sub values permitted as the OBO actor (act.sub claim).
-    #                     Scoped via resourceNames on userextras/actor. Empty = no grant.
+    #   allowedActors:  list of OBO actor entries. Each entry specifies an agent SA
+    #                   (act.sub claim) and the human subjects it may impersonate.
+    #
+    #     sub:              required. Agent SA sub, e.g. "system:serviceaccount:kagent:my-agent".
+    #     allowedSubjects:  optional. Human subject patterns the actor may impersonate.
+    #                       Supports a single leading (*@domain.com) or trailing
+    #                       (system:serviceaccount:ns:*) wildcard. Empty means any
+    #                       subject is allowed, still bounded by allowedClaims.sub.
+    #
+    #                   SECURITY: the chart emits an unrestricted `impersonate users`
+    #                   ClusterRole rule when allowedActors is set. K8s RBAC cannot
+    #                   couple impersonate-users to impersonate-actor (independent verbs)
+    #                   or express wildcard subjects in resourceNames. Per-actor subject
+    #                   scoping is enforced in-process by mcp-kubernetes before any
+    #                   impersonation call reaches the kube-apiserver.
     #
     # Each alias generates: a <alias> namespace, a namespaced Role granting
     # `impersonate serviceaccounts` in that namespace, and a ClusterRole granting
@@ -547,12 +555,19 @@ mcpKubernetes:
     #     allowedAudiences: ["https://mcp.example.com"]
     #     allowedTargetClusters: ["cluster-a", "cluster-b"]
     #
-    # Example (M2M + OBO):
+    # Example (M2M + OBO, glob subjects):
     #   - issuer: "https://oidc.example.com/glean"
     #     jwksURL: "https://oidc.example.com/glean/.well-known/jwks.json"
     #     alias: "glean"
-    #     allowedSubjects: ["alice@example.com", "bob@example.com"]
-    #     allowedActors: ["system:serviceaccount:kagent:my-agent"]
+    #     allowedClaims:
+    #       sub: "system:serviceaccount:kagent:*"
+    #     allowedActors:
+    #       - sub: "system:serviceaccount:kagent:my-agent"
+    #         allowedSubjects:
+    #           - "*@example.com"
+    #       - sub: "system:serviceaccount:kagent:headless-agent"
+    #         # empty allowedSubjects: this actor may impersonate any human
+    #         # whose sub matches allowedClaims.sub
     #
     # Default: [] (no external issuers trusted)
     trustedIssuers: []

--- a/internal/server/oauth_http.go
+++ b/internal/server/oauth_http.go
@@ -302,13 +302,34 @@ func isDNS1123Label(s string) bool {
 }
 
 // matchesSubGlob reports whether s matches a sub-claim pattern.
-// Only a trailing * wildcard is supported (prefix match).
+// matchesSubGlob matches s against pattern using a single leading or trailing
+// wildcard (*). A leading * anchors to a suffix ("*@example.com" matches any
+// string ending in "@example.com"). A trailing * anchors to a prefix
+// ("system:serviceaccount:kagent:*" matches any SA in that namespace).
+// An exact pattern (no *) requires an exact string equality.
 func matchesSubGlob(pattern, s string) bool {
 	if strings.HasSuffix(pattern, "*") {
 		prefix := pattern[:len(pattern)-1]
 		return prefix != "" && strings.HasPrefix(s, prefix)
 	}
+	if strings.HasPrefix(pattern, "*") {
+		suffix := pattern[1:]
+		return suffix != "" && strings.HasSuffix(s, suffix)
+	}
 	return pattern == s
+}
+
+// ActorConfig defines an OBO actor (RFC 8693 act.sub) and the human subjects it
+// is permitted to act on behalf of.
+type ActorConfig struct {
+	// Sub is the actor's JWT subject (act.sub claim), typically a K8s SA sub:
+	// "system:serviceaccount:<ns>:<name>".
+	Sub string `json:"sub"`
+	// AllowedSubjects is the set of human subject values (userInfo.ID) that this
+	// actor may impersonate. Trailing-star glob patterns are supported
+	// (e.g. "*@example.com"). Empty means any subject is allowed, still bounded
+	// by TrustedIssuerConfig.AllowedClaims["sub"] and the RBAC outer grant.
+	AllowedSubjects []string `json:"allowedSubjects,omitempty"`
 }
 
 // TrustedIssuerConfig holds the configuration for a single trusted external JWT issuer.
@@ -335,6 +356,10 @@ type TrustedIssuerConfig struct {
 	AcceptedTypHeaders []string `json:"acceptedTypHeaders,omitempty"`
 	// AllowPrivateIPJWKS permits JWKS endpoints on private/loopback addresses.
 	AllowPrivateIPJWKS bool `json:"allowPrivateIPJWKS,omitempty"`
+	// AllowedActors lists the OBO actors permitted for this issuer and, per actor,
+	// the human subjects they may impersonate. Empty means OBO is disabled for
+	// this issuer (any request with an act claim is rejected).
+	AllowedActors []ActorConfig `json:"allowedActors,omitempty"`
 }
 
 // RedirectURISecurityConfig holds configuration for redirect URI security validation.
@@ -1015,6 +1040,41 @@ func (s *OAuthHTTPServer) createAccessTokenInjectorMiddleware(next http.Handler)
 			// Impersonate the human subject; record the agent SA as the actor so the
 			// kube-apiserver audit log shows "human X via agent Z".
 			if userInfo.IsDelegated() {
+				// Enforce actor allow-list and per-actor subject scoping in-process.
+				// K8s RBAC cannot couple impersonate-users to impersonate-userextras/actor
+				// (independent verbs) and does not support wildcards in resourceNames,
+				// so both checks must live here.
+				actorSub := userInfo.ActorSubject
+				var matchedActor *ActorConfig
+				for i := range tiConfig.AllowedActors {
+					if tiConfig.AllowedActors[i].Sub == actorSub {
+						matchedActor = &tiConfig.AllowedActors[i]
+						break
+					}
+				}
+				if matchedActor == nil {
+					slog.Warn("AccessTokenInjector: OBO actor not in allowedActors, rejecting",
+						"issuer", userInfo.Issuer, "actor", actorSub)
+					http.Error(w, "forbidden: actor not permitted for this issuer", http.StatusForbidden)
+					return
+				}
+				if len(matchedActor.AllowedSubjects) > 0 {
+					humanSub := userInfo.ID
+					subAllowed := false
+					for _, pattern := range matchedActor.AllowedSubjects {
+						if matchesSubGlob(pattern, humanSub) {
+							subAllowed = true
+							break
+						}
+					}
+					if !subAllowed {
+						slog.Warn("AccessTokenInjector: OBO human subject not in actor's allowedSubjects, rejecting",
+							"issuer", userInfo.Issuer, "actor", actorSub, "subject", humanSub)
+						http.Error(w, "forbidden: subject not permitted for this actor", http.StatusForbidden)
+						return
+					}
+				}
+
 				identity := k8s.ImpersonationIdentity{
 					UserName: userInfo.ID,
 					// No groups: user-only impersonation. kube-apiserver auto-adds
@@ -1024,7 +1084,7 @@ func (s *OAuthHTTPServer) createAccessTokenInjectorMiddleware(next http.Handler)
 						"issuer": {userInfo.Issuer},
 						"agent":  {"mcp-kubernetes"},
 					},
-					Actor:                 userInfo.ActorSubject,
+					Actor:                 actorSub,
 					AllowedTargetClusters: tiConfig.AllowedTargetClusters,
 				}
 				ctx = ContextWithImpersonationIdentity(ctx, identity)

--- a/internal/server/oauth_http_test.go
+++ b/internal/server/oauth_http_test.go
@@ -909,14 +909,19 @@ func TestAccessTokenInjectorMiddleware_OBOToken(t *testing.T) {
 		agentSASub    = "system:serviceaccount:kagent:my-agent"
 		agentSAIssuer = "https://k8s.example.com"
 	)
+
+	// issuerMap with a single actor entry that allows any subject
+	// (empty AllowedSubjects = unrestricted, bounded by allowedClaims.sub).
 	issuerMap := map[string]TrustedIssuerConfig{
 		testIssuer: {
 			Issuer:                testIssuer,
 			JwksURL:               "https://oidc.example.com/.well-known/jwks.json",
 			Alias:                 testAlias,
 			AllowedTargetClusters: []string{"cluster-a"},
-			// matchesSubGlob supports prefix* patterns only; use exact match for human subjects.
-			AllowedClaims: map[string]string{"sub": humanSubject},
+			AllowedClaims:         map[string]string{"sub": humanSubject},
+			AllowedActors: []ActorConfig{
+				{Sub: agentSASub},
+			},
 		},
 	}
 
@@ -998,4 +1003,170 @@ func TestAccessTokenInjectorMiddleware_OBOToken(t *testing.T) {
 		})).ServeHTTP(rr, newOBOReq("attacker@evil.com", agentSASub))
 		require.Equal(t, http.StatusForbidden, rr.Code)
 	})
+
+	t.Run("OBO actor not in allowedActors returns 403", func(t *testing.T) {
+		s := &OAuthHTTPServer{trustedIssuersByIssuer: issuerMap}
+		rr := httptest.NewRecorder()
+		s.createAccessTokenInjectorMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})).ServeHTTP(rr, newOBOReq(humanSubject, "system:serviceaccount:other:rogue-agent"))
+		require.Equal(t, http.StatusForbidden, rr.Code)
+	})
+
+	t.Run("OBO allowedActors empty rejects any OBO request", func(t *testing.T) {
+		noActorMap := map[string]TrustedIssuerConfig{
+			testIssuer: {
+				Issuer:        testIssuer,
+				JwksURL:       "https://oidc.example.com/.well-known/jwks.json",
+				Alias:         testAlias,
+				AllowedClaims: map[string]string{"sub": humanSubject},
+				// AllowedActors intentionally empty — OBO disabled.
+			},
+		}
+		s := &OAuthHTTPServer{trustedIssuersByIssuer: noActorMap}
+		rr := httptest.NewRecorder()
+		s.createAccessTokenInjectorMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})).ServeHTTP(rr, newOBOReq(humanSubject, agentSASub))
+		require.Equal(t, http.StatusForbidden, rr.Code)
+	})
+
+	t.Run("OBO actor with allowedSubjects glob allows matching human", func(t *testing.T) {
+		var capturedCtx context.Context
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedCtx = r.Context()
+			w.WriteHeader(http.StatusOK)
+		})
+		globMap := map[string]TrustedIssuerConfig{
+			testIssuer: {
+				Issuer:        testIssuer,
+				JwksURL:       "https://oidc.example.com/.well-known/jwks.json",
+				Alias:         testAlias,
+				AllowedClaims: map[string]string{"sub": "*@example.com"},
+				AllowedActors: []ActorConfig{
+					{
+						Sub:             agentSASub,
+						AllowedSubjects: []string{"*@example.com"},
+					},
+				},
+			},
+		}
+		s := &OAuthHTTPServer{trustedIssuersByIssuer: globMap}
+		rr := httptest.NewRecorder()
+		s.createAccessTokenInjectorMiddleware(next).ServeHTTP(rr, newOBOReq("alice@example.com", agentSASub))
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		identity, ok := ImpersonationIdentityFromContext(capturedCtx)
+		require.True(t, ok)
+		require.Equal(t, "alice@example.com", identity.UserName)
+		require.Equal(t, agentSASub, identity.Actor)
+	})
+
+	t.Run("OBO actor with allowedSubjects glob rejects non-matching human", func(t *testing.T) {
+		globMap := map[string]TrustedIssuerConfig{
+			testIssuer: {
+				Issuer:        testIssuer,
+				JwksURL:       "https://oidc.example.com/.well-known/jwks.json",
+				Alias:         testAlias,
+				AllowedClaims: map[string]string{"sub": "*@example.com"},
+				AllowedActors: []ActorConfig{
+					{
+						Sub:             agentSASub,
+						AllowedSubjects: []string{"*@example.com"},
+					},
+				},
+			},
+		}
+		s := &OAuthHTTPServer{trustedIssuersByIssuer: globMap}
+		rr := httptest.NewRecorder()
+		s.createAccessTokenInjectorMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})).ServeHTTP(rr, newOBOReq("intruder@other.org", agentSASub))
+		require.Equal(t, http.StatusForbidden, rr.Code)
+	})
+
+	t.Run("OBO actor with empty allowedSubjects allows any matching human", func(t *testing.T) {
+		var capturedCtx context.Context
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedCtx = r.Context()
+			w.WriteHeader(http.StatusOK)
+		})
+		s := &OAuthHTTPServer{trustedIssuersByIssuer: issuerMap}
+		rr := httptest.NewRecorder()
+		s.createAccessTokenInjectorMiddleware(next).ServeHTTP(rr, newOBOReq(humanSubject, agentSASub))
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		identity, ok := ImpersonationIdentityFromContext(capturedCtx)
+		require.True(t, ok)
+		require.Equal(t, humanSubject, identity.UserName)
+	})
+
+	t.Run("OBO multiple actors: each actor scoped to different subjects", func(t *testing.T) {
+		const (
+			agent1 = "system:serviceaccount:kagent:agent-one"
+			agent2 = "system:serviceaccount:kagent:agent-two"
+		)
+		multiActorMap := map[string]TrustedIssuerConfig{
+			testIssuer: {
+				Issuer:        testIssuer,
+				JwksURL:       "https://oidc.example.com/.well-known/jwks.json",
+				Alias:         testAlias,
+				AllowedClaims: map[string]string{"sub": "*@example.com"},
+				AllowedActors: []ActorConfig{
+					{Sub: agent1, AllowedSubjects: []string{"admin@example.com"}},
+					{Sub: agent2, AllowedSubjects: []string{"*@example.com"}},
+				},
+			},
+		}
+		s := &OAuthHTTPServer{trustedIssuersByIssuer: multiActorMap}
+
+		// agent1 may only impersonate admin@example.com
+		rr := httptest.NewRecorder()
+		s.createAccessTokenInjectorMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})).ServeHTTP(rr, newOBOReq("other@example.com", agent1))
+		require.Equal(t, http.StatusForbidden, rr.Code)
+
+		// agent2 may impersonate any @example.com human
+		var capturedCtx context.Context
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedCtx = r.Context()
+			w.WriteHeader(http.StatusOK)
+		})
+		rr2 := httptest.NewRecorder()
+		s.createAccessTokenInjectorMiddleware(next).ServeHTTP(rr2, newOBOReq("other@example.com", agent2))
+		require.Equal(t, http.StatusOK, rr2.Code)
+		identity, ok := ImpersonationIdentityFromContext(capturedCtx)
+		require.True(t, ok)
+		require.Equal(t, "other@example.com", identity.UserName)
+	})
+}
+
+func TestMatchesSubGlob(t *testing.T) {
+	tests := []struct {
+		pattern string
+		s       string
+		want    bool
+	}{
+		// exact match
+		{"alice@example.com", "alice@example.com", true},
+		{"alice@example.com", "bob@example.com", false},
+
+		// trailing star — prefix match
+		{"system:serviceaccount:kagent:*", "system:serviceaccount:kagent:bot", true},
+		{"system:serviceaccount:kagent:*", "system:serviceaccount:other:bot", false},
+		// trailing-star prefix must be non-empty
+		{"*", "anything", false},
+
+		// leading star — suffix match
+		{"*@giantswarm.io", "quentin@giantswarm.io", true},
+		{"*@giantswarm.io", "quentin@otherdomain.io", false},
+		// leading-star suffix must be non-empty
+		{"*", "anything", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.pattern+"|"+tc.s, func(t *testing.T) {
+			require.Equal(t, tc.want, matchesSubGlob(tc.pattern, tc.s))
+		})
+	}
 }


### PR DESCRIPTION
## What

`allowedActors` changes from `[]string` to a list of objects:

```yaml
allowedActors:
  - sub: "system:serviceaccount:kagent:sre-agent"
    allowedSubjects:       # optional; empty = any subject
      - "*@giantswarm.io"  # leading-* glob = suffix match
  - sub: "system:serviceaccount:kagent:headless-agent"
    # no allowedSubjects: may impersonate any human passing allowedClaims.sub
```

The issuer-level `allowedSubjects` field is removed. Subject restriction now lives per-actor.

## Why

K8s RBAC cannot couple `impersonate users` to `impersonate userextras/actor` — they are independent verbs checked independently. No RBAC rule expresses "may impersonate user X only when actor=A". `resourceNames` also has no wildcard support, so glob subjects like `*@giantswarm.io` cannot be expressed there.

Per-actor subject enforcement runs in the OBO branch of the access-token injector middleware before any impersonation call reaches the apiserver. The RBAC grant (now emitted unrestricted whenever `allowedActors` is non-empty) is the outer bound; the inner enforcement is in code.

## Changes

- `ActorConfig` type (`{Sub, AllowedSubjects}`) added to `TrustedIssuerConfig`.
- OBO branch validates the actor is in `AllowedActors`, then (if `AllowedSubjects` is non-empty) that the human subject matches at least one pattern.
- `matchesSubGlob` extended to support a single leading `*` (suffix match) in addition to the existing trailing `*` (prefix match).
- Chart emits an unrestricted `users` impersonate rule + `userextras/actor` scoped to the listed subs when `allowedActors` is set.
- Issuer-level `allowedSubjects` removed from values + schema.
- Helm-unittest cases added for the previously untested M2M/OBO ClusterRole block.

## Breaking change

Existing `allowedActors: ["system:serviceaccount:..."]` flat-string values must migrate to:

```yaml
allowedActors:
  - sub: "system:serviceaccount:..."
```