### PR TITLE
feat(obo): per-issuer subjectClaim remap + act-chain actor matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* `trustedIssuers[].subjectClaim`: names the verified claim whose value becomes the impersonated subject, replacing the standard `sub` (set to `email` for the muster-obo issuer). When set, the impersonated-subject pattern lives under that key in `allowedClaims` (e.g. `allowedClaims.email`), and the token is rejected if the claim is absent. The in-process subject gate and startup validation key off this claim.
+* The OBO actor allow-list now matches any actor in the RFC 8693 `act` delegation chain (`act`, `act.act`, ...), not only the leaf, so multi-hop A2A delegation (human via agent A via agent B) is authorized.
 * OBO (Phase 2): external-issuer tokens carrying an RFC 8693 `act` claim now take the OBO impersonation branch. `Impersonate-User` is set to the human subject; `Impersonate-Extra-actor` is set to the agent SA sub, so the kube-apiserver audit log records both parties. Tokens without an `act` claim continue to use the existing M2M path unchanged.
 * `trustedIssuers[].allowedActors` is now a list of objects: each entry specifies an agent SA `sub` and an optional `allowedSubjects` list of human subject patterns. Per-actor subject enforcement runs in-process before any impersonation call reaches the kube-apiserver. Subject patterns support a single leading (`*@domain.com`) or trailing (`system:serviceaccount:ns:*`) wildcard. An empty `allowedSubjects` list permits any subject that passes `allowedClaims.sub`.
 * The `impersonate users` ClusterRole rule is now emitted unrestricted (no `resourceNames`) whenever `allowedActors` is non-empty. K8s RBAC cannot couple `impersonate-users` to `impersonate-userextras/actor` (independent verbs) or express wildcard subjects in `resourceNames`; the RBAC grant is the outer bound and the inner enforcement is in code.
@@ -21,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * `trustedIssuers[].allowedActors` is now a list of objects (`{sub, allowedSubjects}`) instead of a flat list of strings. This is a breaking values change. OBO is disabled for an issuer when `allowedActors` is empty or omitted.
+* **deps:** update module github.com/giantswarm/mcp-oauth to v0.10.2.
 
 ## [0.1.113](https://github.com/giantswarm/mcp-kubernetes/compare/v0.1.112...v0.1.113) (2026-06-03)
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -438,6 +438,43 @@ Downstream OAuth (--downstream-oauth):
 }
 
 // validateEncryptionKey validates an AES-256 encryption key for security weaknesses
+// validateTrustedIssuers checks per-issuer invariants: a present issuer URL and
+// JWKS URL, a DNS-1123 alias, a non-wildcard subject pattern under the issuer's
+// effective subject claim (sub, or SubjectClaim when remapped), and unique
+// issuer URLs and aliases.
+func validateTrustedIssuers(issuers []server.TrustedIssuerConfig) error {
+	seenIssuers := make(map[string]struct{}, len(issuers))
+	seenAliases := make(map[string]struct{}, len(issuers))
+	for _, ti := range issuers {
+		if ti.Issuer == "" {
+			return fmt.Errorf("trusted issuer entry has empty issuer URL")
+		}
+		if ti.JwksURL == "" {
+			return fmt.Errorf("trusted issuer %q: jwksURL is required", ti.Issuer)
+		}
+		if !isDNS1123Label(ti.Alias) {
+			return fmt.Errorf("trusted issuer %q: alias %q is not a valid DNS-1123 label "+
+				"(lowercase alphanumeric and hyphens, must start/end with alphanumeric, max 63 chars)",
+				ti.Issuer, ti.Alias)
+		}
+		subjectKey := ti.EffectiveSubjectKey()
+		subPattern, hasSub := ti.AllowedClaims[subjectKey]
+		if !hasSub || subPattern == "" || subPattern == "*" {
+			return fmt.Errorf("trusted issuer %q: allowedClaims.%s must be a non-empty pattern "+
+				"that is not bare '*' (prevents any identity from being impersonated)", ti.Issuer, subjectKey)
+		}
+		if _, seen := seenIssuers[ti.Issuer]; seen {
+			return fmt.Errorf("duplicate trusted issuer URL %q", ti.Issuer)
+		}
+		seenIssuers[ti.Issuer] = struct{}{}
+		if _, seen := seenAliases[ti.Alias]; seen {
+			return fmt.Errorf("trusted issuer %q: alias %q is already used by another issuer", ti.Issuer, ti.Alias)
+		}
+		seenAliases[ti.Alias] = struct{}{}
+	}
+	return nil
+}
+
 func validateEncryptionKey(key []byte) error {
 	if len(key) != 32 {
 		return fmt.Errorf("encryption key must be exactly 32 bytes, got %d bytes", len(key))
@@ -593,33 +630,8 @@ func runServe(config ServeConfig) error {
 		if !config.InCluster {
 			return fmt.Errorf("trusted issuers require in-cluster mode (--in-cluster)")
 		}
-		seenIssuers := make(map[string]struct{}, len(config.OAuth.TrustedIssuers))
-		seenAliases := make(map[string]struct{}, len(config.OAuth.TrustedIssuers))
-		for _, ti := range config.OAuth.TrustedIssuers {
-			if ti.Issuer == "" {
-				return fmt.Errorf("trusted issuer entry has empty issuer URL")
-			}
-			if ti.JwksURL == "" {
-				return fmt.Errorf("trusted issuer %q: jwksURL is required", ti.Issuer)
-			}
-			if !isDNS1123Label(ti.Alias) {
-				return fmt.Errorf("trusted issuer %q: alias %q is not a valid DNS-1123 label "+
-					"(lowercase alphanumeric and hyphens, must start/end with alphanumeric, max 63 chars)",
-					ti.Issuer, ti.Alias)
-			}
-			subPattern, hasSub := ti.AllowedClaims["sub"]
-			if !hasSub || subPattern == "" || subPattern == "*" {
-				return fmt.Errorf("trusted issuer %q: allowedClaims.sub must be a non-empty pattern "+
-					"that is not bare '*' (prevents any service account from being impersonated)", ti.Issuer)
-			}
-			if _, seen := seenIssuers[ti.Issuer]; seen {
-				return fmt.Errorf("duplicate trusted issuer URL %q", ti.Issuer)
-			}
-			seenIssuers[ti.Issuer] = struct{}{}
-			if _, seen := seenAliases[ti.Alias]; seen {
-				return fmt.Errorf("trusted issuer %q: alias %q is already used by another issuer", ti.Issuer, ti.Alias)
-			}
-			seenAliases[ti.Alias] = struct{}{}
+		if err := validateTrustedIssuers(config.OAuth.TrustedIssuers); err != nil {
+			return err
 		}
 		impersonationFactory, err := k8s.NewInClusterImpersonationFactory(k8sConfig)
 		if err != nil {

--- a/cmd/trusted_issuers_test.go
+++ b/cmd/trusted_issuers_test.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/giantswarm/mcp-kubernetes/internal/server"
+)
+
+func TestValidateTrustedIssuers(t *testing.T) {
+	const (
+		issuerURL = "https://oidc.example.com"
+		jwksURL   = "https://oidc.example.com/.well-known/jwks.json"
+	)
+
+	tests := []struct {
+		name      string
+		issuers   []server.TrustedIssuerConfig
+		wantError bool
+	}{
+		{
+			name: "sub-keyed issuer is valid",
+			issuers: []server.TrustedIssuerConfig{{
+				Issuer:        issuerURL,
+				JwksURL:       jwksURL,
+				Alias:         "glean",
+				AllowedClaims: map[string]string{"sub": "system:serviceaccount:kagent:*"},
+			}},
+		},
+		{
+			name: "email-remapped issuer gates on allowedClaims.email",
+			issuers: []server.TrustedIssuerConfig{{
+				Issuer:        issuerURL,
+				JwksURL:       jwksURL,
+				Alias:         "muster-obo",
+				SubjectClaim:  "email",
+				AllowedClaims: map[string]string{"email": "*@giantswarm.io"},
+			}},
+		},
+		{
+			name: "SubjectClaim set but no pattern under that key is rejected",
+			issuers: []server.TrustedIssuerConfig{{
+				Issuer:        issuerURL,
+				JwksURL:       jwksURL,
+				Alias:         "muster-obo",
+				SubjectClaim:  "email",
+				AllowedClaims: map[string]string{"sub": "*@giantswarm.io"},
+			}},
+			wantError: true,
+		},
+		{
+			name: "bare wildcard under the effective key is rejected",
+			issuers: []server.TrustedIssuerConfig{{
+				Issuer:        issuerURL,
+				JwksURL:       jwksURL,
+				Alias:         "muster-obo",
+				SubjectClaim:  "email",
+				AllowedClaims: map[string]string{"email": "*"},
+			}},
+			wantError: true,
+		},
+		{
+			name: "missing subject pattern on default sub key is rejected",
+			issuers: []server.TrustedIssuerConfig{{
+				Issuer:  issuerURL,
+				JwksURL: jwksURL,
+				Alias:   "glean",
+			}},
+			wantError: true,
+		},
+		{
+			name: "duplicate alias is rejected",
+			issuers: []server.TrustedIssuerConfig{
+				{Issuer: issuerURL, JwksURL: jwksURL, Alias: "glean", AllowedClaims: map[string]string{"sub": "a"}},
+				{Issuer: "https://other.example.com", JwksURL: jwksURL, Alias: "glean", AllowedClaims: map[string]string{"sub": "b"}},
+			},
+			wantError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateTrustedIssuers(tc.issuers)
+			if tc.wantError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.26.4
 
 require (
 	github.com/creativeprojects/go-selfupdate v1.5.2
-	github.com/giantswarm/mcp-oauth v0.9.3
+	github.com/giantswarm/mcp-oauth v0.10.2
 	github.com/giantswarm/mcp-toolkit v0.2.9
 	github.com/mark3labs/mcp-go v0.55.0
 	github.com/prometheus/client_golang v1.23.2

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/giantswarm/mcp-oauth v0.9.3 h1:muG2x9JFeaqXB8eez+tOFA+LQ2DdeJc+xjuWfpIb7PQ=
-github.com/giantswarm/mcp-oauth v0.9.3/go.mod h1:Z/f5JZAz6JGs8A++hfXPUIN4CR1yuMb9cXRx4qrzzIA=
+github.com/giantswarm/mcp-oauth v0.10.2 h1:D+rx02uWka6Xuxkm/j9TGQ6MgUnqtUXSImOlxNFV0oY=
+github.com/giantswarm/mcp-oauth v0.10.2/go.mod h1:Z/f5JZAz6JGs8A++hfXPUIN4CR1yuMb9cXRx4qrzzIA=
 github.com/giantswarm/mcp-toolkit v0.2.9 h1:U6HhPlHX5+SuCKqZWWMXzcmJmhdcZrobhOsq/+LpiVg=
 github.com/giantswarm/mcp-toolkit v0.2.9/go.mod h1:jwOmxo8+MCPJ6HHPRqFkI6S48A/cbqXOzvT5bydbRds=
 github.com/go-fed/httpsig v1.1.0 h1:9M+hb0jkEICD8/cAiNqEB66R87tTINszBRTjwjQzWcI=

--- a/helm/mcp-kubernetes/values.schema.json
+++ b/helm/mcp-kubernetes/values.schema.json
@@ -582,10 +582,14 @@
                   },
                   "allowedClaims": {
                     "type": "object",
-                    "description": "Optional map of required claim key/value pairs. Tokens lacking these claims are rejected.",
+                    "description": "Optional map of required claim key/value pairs. Tokens lacking these claims are rejected. When subjectClaim is set, the impersonated-subject pattern must live under that key (e.g. allowedClaims.email), not under sub.",
                     "additionalProperties": {
                       "type": "string"
                     }
+                  },
+                  "subjectClaim": {
+                    "type": "string",
+                    "description": "Optional claim name whose value becomes the impersonated subject, replacing the standard sub. Set to 'email' for the muster-obo issuer so muster's opaque sub is remapped to the human email. Validation rejects the token if the claim is absent."
                   },
                   "acceptedTypHeaders": {
                     "type": "array",

--- a/helm/mcp-kubernetes/values.yaml
+++ b/helm/mcp-kubernetes/values.yaml
@@ -521,6 +521,9 @@ mcpKubernetes:
     #   allowedAudiences:       accepted `aud` values (empty = accept any)
     #   allowedTargetClusters:  workload clusters this issuer may target (empty = all)
     #   allowedClaims:          required claim key/value pairs (e.g. sub prefix check)
+    #   subjectClaim:           claim whose value becomes the impersonated subject,
+    #                           replacing sub (e.g. "email"). When set, the subject
+    #                           pattern lives under that key in allowedClaims.
     #   acceptedTypHeaders:     accepted `typ` header values (empty = any)
     #   allowPrivateIPJWKS:     true when the JWKS endpoint is on a private network
     #
@@ -572,11 +575,14 @@ mcpKubernetes:
     #         # empty allowedSubjects: this actor may impersonate any human
     #         # whose sub matches allowedClaims.sub
     #
-    # Example (OBO-only issuer, e.g. muster token exchange endpoint):
+    # Example (OBO-only issuer, e.g. muster token exchange endpoint). muster keeps
+    # sub opaque and carries the human in the email claim, so subjectClaim remaps
+    # the subject to email and the pattern lives under allowedClaims.email:
     #   - issuer: "https://muster.example.com"
     #     jwksURL: "https://muster.example.com/.well-known/jwks.json"
+    #     subjectClaim: "email"
     #     allowedClaims:
-    #       sub: "*@example.com"
+    #       email: "*@example.com"
     #     acceptedTypHeaders: ["at+jwt"]
     #     allowedActors:
     #       - sub: "system:serviceaccount:kagent:my-agent"

--- a/internal/server/oauth_http.go
+++ b/internal/server/oauth_http.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -20,6 +21,7 @@ import (
 	"github.com/giantswarm/mcp-oauth/providers"
 	"github.com/giantswarm/mcp-oauth/providers/dex"
 	"github.com/giantswarm/mcp-oauth/providers/google"
+	"github.com/giantswarm/mcp-oauth/providers/oidc"
 	"github.com/giantswarm/mcp-oauth/security"
 	oauthserver "github.com/giantswarm/mcp-oauth/server"
 	"github.com/giantswarm/mcp-oauth/storage"
@@ -319,6 +321,38 @@ func matchesSubGlob(pattern, s string) bool {
 	return pattern == s
 }
 
+// actorChainSubjects returns the set of subjects in the token's RFC 8693 §4.4
+// delegation chain (act, act.act, ...). The token is already validated by the
+// upstream ValidateToken middleware, so the act claim is read from the
+// authentic payload without re-verifying the signature. Returns nil when the
+// token carries no act claim or cannot be parsed; callers must still seed the
+// set with the validated leaf actor (userInfo.ActorSubject).
+func actorChainSubjects(token string) map[string]struct{} {
+	rawClaims, err := oidc.ParseUnverifiedClaims(token)
+	if err != nil {
+		return nil
+	}
+	actRaw, ok := rawClaims["act"]
+	if !ok {
+		return nil
+	}
+	encoded, err := json.Marshal(actRaw)
+	if err != nil {
+		return nil
+	}
+	var actor oidc.ActorClaim
+	if err := json.Unmarshal(encoded, &actor); err != nil {
+		return nil
+	}
+	subjects := make(map[string]struct{})
+	for a := &actor; a != nil; a = a.Act {
+		if a.Subject != "" {
+			subjects[a.Subject] = struct{}{}
+		}
+	}
+	return subjects
+}
+
 // ActorConfig defines an OBO actor (RFC 8693 act.sub) and the human subjects it
 // is permitted to act on behalf of.
 type ActorConfig struct {
@@ -328,7 +362,7 @@ type ActorConfig struct {
 	// AllowedSubjects is the set of human subject values (userInfo.ID) that this
 	// actor may impersonate. Trailing-star glob patterns are supported
 	// (e.g. "*@example.com"). Empty means any subject is allowed, still bounded
-	// by TrustedIssuerConfig.AllowedClaims["sub"] and the RBAC outer grant.
+	// by the issuer's effective-subject-claim pattern and the RBAC outer grant.
 	AllowedSubjects []string `json:"allowedSubjects,omitempty"`
 }
 
@@ -350,7 +384,16 @@ type TrustedIssuerConfig struct {
 	// AllowedClaims constrains accepted tokens to those whose JWT claims match
 	// all entries exactly (e.g. {"sub": "system:serviceaccount:kagent:*"}).
 	// Wildcard suffix matching is supported for the "sub" claim only.
+	// When SubjectClaim is set, the entry under that key (not "sub") gates the
+	// impersonated subject; mcp-oauth evaluates AllowedClaims against the raw
+	// token before the subject is remapped, so the opaque sub cannot carry the
+	// remapped pattern.
 	AllowedClaims map[string]string `json:"allowedClaims,omitempty"`
+	// SubjectClaim names the verified claim whose value becomes the impersonated
+	// subject, replacing the standard sub claim. Set to "email" on the muster-obo
+	// issuer so muster's opaque sub is remapped to the human email. mcp-oauth
+	// fails closed if the claim is absent or not a non-empty string.
+	SubjectClaim string `json:"subjectClaim,omitempty"`
 	// AcceptedTypHeaders overrides the default RFC 9068 typ=at+jwt check.
 	// Set to ["", "JWT"] to accept Kubernetes ServiceAccount tokens.
 	AcceptedTypHeaders []string `json:"acceptedTypHeaders,omitempty"`
@@ -360,6 +403,16 @@ type TrustedIssuerConfig struct {
 	// the human subjects they may impersonate. Empty means OBO is disabled for
 	// this issuer (any request with an act claim is rejected).
 	AllowedActors []ActorConfig `json:"allowedActors,omitempty"`
+}
+
+// EffectiveSubjectKey returns the AllowedClaims key that gates the impersonated
+// subject: SubjectClaim when set, otherwise the standard "sub". The validated
+// subject (userInfo.ID) is matched against AllowedClaims[EffectiveSubjectKey()].
+func (c TrustedIssuerConfig) EffectiveSubjectKey() string {
+	if c.SubjectClaim != "" {
+		return c.SubjectClaim
+	}
+	return "sub"
 }
 
 // RedirectURISecurityConfig holds configuration for redirect URI security validation.
@@ -677,6 +730,7 @@ func createOAuthServer(config OAuthConfig) (*oauth.Server, storage.TokenStore, e
 				JwksURL:            ti.JwksURL,
 				AllowedAudiences:   ti.AllowedAudiences,
 				AllowedClaims:      ti.AllowedClaims,
+				SubjectClaim:       ti.SubjectClaim,
 				AcceptedTypHeaders: ti.AcceptedTypHeaders,
 				AllowPrivateIPJWKS: ti.AllowPrivateIPJWKS,
 			}
@@ -1020,19 +1074,22 @@ func (s *OAuthHTTPServer) createAccessTokenInjectorMiddleware(next http.Handler)
 				http.Error(w, "internal configuration error: issuer alias missing", http.StatusInternalServerError)
 				return
 			}
-			// Defense-in-depth: re-verify the sub claim at the impersonation boundary,
+			// Defense-in-depth: re-verify the subject at the impersonation boundary,
 			// independent of mcp-oauth's upstream check. Catches misconfigured entries
 			// (missing allowedClaims) and future library regressions before any
-			// impersonation call reaches the kube-apiserver.
-			if subPattern, ok := tiConfig.AllowedClaims["sub"]; !ok || subPattern == "" {
-				slog.Warn("AccessTokenInjector: trusted issuer has no allowedClaims.sub, rejecting",
-					"issuer", userInfo.Issuer)
+			// impersonation call reaches the kube-apiserver. The subject is matched
+			// against the effective-subject-claim pattern; for a remapped issuer
+			// (SubjectClaim set) userInfo.ID already holds the remapped value.
+			subjectKey := tiConfig.EffectiveSubjectKey()
+			if subPattern, ok := tiConfig.AllowedClaims[subjectKey]; !ok || subPattern == "" {
+				slog.Warn("AccessTokenInjector: trusted issuer has no allowedClaims for subject key, rejecting",
+					"issuer", userInfo.Issuer, "subjectKey", subjectKey)
 				http.Error(w, "forbidden: issuer misconfiguration", http.StatusForbidden)
 				return
 			} else if !matchesSubGlob(subPattern, userInfo.ID) {
-				slog.Warn("AccessTokenInjector: sub claim does not match allowedClaims pattern, rejecting",
-					"issuer", userInfo.Issuer, "pattern", subPattern)
-				http.Error(w, "forbidden: sub claim does not match allowed pattern", http.StatusForbidden)
+				slog.Warn("AccessTokenInjector: subject does not match allowedClaims pattern, rejecting",
+					"issuer", userInfo.Issuer, "subjectKey", subjectKey, "pattern", subPattern)
+				http.Error(w, "forbidden: subject does not match allowed pattern", http.StatusForbidden)
 				return
 			}
 
@@ -1044,17 +1101,30 @@ func (s *OAuthHTTPServer) createAccessTokenInjectorMiddleware(next http.Handler)
 				// K8s RBAC cannot couple impersonate-users to impersonate-userextras/actor
 				// (independent verbs) and does not support wildcards in resourceNames,
 				// so both checks must live here.
+				//
+				// Walk the full RFC 8693 act chain: a configured actor is authorized
+				// when its sub appears anywhere in the chain, so multi-hop A2A
+				// (human -> agentA -> agentB -> MCP) is honored, not only the leaf.
+				// The leaf comes from the validated UserInfo; deeper hops are read
+				// from the authentic token payload.
 				actorSub := userInfo.ActorSubject
+				chainSubjects := actorChainSubjects(bearerToken)
+				if chainSubjects == nil {
+					chainSubjects = make(map[string]struct{}, 1)
+				}
+				if actorSub != "" {
+					chainSubjects[actorSub] = struct{}{}
+				}
 				var matchedActor *ActorConfig
 				for i := range tiConfig.AllowedActors {
-					if tiConfig.AllowedActors[i].Sub == actorSub {
+					if _, ok := chainSubjects[tiConfig.AllowedActors[i].Sub]; ok {
 						matchedActor = &tiConfig.AllowedActors[i]
 						break
 					}
 				}
 				if matchedActor == nil {
-					slog.Warn("AccessTokenInjector: OBO actor not in allowedActors, rejecting",
-						"issuer", userInfo.Issuer, "actor", actorSub)
+					slog.Warn("AccessTokenInjector: no actor in delegation chain matches allowedActors, rejecting",
+						"issuer", userInfo.Issuer, "leafActor", actorSub, "chainLen", len(chainSubjects))
 					http.Error(w, "forbidden: actor not permitted for this issuer", http.StatusForbidden)
 					return
 				}

--- a/internal/server/oauth_http_test.go
+++ b/internal/server/oauth_http_test.go
@@ -4,6 +4,8 @@ package server
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -1169,4 +1171,188 @@ func TestMatchesSubGlob(t *testing.T) {
 			require.Equal(t, tc.want, matchesSubGlob(tc.pattern, tc.s))
 		})
 	}
+}
+
+// makeDelegatedJWT builds an unsigned JWT whose payload is the given claims.
+// ParseUnverifiedClaims only base64-decodes the payload segment, so a placeholder
+// signature is sufficient for exercising the in-process act-chain walk.
+func makeDelegatedJWT(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	body, err := json.Marshal(claims)
+	require.NoError(t, err)
+	enc := base64.RawURLEncoding.EncodeToString
+	return enc([]byte(`{"alg":"none","typ":"at+jwt"}`)) + "." + enc(body) + ".sig"
+}
+
+func TestAccessTokenInjectorMiddleware_ActorChain(t *testing.T) {
+	const (
+		testIssuer = "https://muster.example.io"
+		testAlias  = "muster-obo"
+		human      = "quentin@giantswarm.io"
+		agentInner = "system:serviceaccount:kagent:agent-a"
+		agentLeaf  = "system:serviceaccount:kagent:agent-b"
+	)
+
+	// Two-hop chain: human -> agent-a -> agent-b -> MCP. The minted token's act
+	// is the leaf (agent-b) with a nested act for the inner hop (agent-a).
+	twoHopToken := makeDelegatedJWT(t, map[string]any{
+		"iss": testIssuer,
+		"sub": human,
+		"act": map[string]any{
+			"iss": "https://k8s.example.com",
+			"sub": agentLeaf,
+			"act": map[string]any{
+				"iss": "https://k8s.example.com",
+				"sub": agentInner,
+			},
+		},
+	})
+
+	newReq := func(token string) *http.Request {
+		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		userInfo := &providers.UserInfo{
+			ID:           human,
+			Issuer:       testIssuer,
+			TokenSource:  providers.TokenSourceTrustedIssuer,
+			ActorSubject: agentLeaf, // mcp-oauth mirrors only the leaf
+			ActorIssuer:  "https://k8s.example.com",
+		}
+		return req.WithContext(handler.ContextWithUserInfo(req.Context(), userInfo))
+	}
+
+	issuerWith := func(actorSub string) map[string]TrustedIssuerConfig {
+		return map[string]TrustedIssuerConfig{
+			testIssuer: {
+				Issuer:        testIssuer,
+				JwksURL:       "https://muster.example.io/.well-known/jwks.json",
+				Alias:         testAlias,
+				AllowedClaims: map[string]string{"sub": "*@giantswarm.io"},
+				AllowedActors: []ActorConfig{{Sub: actorSub}},
+			},
+		}
+	}
+
+	t.Run("allowedActors matches an inner (non-leaf) hop in the chain", func(t *testing.T) {
+		var capturedCtx context.Context
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedCtx = r.Context()
+			w.WriteHeader(http.StatusOK)
+		})
+		s := &OAuthHTTPServer{trustedIssuersByIssuer: issuerWith(agentInner)}
+		rr := httptest.NewRecorder()
+		s.createAccessTokenInjectorMiddleware(next).ServeHTTP(rr, newReq(twoHopToken))
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		identity, ok := ImpersonationIdentityFromContext(capturedCtx)
+		require.True(t, ok)
+		require.Equal(t, human, identity.UserName)
+		require.Equal(t, agentLeaf, identity.Actor, "Actor records the immediate (leaf) caller")
+	})
+
+	t.Run("allowedActors matches the leaf hop in the chain", func(t *testing.T) {
+		s := &OAuthHTTPServer{trustedIssuersByIssuer: issuerWith(agentLeaf)}
+		rr := httptest.NewRecorder()
+		s.createAccessTokenInjectorMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})).ServeHTTP(rr, newReq(twoHopToken))
+		require.Equal(t, http.StatusOK, rr.Code)
+	})
+
+	t.Run("no hop in the chain matches allowedActors returns 403", func(t *testing.T) {
+		s := &OAuthHTTPServer{trustedIssuersByIssuer: issuerWith("system:serviceaccount:kagent:stranger")}
+		rr := httptest.NewRecorder()
+		s.createAccessTokenInjectorMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})).ServeHTTP(rr, newReq(twoHopToken))
+		require.Equal(t, http.StatusForbidden, rr.Code)
+	})
+}
+
+func TestEffectiveSubjectKey(t *testing.T) {
+	require.Equal(t, "sub", TrustedIssuerConfig{}.EffectiveSubjectKey())
+	require.Equal(t, "email", TrustedIssuerConfig{SubjectClaim: "email"}.EffectiveSubjectKey())
+}
+
+// TestAccessTokenInjectorMiddleware_SubjectClaim covers the muster-obo issuer:
+// the subject is remapped to the email claim, so the in-process gate matches
+// userInfo.ID (already the email) against allowedClaims.email, not .sub.
+func TestAccessTokenInjectorMiddleware_SubjectClaim(t *testing.T) {
+	const (
+		musterIssuer = "https://muster.glean.example.io"
+		musterAlias  = "muster-obo"
+		sreAgentSub  = "system:serviceaccount:kagent:sre-agent"
+		userEmail    = "quentin@giantswarm.io"
+	)
+
+	emailMap := map[string]TrustedIssuerConfig{
+		musterIssuer: {
+			Issuer:                musterIssuer,
+			JwksURL:               "https://muster.glean.example.io/.well-known/jwks.json",
+			Alias:                 musterAlias,
+			AllowedTargetClusters: []string{"glean"},
+			SubjectClaim:          "email",
+			AllowedClaims:         map[string]string{"email": "*@giantswarm.io"},
+			AllowedActors:         []ActorConfig{{Sub: sreAgentSub}},
+		},
+	}
+
+	newReq := func(remappedSubject string) *http.Request {
+		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		req.Header.Set("Authorization", "Bearer fake-obo-token") //nolint:gosec // G101: test fixture
+		userInfo := &providers.UserInfo{
+			ID:           remappedSubject, // mcp-oauth set this from the email claim
+			Issuer:       musterIssuer,
+			TokenSource:  providers.TokenSourceTrustedIssuer,
+			ActorSubject: sreAgentSub,
+			ActorIssuer:  "https://k8s.example.com",
+		}
+		return req.WithContext(handler.ContextWithUserInfo(req.Context(), userInfo))
+	}
+
+	t.Run("email-remapped subject matching allowedClaims.email impersonates the email", func(t *testing.T) {
+		var capturedCtx context.Context
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedCtx = r.Context()
+			w.WriteHeader(http.StatusOK)
+		})
+		s := &OAuthHTTPServer{trustedIssuersByIssuer: emailMap}
+		rr := httptest.NewRecorder()
+		s.createAccessTokenInjectorMiddleware(next).ServeHTTP(rr, newReq(userEmail))
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		identity, ok := ImpersonationIdentityFromContext(capturedCtx)
+		require.True(t, ok)
+		require.Equal(t, userEmail, identity.UserName)
+		require.Equal(t, sreAgentSub, identity.Actor)
+		require.Empty(t, identity.Groups)
+	})
+
+	t.Run("subject outside the email pattern returns 403", func(t *testing.T) {
+		s := &OAuthHTTPServer{trustedIssuersByIssuer: emailMap}
+		rr := httptest.NewRecorder()
+		s.createAccessTokenInjectorMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})).ServeHTTP(rr, newReq("mallory@evil.com"))
+		require.Equal(t, http.StatusForbidden, rr.Code)
+	})
+
+	t.Run("SubjectClaim set but no allowedClaims entry under that key returns 403", func(t *testing.T) {
+		misconfigured := map[string]TrustedIssuerConfig{
+			musterIssuer: {
+				Issuer:        musterIssuer,
+				JwksURL:       "https://muster.glean.example.io/.well-known/jwks.json",
+				Alias:         musterAlias,
+				SubjectClaim:  "email",
+				AllowedClaims: map[string]string{"sub": "*@giantswarm.io"}, // wrong key
+				AllowedActors: []ActorConfig{{Sub: sreAgentSub}},
+			},
+		}
+		s := &OAuthHTTPServer{trustedIssuersByIssuer: misconfigured}
+		rr := httptest.NewRecorder()
+		s.createAccessTokenInjectorMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})).ServeHTTP(rr, newReq(userEmail))
+		require.Equal(t, http.StatusForbidden, rr.Code)
+	})
 }


### PR DESCRIPTION
## What

- Adds `trustedIssuers[].subjectClaim`, mapped onto `oauthserver.TrustedIssuer.SubjectClaim` (mcp-oauth v0.10.2). When set (e.g. `email` on the `muster-obo` issuer), mcp-oauth remaps the validated subject to that claim and fails closed if it is absent. The opaque `sub` stays the stable token id; the human is carried in `email`.
- Generalises the in-process subject gate and startup validation to key off the effective subject claim (`subjectClaim`, or `sub` by default) via a new `TrustedIssuerConfig.EffectiveSubjectKey()` helper. The per-issuer validation moves into a testable `validateTrustedIssuers`.
- Matches the OBO actor allow-list against any actor in the RFC 8693 `act` delegation chain (`act`, `act.act`, ...), not only the leaf, so multi-hop A2A (human via agent A via agent B) is authorized. The leaf comes from the validated `UserInfo`; deeper hops are read from the authentic token payload via `oidc.ParseUnverifiedClaims` (the token is already signature-validated upstream).
- Bumps mcp-oauth `v0.9.3` to `v0.10.2`.
- Helm: documents `subjectClaim` in `values.yaml`, adds it to `values.schema.json` (the items schema is `additionalProperties: false`), and updates the OBO-only example to the email-remap shape.

## Why

muster keeps `sub` opaque and conveys the human identity in `email`. For muster-minted OBO tokens to authorize anything, mcp-kubernetes must impersonate by the email-derived subject. Because mcp-oauth evaluates `allowedClaims` against the **raw** token before the subject is remapped, the subject pattern must live under the remapped key (`allowedClaims.email`), not `allowedClaims.sub` (the opaque `sub` cannot carry it). This is the code companion to the konfigure config change that wires `subjectClaim: email` on the `muster-obo` issuer.

## Follow-ups (to file)

- Host-scoped JWKS exception / static JWKS so `allowPrivateIPJWKS: true` can be retired on the in-cluster muster issuer.
- Revisit whether a per-issuer dual-sub is still needed now that `subjectClaim` ships.