### PR TITLE
fix(helm): dedup per-alias M2M RBAC when multiple trustedIssuers share an alias

### DIFF
--- a/helm/mcp-kubernetes/templates/rbac.yaml
+++ b/helm/mcp-kubernetes/templates/rbac.yaml
@@ -517,11 +517,18 @@ subjects:
 {{/*
 M2M Impersonation RBAC
 
-For each trusted issuer with an alias, this creates:
+For each unique alias across trustedIssuers, this creates:
   - A <alias> Namespace for the impersonated ServiceAccounts
   - A Role + RoleBinding in that namespace granting `impersonate serviceaccounts`
   - A ClusterRole + ClusterRoleBinding for groups and user-extra impersonation,
     scoped to the per-alias SA group and known extra keys/values
+
+Multiple trustedIssuers may legitimately share one alias (e.g. a localMint issuer
+and a fallback OIDC issuer both scoping to the same impersonation namespace). The
+template deduplicates per-alias resources: Namespace, Role, RoleBinding, ClusterRole,
+and ClusterRoleBinding are each rendered exactly once per unique alias. The ClusterRole
+unions the userextras/issuer resourceNames and allowedActors across all issuers that
+share the alias.
 
 This RBAC is load-bearing: without it the kube-apiserver rejects the Impersonate-*
 headers sent by mcp-kubernetes's in-cluster SA. The impersonated SAs themselves
@@ -532,8 +539,21 @@ such as `list pods`) are NOT provisioned from this chart; they must be created
 per-cluster via shared-configs or equivalent.
 */}}
 {{- if and .Values.serviceAccount.create .Values.rbac.create .Values.mcpKubernetes.oauth.enabled }}
+{{- /* Pass 1: group issuers by alias so per-alias resources can union across all of them. */}}
+{{- $aliasBuckets := dict }}
 {{- range .Values.mcpKubernetes.oauth.trustedIssuers }}
 {{- if .alias }}
+{{- $existing := default (list) (index $aliasBuckets .alias) }}
+{{- $_ := set $aliasBuckets .alias (append $existing .) }}
+{{- end }}
+{{- end }}
+{{- /* Pass 2: render once per unique alias (first occurrence in list wins for ordering). */}}
+{{- $seen := dict }}
+{{- range .Values.mcpKubernetes.oauth.trustedIssuers }}
+{{- if .alias }}
+{{- if not (hasKey $seen .alias) }}
+{{- $_ := set $seen .alias true }}
+{{- $aliasIssuers := index $aliasBuckets .alias }}
 ---
 apiVersion: v1
 kind: Namespace
@@ -582,7 +602,6 @@ metadata:
     {{- include "mcp-kubernetes.labels" $ | nindent 4 }}
   annotations:
     mcp-kubernetes.giantswarm.io/m2m-alias: {{ .alias | quote }}
-    mcp-kubernetes.giantswarm.io/m2m-issuer: {{ .issuer | quote }}
 rules:
   - apiGroups: [""]
     resources: ["groups"]
@@ -595,19 +614,26 @@ rules:
   - apiGroups: ["authentication.k8s.io"]
     resources: ["userextras/issuer"]
     verbs: ["impersonate"]
-    resourceNames: [{{ .issuer | quote }}]
+    resourceNames:
+      {{- range $aliasIssuers }}
+      - {{ .issuer | quote }}
+      {{- end }}
 {{- /*
 impersonate users is granted unrestricted because K8s RBAC cannot couple it to
 impersonate-userextras/actor (independent verbs) and resourceNames has no wildcard
 support for glob subjects. Per-actor subject scoping is enforced in-process.
 */}}
-{{- if .allowedActors }}
+{{- $anyActors := false }}
+{{- range $aliasIssuers }}{{- if .allowedActors }}{{- $anyActors = true }}{{- end }}{{- end }}
+{{- if $anyActors }}
   - apiGroups: ["authentication.k8s.io"]
     resources: ["userextras/actor"]
     verbs: ["impersonate"]
     resourceNames:
+      {{- range $aliasIssuers }}
       {{- range .allowedActors }}
       - {{ .sub | quote }}
+      {{- end }}
       {{- end }}
   - apiGroups: [""]
     resources: ["users"]
@@ -628,6 +654,7 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "mcp-kubernetes.serviceAccountName" $ }}
     namespace: {{ $.Release.Namespace }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/helm/mcp-kubernetes/tests/rbac_test.yaml
+++ b/helm/mcp-kubernetes/tests/rbac_test.yaml
@@ -935,3 +935,41 @@ tests:
               - "system:serviceaccount:kagent:agent-one"
               - "system:serviceaccount:kagent:agent-two"
         documentIndex: 5
+
+  - it: should deduplicate per-alias resources when two issuers share the same alias
+    set:
+      serviceAccount.create: true
+      rbac.create: true
+      mcpKubernetes.oauth.enabled: true
+      mcpKubernetes.oauth.trustedIssuers:
+        - issuer: "https://issuer-a.example.com"
+          jwksURL: "https://issuer-a.example.com/jwks"
+          alias: "shared-alias"
+        - issuer: "https://issuer-b.example.com"
+          jwksURL: "https://issuer-b.example.com/jwks"
+          alias: "shared-alias"
+    asserts:
+      # same 7 docs as single-issuer: dedup prevents the duplicate Namespace/Role/ClusterRole
+      - hasDocuments:
+          count: 7
+      - isKind:
+          of: Namespace
+        documentIndex: 2
+      - equal:
+          path: metadata.name
+          value: shared-alias
+        documentIndex: 2
+      - isKind:
+          of: ClusterRole
+        documentIndex: 5
+      # ClusterRole unions both issuers' values in the userextras/issuer rule
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["authentication.k8s.io"]
+            resources: ["userextras/issuer"]
+            verbs: ["impersonate"]
+            resourceNames:
+              - "https://issuer-a.example.com"
+              - "https://issuer-b.example.com"
+        documentIndex: 5


### PR DESCRIPTION
## What

`rbac.yaml` looped naively over `trustedIssuers` and emitted a `Namespace`, `Role`, `RoleBinding`, `ClusterRole`, and `ClusterRoleBinding` per entry that had an `alias`. When two issuers shared the same alias the chart produced duplicate resources and Helm aborted:

```
may not add resource with an already registered id: Namespace kagent-glean
```

This is a real case: glean had a localMint muster issuer and a fallback direct-SA OIDC issuer both configured with `alias: kagent-glean`. A config-level workaround removed the duplicate (giantswarm-configs #716), but the chart itself had no guard.

## How

Two-pass template:

1. Pass 1 (no output) groups all issuers by alias into `$aliasBuckets`.
2. Pass 2 ranges the original list with a `$seen` dict guard and renders each alias exactly once. The `ClusterRole` unions `userextras/issuer` resourceNames and `allowedActors` across all issuers sharing the alias.

Document order is preserved (first occurrence in the list wins), so existing `documentIndex` assertions in the test suite are unaffected.

The `m2m-issuer` annotation is dropped from `ClusterRole` metadata (ambiguous when N issuers share an alias); it remains on `Role` where it names the first-occurrence issuer.

## Test

New test case: two issuers with identical alias → 7 documents (not 12), `ClusterRole` `userextras/issuer` resourceNames contains both issuer URLs.

All 87 tests pass.