### PR TITLE
feat(m2m): pure-projector M2M path with impersonateUser + impersonateGroups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* `trustedIssuers[].impersonateUser`: the exact subject an M2M entry projects as `Impersonate-User`. The token's effective subject must match verbatim; no wildcard. Chart scopes the mck8s SA `impersonate users` RBAC resourceName to this value. Must be paired with `impersonateGroups`.
+* `trustedIssuers[].impersonateGroups`: allow-list of groups an M2M token may project as `Impersonate-Group`. Only groups present in both this list and the token's `groups` claim are impersonated; a token carrying none of the listed groups is rejected (403). Chart scopes the mck8s SA `impersonate groups` RBAC resourceNames to this list. Must be paired with `impersonateUser`.
+* Multiple `trustedIssuers` entries sharing the same issuer URL are now supported. The correct entry is selected at request time by subject-pattern match, so M2M and OBO entries can coexist for the same upstream STS (e.g. muster).
+* `trustedIssuers[].alias` is now optional for M2M entries (still required for OBO entries).
 * `trustedIssuers[].subjectClaim`: names the verified claim whose value becomes the impersonated subject, replacing the standard `sub` (set to `email` for the muster-obo issuer). When set, the impersonated-subject pattern lives under that key in `allowedClaims` (e.g. `allowedClaims.email`), and the token is rejected if the claim is absent. The in-process subject gate and startup validation key off this claim.
 * The OBO actor allow-list now matches any actor in the RFC 8693 `act` delegation chain (`act`, `act.act`, ...), not only the leaf, so multi-hop A2A delegation (human via agent A via agent B) is authorized.
 * OBO (Phase 2): external-issuer tokens carrying an RFC 8693 `act` claim now take the OBO impersonation branch. `Impersonate-User` is set to the human subject; `Impersonate-Extra-actor` is set to the agent SA sub, so the kube-apiserver audit log records both parties. Tokens without an `act` claim continue to use the existing M2M path unchanged.
@@ -22,8 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* M2M path (external-issuer tokens without `act`) replaced the alias-namespace SA construction (`system:serviceaccount:<alias>:<saName>`) with pure projection: `impersonateUser` and `impersonateGroups` fields from the trusted-issuer config drive the impersonation headers directly. Tokens whose subject is not a `system:serviceaccount:...` path are no longer rejected.
 * `trustedIssuers[].allowedActors` is now a list of objects (`{sub, allowedSubjects}`) instead of a flat list of strings. This is a breaking values change. OBO is disabled for an issuer when `allowedActors` is empty or omitted.
-* **deps:** update module github.com/giantswarm/mcp-oauth to v0.10.2.
+* **deps:** update module github.com/giantswarm/mcp-oauth to v0.14.0.
 
 ## [0.1.113](https://github.com/giantswarm/mcp-kubernetes/compare/v0.1.112...v0.1.113) (2026-06-03)
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -438,11 +438,12 @@ Downstream OAuth (--downstream-oauth):
 }
 
 // validateEncryptionKey validates an AES-256 encryption key for security weaknesses
-// validateTrustedIssuers checks per-issuer invariants: a present issuer URL and
-// JWKS URL, a DNS-1123 alias, and a non-wildcard subject pattern under the
-// issuer's effective subject claim. Aliases must be unique across all entries.
-// Multiple entries may share the same issuer URL (e.g. M2M + OBO from the same
-// STS), provided their aliases differ.
+// validateTrustedIssuers checks per-issuer invariants:
+//   - M2M entries (impersonateGroups set): must omit alias; impersonateUser required.
+//   - OBO/SSO entries: alias must be a valid DNS-1123 label and unique.
+//   - All entries: non-wildcard subject pattern under the effective subject claim.
+//
+// Multiple entries may share the same issuer URL (e.g. M2M + OBO from the same STS).
 func validateTrustedIssuers(issuers []server.TrustedIssuerConfig) error {
 	seenAliases := make(map[string]struct{}, len(issuers))
 	for _, ti := range issuers {
@@ -452,10 +453,25 @@ func validateTrustedIssuers(issuers []server.TrustedIssuerConfig) error {
 		if ti.JwksURL == "" {
 			return fmt.Errorf("trusted issuer %q: jwksURL is required", ti.Issuer)
 		}
-		if !isDNS1123Label(ti.Alias) {
-			return fmt.Errorf("trusted issuer %q: alias %q is not a valid DNS-1123 label "+
-				"(lowercase alphanumeric and hyphens, must start/end with alphanumeric, max 63 chars)",
-				ti.Issuer, ti.Alias)
+		if len(ti.ImpersonateGroups) > 0 {
+			// M2M entry.
+			if ti.Alias != "" {
+				return fmt.Errorf("trusted issuer %q: M2M entries (impersonateGroups set) must not set alias", ti.Issuer)
+			}
+			if ti.ImpersonateUser == "" {
+				return fmt.Errorf("trusted issuer %q: impersonateUser is required when impersonateGroups is set", ti.Issuer)
+			}
+		} else {
+			// OBO/SSO entry.
+			if !isDNS1123Label(ti.Alias) {
+				return fmt.Errorf("trusted issuer %q: alias %q is not a valid DNS-1123 label "+
+					"(lowercase alphanumeric and hyphens, must start/end with alphanumeric, max 63 chars)",
+					ti.Issuer, ti.Alias)
+			}
+			if _, seen := seenAliases[ti.Alias]; seen {
+				return fmt.Errorf("trusted issuer %q: alias %q is already used by another issuer", ti.Issuer, ti.Alias)
+			}
+			seenAliases[ti.Alias] = struct{}{}
 		}
 		subjectKey := ti.EffectiveSubjectKey()
 		subPattern, hasSub := ti.AllowedClaims[subjectKey]
@@ -463,10 +479,6 @@ func validateTrustedIssuers(issuers []server.TrustedIssuerConfig) error {
 			return fmt.Errorf("trusted issuer %q: allowedClaims.%s must be a non-empty pattern "+
 				"that is not bare '*' (prevents any identity from being impersonated)", ti.Issuer, subjectKey)
 		}
-		if _, seen := seenAliases[ti.Alias]; seen {
-			return fmt.Errorf("trusted issuer %q: alias %q is already used by another issuer", ti.Issuer, ti.Alias)
-		}
-		seenAliases[ti.Alias] = struct{}{}
 	}
 	return nil
 }

--- a/docs/trusted-issuer-m2m-obo.md
+++ b/docs/trusted-issuer-m2m-obo.md
@@ -1,0 +1,190 @@
+# Trusted-issuer M2M and OBO identity model
+
+mcp-kubernetes supports two identity flows for tokens minted by an external broker
+(muster in the GiantSwarm platform): M2M (machine-to-machine, headless agents) and
+OBO (on-behalf-of, agents acting for an authenticated human). Both flows use the
+`trustedIssuers` configuration block.
+
+## Roles in the model
+
+| Component | Role |
+|-----------|------|
+| **muster** | Single authority for the Kubernetes identity an agent acts as. Validates the agent's SA token via `WithTrustedIssuers`, mints a short-lived JWT carrying the downstream K8s user and groups. |
+| **mcp-kubernetes** | Pure projector. Maps the minted `sub` → `Impersonate-User` and minted `groups` → `Impersonate-Group`. Decides nothing about authorization; enforces exact allow-lists (`impersonateUser`, `impersonateGroups`). |
+| **rbac-operator / CRB** | Binds the minted group to a ClusterRole (e.g. `read-all`) on the target cluster. All K8s access decisions stay in Kubernetes RBAC. |
+
+mcp-kubernetes never interprets the token's audience or constructs a synthetic
+namespace-based SA identity from the subject. The minted user and groups arrive
+verbatim from the broker.
+
+## M2M (machine identity, headless agents)
+
+muster mints a token with:
+
+- `sub` = the impersonated user (e.g. `agent:sre`), set by the `WorkloadGroupGrant`
+  `granted.subject` field
+- `groups` = the impersonated groups (e.g. `["agent:sre"]`), set by `granted.groups`
+- no `act` claim (pure machine identity, no delegation chain)
+- `aud` = the backend audience (e.g. `mcp-kubernetes`)
+- `typ: at+jwt` (RFC 9068)
+
+mcp-kubernetes, on receiving the token:
+
+1. Validates the JWT signature against the trusted issuer's JWKS.
+2. Checks `allowedClaims.sub` pattern against the remapped subject.
+3. Asserts the minted subject equals `impersonateUser` (exact match; no wildcard).
+4. Intersects the minted `groups` with `impersonateGroups`; rejects if the
+   intersection is empty (403).
+5. Sets `Impersonate-User` and `Impersonate-Group` headers on every downstream
+   Kubernetes API call.
+
+The intersection at step 4 is the MCP-level allow-list. Kubernetes RBAC provides
+the second gate: the group must be bound to the required ClusterRole on the target
+cluster.
+
+### Required K8s RBAC
+
+The minted group must be bound to a ClusterRole on each target cluster:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: agent-sre-read-all
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: read-all          # GiantSwarm standard read-only ClusterRole
+subjects:
+  - kind: Group
+    name: agent:sre
+    apiGroup: rbac.authorization.k8s.io
+```
+
+At GiantSwarm this binding is owned by rbac-operator; do not hand-write it.
+
+### Configuration (trustedIssuers)
+
+```yaml
+mcpKubernetes:
+  oauth:
+    trustedIssuers:
+      - issuer: "https://muster.example.io"
+        jwksURL: "https://muster.example.io/.well-known/jwks.json"
+        impersonateUser: agent:sre
+        impersonateGroups:
+          - agent:sre
+        allowedClaims:
+          sub: agent:sre          # exact match; use globs for multiple agents
+        acceptedTypHeaders:
+          - "at+jwt"
+```
+
+When the muster JWKS endpoint resolves to a private IP (in-cluster load balancer),
+add `allowPrivateIPJWKS: true` on that issuer entry. This is an SSRF downgrade
+scoped to the pinned issuer; prefer host-scoped JWKS allowlist when available.
+
+### Why group impersonation, not SA namespace impersonation
+
+The earlier `kagent-glean` model impersonated
+`system:serviceaccount:<alias-namespace>:<agent-name>` and required a hand-written
+Role + RoleBinding per alias namespace. That approach:
+
+- required bespoke RBAC per agent alias rather than using the standard rbac-operator
+  bindings that govern human access;
+- coupled the agent's K8s identity to the MCP deployment namespace, creating
+  per-install drift;
+- did not compose with GiantSwarm's group-based RBAC model.
+
+Group impersonation via a dedicated agent group (`agent:sre`) resolves to the same
+string on every cluster regardless of connector prefix (both `giantswarm-ad` and
+`giantswarm-github` connectors exist on every MC). rbac-operator binds that group
+to `read-all` using the same mechanism it uses for human groups.
+
+## OBO (on-behalf-of, human-triggered via A2A)
+
+muster mints a delegated token with:
+
+- `sub` = the human's email (remapped from the Dex ID token via `subjectClaim: email`)
+- `act.sub` = the agent SA (`system:serviceaccount:kagent:sre-agent`)
+- `aud` = the backend audience
+- `typ: at+jwt`
+
+mcp-kubernetes, on receiving an OBO token (`act` claim present):
+
+1. Validates the JWT and the actor against `allowedActors[].sub`. The check walks
+   the full RFC 8693 chain (`act.act.sub`, etc.) so multi-hop A2A is honored.
+2. If `matchedActor.allowedSubjects` is set, checks the human subject (`sub`) matches
+   one of the patterns.
+3. Sets `Impersonate-User` to the human's email. No groups are carried in the current
+   implementation (OBO group-carrying is a follow-up; human K8s RBAC at GiantSwarm
+   uses per-user subject bindings for now).
+
+### Configuration (trustedIssuers, OBO entry)
+
+The OBO entry requires a distinct `alias` so the chart generates a separate RBAC
+grant covering the unrestricted `impersonate users` verb:
+
+```yaml
+mcpKubernetes:
+  oauth:
+    trustedIssuers:
+      # M2M entry above ...
+      - issuer: "https://muster.example.io"
+        jwksURL: "https://muster.example.io/.well-known/jwks.json"
+        alias: "muster-obo"
+        allowedClaims:
+          sub: "*@example.io"
+        acceptedTypHeaders:
+          - "at+jwt"
+        allowedActors:
+          - sub: "system:serviceaccount:kagent:sre-agent"
+            allowedSubjects:
+              - "*@example.io"
+```
+
+The `alias` field causes the chart to emit a `ClusterRole`/`ClusterRoleBinding`
+granting `impersonate users` (unrestricted) for this issuer. Per-actor subject
+enforcement runs in-process; Kubernetes RBAC cannot couple impersonation verbs to
+extras.
+
+## mcp-kubernetes SA RBAC (own pod)
+
+The mcp-kubernetes `ServiceAccount` needs `impersonate` rights on both `users` and
+`groups` resources scoped to the identities it projects. The chart emits these grants
+automatically from the `trustedIssuers` entries; do not manage them manually.
+
+For M2M, the chart creates a `ClusterRole` allowing impersonation of the configured
+`impersonateUser` and each `impersonateGroups` entry via `resourceNames`. For OBO
+(`alias` present), it grants unrestricted `impersonate users`.
+
+## Authority model and cloud-agnosticism
+
+muster owns the identity assertion: it validates the agent's K8s SA token via
+`WithTrustedIssuers` (per-cluster OIDC issuer; only the issuer URL differs between
+Azure Workload Identity and IRSA) and emits from a `workloadGroupGrant` keyed on
+explicit issuer + subject. The grant is the auditable, deprovisionable declaration
+that this agent serves this tenant; no mint-time external call means no fail-open path.
+
+The agent group (`agent:sre`) is a single deterministic string on every cluster,
+independent of the Dex connector prefix (both `giantswarm-ad` and `giantswarm-github`
+connectors exist on every management cluster). Human OBO groups still arrive
+connector-prefixed from Dex; only the autonomous M2M agent uses the connector-free group.
+
+This model was chosen over Azure AD group-gating and Keycloak client-credentials:
+both require per-cloud adapter layers that add complexity without removing the need
+for backend group bindings, and neither applies to the majority of the fleet running
+on AWS/IRSA. See `subplans/14-external-workload-identity.md` for the full evaluation.
+
+SPIFFE/JWT-SVIDs are the intended successor for the SA token source when SPIRE is
+available fleet-wide: mcp-oauth's `JWTSVIDValidator` accepts SVIDs as `subject_token`,
+the grant becomes `spiffe://…/sa/sre-agent -> group`, and everything downstream
+(mck8s projector, rbac-operator binding) is unchanged.
+
+## Non-regression: SSO + IRSA paths
+
+The trusted-issuer path activates only when the Bearer token's issuer matches a
+`trustedIssuers` entry (`userInfo.IsExternalIssuer()`). Tokens validated via
+`trustedAudiences` (Dex SSO forwarded by muster) or IRSA/SA-direct paths are
+unaffected; they continue through the existing SSO forwarding or in-cluster auth
+paths.

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.26.4
 
 require (
 	github.com/creativeprojects/go-selfupdate v1.5.2
-	github.com/giantswarm/mcp-oauth v0.13.2
+	github.com/giantswarm/mcp-oauth v0.14.0
 	github.com/giantswarm/mcp-toolkit v0.2.9
 	github.com/mark3labs/mcp-go v0.55.0
 	github.com/prometheus/client_golang v1.23.2

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,6 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/giantswarm/mcp-oauth v0.13.2 h1:4uwFEZ+B1KMxCCDbIZKw6BHJsRSE3Oy1Q6XuE+AtmKE=
-github.com/giantswarm/mcp-oauth v0.13.2/go.mod h1:Z/f5JZAz6JGs8A++hfXPUIN4CR1yuMb9cXRx4qrzzIA=
 github.com/giantswarm/mcp-oauth v0.14.0 h1:Znm9cMGjBS0wahVB27V4SrA1SORLYpcaJD6RR5fIZZ0=
 github.com/giantswarm/mcp-oauth v0.14.0/go.mod h1:Z/f5JZAz6JGs8A++hfXPUIN4CR1yuMb9cXRx4qrzzIA=
 github.com/giantswarm/mcp-toolkit v0.2.9 h1:U6HhPlHX5+SuCKqZWWMXzcmJmhdcZrobhOsq/+LpiVg=

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sa
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/giantswarm/mcp-oauth v0.13.2 h1:4uwFEZ+B1KMxCCDbIZKw6BHJsRSE3Oy1Q6XuE+AtmKE=
 github.com/giantswarm/mcp-oauth v0.13.2/go.mod h1:Z/f5JZAz6JGs8A++hfXPUIN4CR1yuMb9cXRx4qrzzIA=
+github.com/giantswarm/mcp-oauth v0.14.0 h1:Znm9cMGjBS0wahVB27V4SrA1SORLYpcaJD6RR5fIZZ0=
+github.com/giantswarm/mcp-oauth v0.14.0/go.mod h1:Z/f5JZAz6JGs8A++hfXPUIN4CR1yuMb9cXRx4qrzzIA=
 github.com/giantswarm/mcp-toolkit v0.2.9 h1:U6HhPlHX5+SuCKqZWWMXzcmJmhdcZrobhOsq/+LpiVg=
 github.com/giantswarm/mcp-toolkit v0.2.9/go.mod h1:jwOmxo8+MCPJ6HHPRqFkI6S48A/cbqXOzvT5bydbRds=
 github.com/go-fed/httpsig v1.1.0 h1:9M+hb0jkEICD8/cAiNqEB66R87tTINszBRTjwjQzWcI=

--- a/internal/server/oauth_http.go
+++ b/internal/server/oauth_http.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"time"
 
-	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 
 	oauth "github.com/giantswarm/mcp-oauth"
 	"github.com/giantswarm/mcp-oauth/handler"
@@ -298,9 +297,31 @@ type OAuthConfig struct {
 	TrustedIssuers []TrustedIssuerConfig
 }
 
-// isDNS1123Label reports whether s is a valid Kubernetes DNS-1123 label.
-func isDNS1123Label(s string) bool {
-	return len(k8svalidation.IsDNS1123Label(s)) == 0
+// intersectGroups returns the members of tokenGroups present in allowList,
+// preserving allowList order and dropping duplicates. It is the allow-list gate
+// for M2M group impersonation: only configured groups carried by the token are
+// honored.
+func intersectGroups(allowList, tokenGroups []string) []string {
+	if len(allowList) == 0 || len(tokenGroups) == 0 {
+		return nil
+	}
+	present := make(map[string]struct{}, len(tokenGroups))
+	for _, g := range tokenGroups {
+		present[g] = struct{}{}
+	}
+	var matched []string
+	seen := make(map[string]struct{}, len(allowList))
+	for _, g := range allowList {
+		if _, ok := present[g]; !ok {
+			continue
+		}
+		if _, dup := seen[g]; dup {
+			continue
+		}
+		seen[g] = struct{}{}
+		matched = append(matched, g)
+	}
+	return matched
 }
 
 // matchesSubGlob reports whether s matches a sub-claim pattern.
@@ -372,10 +393,27 @@ type TrustedIssuerConfig struct {
 	Issuer string `json:"issuer"`
 	// JwksURL is the JWKS endpoint used to verify signatures.
 	JwksURL string `json:"jwksURL"`
-	// Alias is a required stable short identifier for this issuer (e.g. "glean", "mc-foo").
-	// It is encoded into the impersonated principal as the namespace component:
-	// system:serviceaccount:<alias>:<saName>
-	Alias string `json:"alias"`
+	// Alias is a stable short identifier for an OBO issuer (e.g. "muster-obo"). The
+	// chart keys the per-alias Namespace and users/userextras impersonation ClusterRole
+	// on this value. Required on OBO entries; must be omitted on M2M entries (which
+	// identify themselves via ImpersonateUser / ImpersonateGroups instead).
+	Alias string `json:"alias,omitempty"`
+	// ImpersonateUser is the exact subject this M2M entry may project as
+	// Impersonate-User. The token's effective subject (userInfo.ID, after any
+	// SubjectClaim remap) must equal this value verbatim; no glob matching applies
+	// (use AllowedClaims for routing patterns). The chart scopes the mck8s
+	// ServiceAccount's impersonate-users RBAC resourceName to exactly this value.
+	// Empty disables the M2M path for this issuer.
+	// Must be paired with a non-empty ImpersonateGroups.
+	ImpersonateUser string `json:"impersonateUser,omitempty"`
+	// ImpersonateGroups is the exact allow-list of groups an M2M token from this
+	// issuer may project as Impersonate-Group. The intersection of this list and the
+	// token's minted groups claim becomes the set of impersonated groups; a token
+	// carrying none of these groups is rejected. The chart scopes the mck8s
+	// ServiceAccount's impersonate-groups RBAC resourceNames to exactly this list.
+	// Empty disables the M2M path for this issuer.
+	// Must be paired with a non-empty ImpersonateUser.
+	ImpersonateGroups []string `json:"impersonateGroups,omitempty"`
 	// AllowedAudiences restricts accepted `aud` values. Empty means any audience.
 	AllowedAudiences []string `json:"allowedAudiences,omitempty"`
 	// AllowedTargetClusters limits which management/workload cluster names this
@@ -1091,13 +1129,6 @@ func (s *OAuthHTTPServer) createAccessTokenInjectorMiddleware(next http.Handler)
 				http.Error(w, "forbidden: subject does not match allowed pattern", http.StatusForbidden)
 				return
 			}
-			if tiConfig.Alias == "" {
-				slog.Warn("AccessTokenInjector: trusted issuer has no alias configured",
-					"issuer", userInfo.Issuer)
-				http.Error(w, "internal configuration error: issuer alias missing", http.StatusInternalServerError)
-				return
-			}
-
 			// OBO path (Phase 2): sub=human, act.sub=agent SA.
 			// Impersonate the human subject; record the agent SA as the actor so the
 			// kube-apiserver audit log shows "human X via agent Z".
@@ -1169,37 +1200,34 @@ func (s *OAuthHTTPServer) createAccessTokenInjectorMiddleware(next http.Handler)
 				return
 			}
 
-			// M2M path (Phase 1B): sub=agent SA, no act claim.
-			// K8s SA token sub: "system:serviceaccount:<ns>:<name>" → extract <name>.
-			saName := userInfo.ID
-			if parts := strings.SplitN(userInfo.ID, ":", 4); len(parts) == 4 && parts[0] == "system" && parts[1] == "serviceaccount" {
-				saName = parts[3]
-			}
-			if saName == "" {
-				slog.Warn("AccessTokenInjector: empty service account name in token sub, rejecting",
-					"issuer", userInfo.Issuer)
-				http.Error(w, "forbidden: empty service account name", http.StatusForbidden)
+			// M2M path: pure projection. muster asserted the subject (GrantedSubject
+			// in mcp-oauth); ImpersonateUser is the final exact gate here. The
+			// intersection of ImpersonateGroups and the minted token groups becomes
+			// Impersonate-Group; cluster RBAC (bound to the group) authorizes.
+			if tiConfig.ImpersonateUser != userInfo.ID {
+				slog.Warn("AccessTokenInjector: M2M subject does not match impersonateUser, rejecting",
+					"issuer", userInfo.Issuer, "subject", userInfo.ID)
+				http.Error(w, "forbidden: subject not permitted for impersonation", http.StatusForbidden)
 				return
 			}
-			if !isDNS1123Label(saName) {
-				slog.Warn("AccessTokenInjector: service account name is not a valid DNS-1123 label, rejecting",
-					"issuer", userInfo.Issuer)
-				http.Error(w, "forbidden: invalid service account name", http.StatusForbidden)
+			impersonateGroups := intersectGroups(tiConfig.ImpersonateGroups, userInfo.Groups)
+			if len(impersonateGroups) == 0 {
+				slog.Warn("AccessTokenInjector: M2M token carries no allow-listed group, rejecting",
+					"issuer", userInfo.Issuer, "subject", userInfo.ID)
+				http.Error(w, "forbidden: no permitted group in token", http.StatusForbidden)
 				return
 			}
-			qualifiedUserName := "system:serviceaccount:" + tiConfig.Alias + ":" + saName
-			// Groups are pinned to the per-alias group; SA token group claims are not
-			// forwarded because they reflect the source namespace and would be rejected
-			// by the kube-apiserver impersonation RBAC.
 			identity := k8s.ImpersonationIdentity{
-				UserName: qualifiedUserName,
-				Groups:   []string{"system:serviceaccounts:" + tiConfig.Alias},
+				UserName: userInfo.ID,
+				Groups:   impersonateGroups,
 				Extra: map[string][]string{
 					"issuer": {userInfo.Issuer},
 					"agent":  {"mcp-kubernetes"},
 				},
 				AllowedTargetClusters: tiConfig.AllowedTargetClusters,
 			}
+			slog.Debug("AccessTokenInjector: M2M group impersonation",
+				"issuer", userInfo.Issuer, "subject", userInfo.ID, "groups", impersonateGroups)
 
 			ctx = ContextWithImpersonationIdentity(ctx, identity)
 			r = r.WithContext(ctx)

--- a/internal/server/oauth_http.go
+++ b/internal/server/oauth_http.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"time"
 
-
 	oauth "github.com/giantswarm/mcp-oauth"
 	"github.com/giantswarm/mcp-oauth/handler"
 	oauthinstrumentation "github.com/giantswarm/mcp-oauth/instrumentation"

--- a/internal/server/oauth_http_test.go
+++ b/internal/server/oauth_http_test.go
@@ -771,9 +771,9 @@ func makeIssuerMap(c TrustedIssuerConfig) map[string][]TrustedIssuerConfig {
 
 func TestAccessTokenInjectorMiddleware_M2MToken(t *testing.T) {
 	const (
-		testIssuer  = "https://oidc.example.com"
-		agentUser   = "agent:sre"
-		agentGroup  = "agent:sre"
+		testIssuer = "https://oidc.example.com"
+		agentUser  = "agent:sre"
+		agentGroup = "agent:sre"
 	)
 	issuerMap := makeIssuerMap(TrustedIssuerConfig{
 		Issuer:                testIssuer,

--- a/internal/server/oauth_http_test.go
+++ b/internal/server/oauth_http_test.go
@@ -771,29 +771,32 @@ func makeIssuerMap(c TrustedIssuerConfig) map[string][]TrustedIssuerConfig {
 
 func TestAccessTokenInjectorMiddleware_M2MToken(t *testing.T) {
 	const (
-		testIssuer = "https://oidc.example.com"
-		testAlias  = "glean"
+		testIssuer  = "https://oidc.example.com"
+		agentUser   = "agent:sre"
+		agentGroup  = "agent:sre"
 	)
 	issuerMap := makeIssuerMap(TrustedIssuerConfig{
 		Issuer:                testIssuer,
 		JwksURL:               "https://oidc.example.com/.well-known/jwks.json",
-		Alias:                 testAlias,
+		ImpersonateUser:       agentUser,
+		ImpersonateGroups:     []string{agentGroup},
 		AllowedTargetClusters: []string{"cluster-a"},
-		AllowedClaims:         map[string]string{"sub": "system:serviceaccount:kagent:*"},
+		AllowedClaims:         map[string]string{"sub": agentUser},
 	})
 
-	newReq := func(issuer, id string) *http.Request {
+	newReq := func(issuer, id string, groups []string) *http.Request {
 		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
 		req.Header.Set("Authorization", "Bearer fake-m2m-token") //nolint:gosec // G101: test fixture
 		userInfo := &providers.UserInfo{
 			ID:          id,
 			Issuer:      issuer,
+			Groups:      groups,
 			TokenSource: providers.TokenSourceTrustedIssuer,
 		}
 		return req.WithContext(handler.ContextWithUserInfo(req.Context(), userInfo))
 	}
 
-	t.Run("K8s SA sub yields <alias>:<name>", func(t *testing.T) {
+	t.Run("sub matches impersonateUser and group intersects", func(t *testing.T) {
 		var capturedCtx context.Context
 		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			capturedCtx = r.Context()
@@ -802,77 +805,57 @@ func TestAccessTokenInjectorMiddleware_M2MToken(t *testing.T) {
 		s := &OAuthHTTPServer{trustedIssuersByIssuer: issuerMap}
 
 		rr := httptest.NewRecorder()
-		s.createAccessTokenInjectorMiddleware(next).ServeHTTP(rr, newReq(testIssuer, "system:serviceaccount:kagent:my-agent"))
+		s.createAccessTokenInjectorMiddleware(next).ServeHTTP(rr, newReq(testIssuer, agentUser, []string{agentGroup}))
 
 		require.Equal(t, http.StatusOK, rr.Code)
 		identity, ok := ImpersonationIdentityFromContext(capturedCtx)
 		require.True(t, ok)
-		require.Equal(t, "system:serviceaccount:glean:my-agent", identity.UserName)
-		require.Equal(t, []string{"system:serviceaccounts:glean"}, identity.Groups)
+		require.Equal(t, agentUser, identity.UserName)
+		require.Equal(t, []string{agentGroup}, identity.Groups)
 		require.Equal(t, []string{"cluster-a"}, identity.AllowedTargetClusters)
 		require.Equal(t, []string{testIssuer}, identity.Extra["issuer"])
 		require.Equal(t, []string{"mcp-kubernetes"}, identity.Extra["agent"])
 	})
 
-	t.Run("non-K8s sub used verbatim", func(t *testing.T) {
-		var capturedCtx context.Context
-		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			capturedCtx = r.Context()
-			w.WriteHeader(http.StatusOK)
-		})
-		nonK8sMap := makeIssuerMap(TrustedIssuerConfig{
-			Issuer:        testIssuer,
-			JwksURL:       "https://oidc.example.com/.well-known/jwks.json",
-			Alias:         testAlias,
-			AllowedClaims: map[string]string{"sub": "pipeline-*"},
-		})
-		s := &OAuthHTTPServer{trustedIssuersByIssuer: nonK8sMap}
-
+	t.Run("sub not matching impersonateUser returns 403", func(t *testing.T) {
+		s := &OAuthHTTPServer{trustedIssuersByIssuer: issuerMap}
 		rr := httptest.NewRecorder()
-		s.createAccessTokenInjectorMiddleware(next).ServeHTTP(rr, newReq(testIssuer, "pipeline-bot"))
-
-		require.Equal(t, http.StatusOK, rr.Code)
-		identity, ok := ImpersonationIdentityFromContext(capturedCtx)
-		require.True(t, ok)
-		require.Equal(t, "system:serviceaccount:glean:pipeline-bot", identity.UserName)
-		require.Equal(t, []string{"system:serviceaccounts:glean"}, identity.Groups)
+		s.createAccessTokenInjectorMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})).ServeHTTP(rr, newReq(testIssuer, "agent:other", []string{agentGroup}))
+		require.Equal(t, http.StatusForbidden, rr.Code)
 	})
 
-	t.Run("missing allowedClaims sub returns 403", func(t *testing.T) {
+	t.Run("token carrying no allow-listed group returns 403", func(t *testing.T) {
+		s := &OAuthHTTPServer{trustedIssuersByIssuer: issuerMap}
+		rr := httptest.NewRecorder()
+		s.createAccessTokenInjectorMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})).ServeHTTP(rr, newReq(testIssuer, agentUser, []string{"some:other-group"}))
+		require.Equal(t, http.StatusForbidden, rr.Code)
+	})
+
+	t.Run("missing allowedClaims.sub returns 403", func(t *testing.T) {
 		noClaimsMap := makeIssuerMap(TrustedIssuerConfig{
-			Issuer:  testIssuer,
-			JwksURL: "https://oidc.example.com/.well-known/jwks.json",
-			Alias:   testAlias,
+			Issuer:            testIssuer,
+			JwksURL:           "https://oidc.example.com/.well-known/jwks.json",
+			ImpersonateUser:   agentUser,
+			ImpersonateGroups: []string{agentGroup},
 		})
 		s := &OAuthHTTPServer{trustedIssuersByIssuer: noClaimsMap}
 		rr := httptest.NewRecorder()
 		s.createAccessTokenInjectorMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
-		})).ServeHTTP(rr, newReq(testIssuer, "system:serviceaccount:kagent:bot"))
+		})).ServeHTTP(rr, newReq(testIssuer, agentUser, []string{agentGroup}))
 		require.Equal(t, http.StatusForbidden, rr.Code)
 	})
 
-	t.Run("sub not matching allowedClaims pattern returns 403", func(t *testing.T) {
+	t.Run("sub not matching allowedClaims routing pattern returns 403", func(t *testing.T) {
 		s := &OAuthHTTPServer{trustedIssuersByIssuer: issuerMap}
 		rr := httptest.NewRecorder()
 		s.createAccessTokenInjectorMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
-		})).ServeHTTP(rr, newReq(testIssuer, "system:serviceaccount:other-ns:attacker"))
-		require.Equal(t, http.StatusForbidden, rr.Code)
-	})
-
-	t.Run("invalid DNS-1123 saName returns 403", func(t *testing.T) {
-		badSubMap := makeIssuerMap(TrustedIssuerConfig{
-			Issuer:        testIssuer,
-			JwksURL:       "https://oidc.example.com/.well-known/jwks.json",
-			Alias:         testAlias,
-			AllowedClaims: map[string]string{"sub": "*"},
-		})
-		s := &OAuthHTTPServer{trustedIssuersByIssuer: badSubMap}
-		rr := httptest.NewRecorder()
-		s.createAccessTokenInjectorMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(http.StatusOK)
-		})).ServeHTTP(rr, newReq(testIssuer, "Bad_Name"))
+		})).ServeHTTP(rr, newReq(testIssuer, "attacker:imposter", []string{agentGroup}))
 		require.Equal(t, http.StatusForbidden, rr.Code)
 	})
 
@@ -881,22 +864,26 @@ func TestAccessTokenInjectorMiddleware_M2MToken(t *testing.T) {
 		rr := httptest.NewRecorder()
 		s.createAccessTokenInjectorMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
-		})).ServeHTTP(rr, newReq("https://unknown.example.com", "system:serviceaccount:kagent:bot"))
+		})).ServeHTTP(rr, newReq("https://unknown.example.com", agentUser, []string{agentGroup}))
 		require.Equal(t, http.StatusForbidden, rr.Code)
 	})
+}
 
-	t.Run("alias empty returns 500", func(t *testing.T) {
-		noAlias := makeIssuerMap(TrustedIssuerConfig{
-			Issuer:        testIssuer,
-			JwksURL:       "https://oidc.example.com/.well-known/jwks.json",
-			AllowedClaims: map[string]string{"sub": "system:serviceaccount:kagent:*"},
-		})
-		s := &OAuthHTTPServer{trustedIssuersByIssuer: noAlias}
-		rr := httptest.NewRecorder()
-		s.createAccessTokenInjectorMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(http.StatusOK)
-		})).ServeHTTP(rr, newReq(testIssuer, "system:serviceaccount:kagent:bot"))
-		require.Equal(t, http.StatusInternalServerError, rr.Code)
+func TestIntersectGroups(t *testing.T) {
+	t.Run("intersection preserves allowList order", func(t *testing.T) {
+		require.Equal(t, []string{"b", "a"}, intersectGroups([]string{"b", "a", "c"}, []string{"a", "b", "d"}))
+	})
+	t.Run("deduplicates within allowList", func(t *testing.T) {
+		require.Equal(t, []string{"x"}, intersectGroups([]string{"x", "x"}, []string{"x"}))
+	})
+	t.Run("empty allowList returns nil", func(t *testing.T) {
+		require.Nil(t, intersectGroups(nil, []string{"a"}))
+	})
+	t.Run("empty tokenGroups returns nil", func(t *testing.T) {
+		require.Nil(t, intersectGroups([]string{"a"}, nil))
+	})
+	t.Run("no overlap returns nil", func(t *testing.T) {
+		require.Nil(t, intersectGroups([]string{"a"}, []string{"b"}))
 	})
 }
 
@@ -966,18 +953,20 @@ func TestAccessTokenInjectorMiddleware_OBOToken(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
 		req.Header.Set("Authorization", "Bearer fake-m2m-token") //nolint:gosec // G101: test fixture
 		userInfo := &providers.UserInfo{
-			ID:          "system:serviceaccount:kagent:bot",
+			ID:          "agent:bot",
 			Issuer:      testIssuer,
+			Groups:      []string{"agent:bot"},
 			TokenSource: providers.TokenSourceTrustedIssuer,
 			// ActorSubject intentionally absent
 		}
 		req = req.WithContext(handler.ContextWithUserInfo(req.Context(), userInfo))
 
 		m2mMap := makeIssuerMap(TrustedIssuerConfig{
-			Issuer:        testIssuer,
-			JwksURL:       "https://oidc.example.com/.well-known/jwks.json",
-			Alias:         testAlias,
-			AllowedClaims: map[string]string{"sub": "system:serviceaccount:kagent:*"},
+			Issuer:            testIssuer,
+			JwksURL:           "https://oidc.example.com/.well-known/jwks.json",
+			ImpersonateUser:   "agent:bot",
+			ImpersonateGroups: []string{"agent:bot"},
+			AllowedClaims:     map[string]string{"sub": "agent:bot"},
 		})
 		s := &OAuthHTTPServer{trustedIssuersByIssuer: m2mMap}
 		rr := httptest.NewRecorder()
@@ -986,7 +975,8 @@ func TestAccessTokenInjectorMiddleware_OBOToken(t *testing.T) {
 		require.Equal(t, http.StatusOK, rr.Code)
 		identity, ok := ImpersonationIdentityFromContext(capturedCtx)
 		require.True(t, ok)
-		require.Equal(t, "system:serviceaccount:glean:bot", identity.UserName)
+		require.Equal(t, "agent:bot", identity.UserName)
+		require.Equal(t, []string{"agent:bot"}, identity.Groups)
 		require.Empty(t, identity.Actor, "M2M path must not set Actor")
 	})
 
@@ -1337,24 +1327,26 @@ func TestAccessTokenInjectorMiddleware_SubjectClaim(t *testing.T) {
 }
 
 // TestAccessTokenInjectorMiddleware_MultiIssuerURL covers the glean production
-// scenario: M2M (SA sub) and OBO (email sub) entries share the same muster
+// scenario: M2M (agent sub) and OBO (email sub) entries share the same muster
 // issuer URL. The middleware must route each token to the correct entry.
 func TestAccessTokenInjectorMiddleware_MultiIssuerURL(t *testing.T) {
 	const (
 		musterIssuer = "https://muster.glean.example.io"
-		m2mAlias     = "kagent-glean"
 		oboAlias     = "muster-obo"
 		agentSA      = "system:serviceaccount:kagent:sre-agent"
+		agentUser    = "agent:sre"
+		agentGroup   = "agent:sre"
 		humanEmail   = "alice@giantswarm.io"
 	)
 
 	dualIssuerMap := map[string][]TrustedIssuerConfig{
 		musterIssuer: {
 			{
-				Issuer:        musterIssuer,
-				JwksURL:       "https://muster.glean.example.io/.well-known/jwks.json",
-				Alias:         m2mAlias,
-				AllowedClaims: map[string]string{"sub": "system:serviceaccount:kagent:*"},
+				Issuer:            musterIssuer,
+				JwksURL:           "https://muster.glean.example.io/.well-known/jwks.json",
+				ImpersonateUser:   agentUser,
+				ImpersonateGroups: []string{agentGroup},
+				AllowedClaims:     map[string]string{"sub": agentUser},
 			},
 			{
 				Issuer:        musterIssuer,
@@ -1367,7 +1359,7 @@ func TestAccessTokenInjectorMiddleware_MultiIssuerURL(t *testing.T) {
 		},
 	}
 
-	t.Run("M2M token routes to SA-pattern entry", func(t *testing.T) {
+	t.Run("M2M token routes to M2M entry", func(t *testing.T) {
 		var capturedCtx context.Context
 		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			capturedCtx = r.Context()
@@ -1376,8 +1368,9 @@ func TestAccessTokenInjectorMiddleware_MultiIssuerURL(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
 		req.Header.Set("Authorization", "Bearer fake-m2m-token") //nolint:gosec // G101: test fixture
 		userInfo := &providers.UserInfo{
-			ID:          agentSA,
+			ID:          agentUser,
 			Issuer:      musterIssuer,
+			Groups:      []string{agentGroup},
 			TokenSource: providers.TokenSourceTrustedIssuer,
 		}
 		req = req.WithContext(handler.ContextWithUserInfo(req.Context(), userInfo))
@@ -1389,8 +1382,8 @@ func TestAccessTokenInjectorMiddleware_MultiIssuerURL(t *testing.T) {
 		require.Equal(t, http.StatusOK, rr.Code)
 		identity, ok := ImpersonationIdentityFromContext(capturedCtx)
 		require.True(t, ok)
-		require.Equal(t, "system:serviceaccount:"+m2mAlias+":sre-agent", identity.UserName)
-		require.Equal(t, []string{"system:serviceaccounts:" + m2mAlias}, identity.Groups)
+		require.Equal(t, agentUser, identity.UserName)
+		require.Equal(t, []string{agentGroup}, identity.Groups)
 	})
 
 	t.Run("OBO token routes to email-pattern entry", func(t *testing.T) {


### PR DESCRIPTION
Replaces the alias-namespace SA construction with a pure projection model for M2M trusted-issuer tokens.

## What changed

**M2M path (no `act` claim):** the old code parsed the token sub as `system:serviceaccount:<ns>:<name>`, constructed `system:serviceaccount:<alias>:<name>`, and impersonated the alias-namespace SA group. The new path:

- requires `impersonateUser` (exact subject gate) and `impersonateGroups` (intersection gate) on the trusted-issuer entry
- rejects tokens whose sub does not equal `impersonateUser` verbatim (403)
- rejects tokens whose `groups` claim contains none of the `impersonateGroups` values (403)
- sets `Impersonate-User` + `Impersonate-Group` from these fields directly — no SA parsing, no alias namespace construction

**Multi-entry per issuer URL:** `trustedIssuersByIssuer` is now `map[string][]TrustedIssuerConfig`. The correct entry is selected at request time by matching the token subject against `allowedClaims.sub`, so M2M and OBO entries can coexist for the same upstream STS (e.g. muster).

**`alias` is optional for M2M entries.** OBO entries still require a valid DNS-1123 alias (drives the Namespace + ClusterRole rendering in the chart).

**mcp-oauth bumped to v0.14.0** (`WorkloadGrantedIdentity` — `Granted.Subject` + `Granted.Groups`).

## Design

muster is the single authority for the K8s identity an agent acts as. It mints a token with `sub=<user>` and `groups=[<group>]` via a `workloadGroupGrant`. mcp-kubernetes is a pure projector: it maps the minted claims to impersonation headers and enforces exact allow-lists. Cluster RBAC (read-all) is bound to the agent group by rbac-operator, not by mcp-kubernetes.

This removes the `kagent-glean`-style alias namespace + per-alias Role/RoleBinding model. The agent group (`agent:sre`) is a single deterministic string across all clusters, independent of Dex connector prefix.

See `docs/trusted-issuer-m2m-obo.md` for the full model.

## Glean config

giantswarm-configs #717 has the matching `impersonateUser: agent:sre` / `impersonateGroups: [agent:sre]` config. management-clusters #2161 has the CRB binding `agent:sre` → `read-all`.