### PR TITLE
fix(server): deduplicate same-issuer TrustedIssuers for OIDCValidator

### DIFF
--- a/internal/server/oauth_http.go
+++ b/internal/server/oauth_http.go
@@ -325,6 +325,23 @@ func intersectGroups(allowList, tokenGroups []string) []string {
 
 // matchesSubGlob reports whether s matches a sub-claim pattern.
 // matchesSubGlob matches s against pattern using a single leading or trailing
+// unionStrings returns a slice containing all elements from a and b with
+// duplicates removed. Order is a first, then elements from b not already in a.
+func unionStrings(a, b []string) []string {
+	seen := make(map[string]struct{}, len(a))
+	result := make([]string, 0, len(a)+len(b))
+	for _, v := range a {
+		seen[v] = struct{}{}
+		result = append(result, v)
+	}
+	for _, v := range b {
+		if _, ok := seen[v]; !ok {
+			result = append(result, v)
+		}
+	}
+	return result
+}
+
 // wildcard (*). A leading * anchors to a suffix ("*@example.com" matches any
 // string ending in "@example.com"). A trailing * anchors to a prefix
 // ("system:serviceaccount:kagent:*" matches any SA in that namespace).
@@ -761,17 +778,50 @@ func createOAuthServer(config OAuthConfig) (*oauth.Server, storage.TokenStore, e
 	}
 
 	if len(config.TrustedIssuers) > 0 {
-		issuers := make([]oauthserver.TrustedIssuer, len(config.TrustedIssuers))
-		for i, ti := range config.TrustedIssuers {
-			issuers[i] = oauthserver.TrustedIssuer{
-				Issuer:             ti.Issuer,
-				JwksURL:            ti.JwksURL,
-				AllowedAudiences:   ti.AllowedAudiences,
-				AllowedClaims:      ti.AllowedClaims,
-				SubjectClaim:       ti.SubjectClaim,
-				AcceptedTypHeaders: ti.AcceptedTypHeaders,
-				AllowPrivateIPJWKS: ti.AllowPrivateIPJWKS,
+		// mcp-oauth's OIDCValidator is keyed map[issuerURL]TrustedIssuer; duplicate
+		// issuer URLs overwrite each other. When a single issuer hosts multiple trust
+		// domains (e.g. M2M SA sub + OBO email sub), deduplicate into one entry per
+		// issuer with unioned audiences. AllowedClaims is omitted for multi-entry
+		// issuers because per-entry subject matching runs in AccessTokenInjector.
+		type mergedIssuer struct {
+			oauthserver.TrustedIssuer
+			entryCount int
+		}
+		merged := make(map[string]*mergedIssuer, len(config.TrustedIssuers))
+		var issuerOrder []string
+		for _, ti := range config.TrustedIssuers {
+			if e, ok := merged[ti.Issuer]; !ok {
+				merged[ti.Issuer] = &mergedIssuer{
+					TrustedIssuer: oauthserver.TrustedIssuer{
+						Issuer:             ti.Issuer,
+						JwksURL:            ti.JwksURL,
+						AllowedAudiences:   ti.AllowedAudiences,
+						AllowedClaims:      ti.AllowedClaims,
+						SubjectClaim:       ti.SubjectClaim,
+						AcceptedTypHeaders: ti.AcceptedTypHeaders,
+						AllowPrivateIPJWKS: ti.AllowPrivateIPJWKS,
+					},
+					entryCount: 1,
+				}
+				issuerOrder = append(issuerOrder, ti.Issuer)
+			} else {
+				e.entryCount++
+				e.AllowedAudiences = unionStrings(e.AllowedAudiences, ti.AllowedAudiences)
+				if ti.AllowPrivateIPJWKS {
+					e.AllowPrivateIPJWKS = true
+				}
 			}
+		}
+		issuers := make([]oauthserver.TrustedIssuer, 0, len(merged))
+		for _, iss := range issuerOrder {
+			e := merged[iss]
+			if e.entryCount > 1 {
+				// Per-entry allowedClaims enforcement is in AccessTokenInjector; drop
+				// it here so a later entry's pattern cannot reject earlier entries' tokens.
+				e.AllowedClaims = nil
+				e.SubjectClaim = ""
+			}
+			issuers = append(issuers, e.TrustedIssuer)
 		}
 		opts = append(opts, oauthserver.WithTrustedIssuers(issuers))
 	}

--- a/internal/server/oauth_http_test.go
+++ b/internal/server/oauth_http_test.go
@@ -316,6 +316,66 @@ func TestCreateOAuthServerWithTrustedIssuers(t *testing.T) {
 	require.NotNil(t, oauthServer.Config)
 }
 
+// TestCreateOAuthServer_MultiEntryIssuerDeduplication verifies that two TrustedIssuerConfig
+// entries sharing an issuer URL are collapsed into a single oauthserver.TrustedIssuer
+// with unioned audiences and no AllowedClaims (which would reject valid tokens from
+// the other entry). Per-entry subject matching runs in AccessTokenInjector.
+func TestCreateOAuthServer_MultiEntryIssuerDeduplication(t *testing.T) {
+	// Two entries for the same issuer: M2M (SA sub) and OBO (email sub).
+	// Without deduplication the OIDCValidator map overwrites the first entry with
+	// the second; the second entry's allowedClaims.sub="*@giantswarm.io" would
+	// then reject M2M tokens whose sub="system:serviceaccount:kagent:sre-agent".
+	config := OAuthConfig{
+		BaseURL:            "https://mcp.example.com",
+		Provider:           OAuthProviderGoogle,
+		GoogleClientID:     "test-client-id",
+		GoogleClientSecret: "test-client-secret",
+		TrustedIssuers: []TrustedIssuerConfig{
+			{
+				Issuer:           "https://muster.example.com",
+				JwksURL:          "https://muster.example.com/.well-known/jwks.json",
+				AllowedAudiences: []string{"mcp-kubernetes"},
+				AllowedClaims:    map[string]string{"sub": "system:serviceaccount:kagent:sre-agent"},
+			},
+			{
+				Issuer:           "https://muster.example.com",
+				JwksURL:          "https://muster.example.com/.well-known/jwks.json",
+				AllowedAudiences: []string{"mcp-kubernetes"},
+				AllowedClaims:    map[string]string{"sub": "*@giantswarm.io"},
+			},
+		},
+	}
+
+	oauthServer, _, err := createOAuthServer(config)
+	require.NoError(t, err)
+	require.NotNil(t, oauthServer)
+}
+
+// TestUnionStrings verifies the helper used when deduplicating multi-entry issuers.
+func TestUnionStrings(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b []string
+		want []string
+	}{
+		{name: "both empty", a: nil, b: nil, want: []string{}},
+		{name: "b empty", a: []string{"x"}, b: nil, want: []string{"x"}},
+		{name: "a empty", a: nil, b: []string{"x"}, want: []string{"x"}},
+		{name: "disjoint", a: []string{"a"}, b: []string{"b"}, want: []string{"a", "b"}},
+		{name: "overlap", a: []string{"a", "b"}, b: []string{"b", "c"}, want: []string{"a", "b", "c"}},
+		{name: "identical", a: []string{"x"}, b: []string{"x"}, want: []string{"x"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := unionStrings(tc.a, tc.b)
+			if len(got) == 0 {
+				got = []string{}
+			}
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
 // TestCreateOAuthServerWithDexProvider tests Dex provider creation.
 //
 // Integration Test Requirements:


### PR DESCRIPTION
## Problem

mcp-oauth's `OIDCValidator` stores issuers in `map[string]TrustedIssuer` keyed by issuer URL (`subject_validator.go:142: m[ti.Issuer] = ti`). When two `TrustedIssuerConfig` entries share an issuer URL (M2M SA sub + OBO email sub for the same muster instance), the second entry overwrites the first. The second entry's `AllowedClaims` then applies to ALL tokens from that issuer at the OIDCValidator layer.

Concretely: OBO entry has `allowedClaims.sub: "*@giantswarm.io"`; M2M tokens have `sub=system:serviceaccount:kagent:sre-agent`; OIDCValidator rejects M2M tokens with `claim "sub": value "...sre-agent" does not match allowed pattern "*@giantswarm.io"`.

## Fix

Collapse same-issuer `TrustedIssuerConfig` entries into a single `oauthserver.TrustedIssuer`:
- Union `AllowedAudiences` across entries (all muster-minted tokens carry the same audience regardless of M2M vs OBO path).
- Propagate `AllowPrivateIPJWKS` if any entry sets it.
- Drop `AllowedClaims` and `SubjectClaim` for multi-entry issuers. Per-entry subject matching already runs in `AccessTokenInjector` (lines 1117-1124) after JWT validation passes.

Single-entry issuers retain `AllowedClaims` for defense-in-depth at the OIDCValidator layer.

## Verification

204 tests pass (+8 new: deduplication smoke test + `unionStrings` unit tests).