### PR TITLE
fix(middleware): bypass email check for trusted-issuer tokens in RequireIdentity

### DIFF
--- a/internal/server/middleware/identity.go
+++ b/internal/server/middleware/identity.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/giantswarm/mcp-oauth/handler"
+	"github.com/giantswarm/mcp-oauth/providers"
 	"github.com/giantswarm/mcp-oauth/security"
 )
 
@@ -39,6 +40,12 @@ func RequireIdentity(auditor *security.Auditor, logger *slog.Logger) func(http.H
 			}
 
 			if userInfo.Email != "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+			// Trusted-issuer tokens (M2M and OBO) carry no email in UserInfo;
+			// AccessTokenInjector handles their identity enforcement.
+			if userInfo.TokenSource == providers.TokenSourceTrustedIssuer {
 				next.ServeHTTP(w, r)
 				return
 			}


### PR DESCRIPTION
M2M tokens from muster carry `sub=system:serviceaccount:...` with no email claim. `RequireIdentity` rejected them unconditionally because `UserInfo.Email == ""`.

`AccessTokenInjector` already handles trusted-issuer token identity via `ImpersonateUser` config (no email needed). This patch skips the email gate for `TokenSourceTrustedIssuer`, letting M2M tokens reach the injector.