### PR TITLE
fix(impersonation): add system:authenticated to impersonated group set

### DIFF
--- a/internal/server/oauth_http.go
+++ b/internal/server/oauth_http.go
@@ -342,6 +342,15 @@ func unionStrings(a, b []string) []string {
 	return result
 }
 
+func appendIfMissing(slice []string, s string) []string {
+	for _, v := range slice {
+		if v == s {
+			return slice
+		}
+	}
+	return append(slice, s)
+}
+
 // wildcard (*). A leading * anchors to a suffix ("*@example.com" matches any
 // string ending in "@example.com"). A trailing * anchors to a prefix
 // ("system:serviceaccount:kagent:*" matches any SA in that namespace).
@@ -1232,9 +1241,10 @@ func (s *OAuthHTTPServer) createAccessTokenInjectorMiddleware(next http.Handler)
 
 				identity := k8s.ImpersonationIdentity{
 					UserName: userInfo.ID,
-					// No groups: user-only impersonation. kube-apiserver auto-adds
-					// system:authenticated. Human access is governed by RoleBindings
-					// to the user subject on each target cluster.
+					// system:authenticated must be explicit; impersonation does not
+					// inherit the real-auth group set. Human access is governed by
+					// RoleBindings to the user subject on each target cluster.
+					Groups: []string{"system:authenticated"},
 					Extra: map[string][]string{
 						"issuer": {userInfo.Issuer},
 						"agent":  {"mcp-kubernetes"},
@@ -1266,6 +1276,10 @@ func (s *OAuthHTTPServer) createAccessTokenInjectorMiddleware(next http.Handler)
 				http.Error(w, "forbidden: no permitted group in token", http.StatusForbidden)
 				return
 			}
+			// system:authenticated is not added automatically for impersonation (unlike
+			// real auth); without it the impersonated identity lacks system:discovery
+			// access and API resource enumeration silently returns empty results.
+			impersonateGroups = appendIfMissing(impersonateGroups, "system:authenticated")
 			identity := k8s.ImpersonationIdentity{
 				UserName: userInfo.ID,
 				Groups:   impersonateGroups,

--- a/internal/server/oauth_http_test.go
+++ b/internal/server/oauth_http_test.go
@@ -871,7 +871,7 @@ func TestAccessTokenInjectorMiddleware_M2MToken(t *testing.T) {
 		identity, ok := ImpersonationIdentityFromContext(capturedCtx)
 		require.True(t, ok)
 		require.Equal(t, agentUser, identity.UserName)
-		require.Equal(t, []string{agentGroup}, identity.Groups)
+		require.Equal(t, []string{agentGroup, "system:authenticated"}, identity.Groups)
 		require.Equal(t, []string{"cluster-a"}, identity.AllowedTargetClusters)
 		require.Equal(t, []string{testIssuer}, identity.Extra["issuer"])
 		require.Equal(t, []string{"mcp-kubernetes"}, identity.Extra["agent"])
@@ -947,6 +947,19 @@ func TestIntersectGroups(t *testing.T) {
 	})
 }
 
+func TestAppendIfMissing(t *testing.T) {
+	t.Run("appends when absent", func(t *testing.T) {
+		require.Equal(t, []string{"a", "b"}, appendIfMissing([]string{"a"}, "b"))
+	})
+	t.Run("no-op when present", func(t *testing.T) {
+		got := appendIfMissing([]string{"a", "b"}, "b")
+		require.Equal(t, []string{"a", "b"}, got)
+	})
+	t.Run("appends to nil slice", func(t *testing.T) {
+		require.Equal(t, []string{"x"}, appendIfMissing(nil, "x"))
+	})
+}
+
 func TestAccessTokenInjectorMiddleware_OBOToken(t *testing.T) {
 	const (
 		testIssuer    = "https://oidc.example.com"
@@ -997,7 +1010,7 @@ func TestAccessTokenInjectorMiddleware_OBOToken(t *testing.T) {
 		identity, ok := ImpersonationIdentityFromContext(capturedCtx)
 		require.True(t, ok)
 		require.Equal(t, humanSubject, identity.UserName)
-		require.Empty(t, identity.Groups, "OBO impersonates user-only; no groups must be set")
+		require.Equal(t, []string{"system:authenticated"}, identity.Groups)
 		require.Equal(t, agentSASub, identity.Actor)
 		require.Equal(t, []string{testIssuer}, identity.Extra["issuer"])
 		require.Equal(t, []string{"mcp-kubernetes"}, identity.Extra["agent"])
@@ -1036,7 +1049,7 @@ func TestAccessTokenInjectorMiddleware_OBOToken(t *testing.T) {
 		identity, ok := ImpersonationIdentityFromContext(capturedCtx)
 		require.True(t, ok)
 		require.Equal(t, "agent:bot", identity.UserName)
-		require.Equal(t, []string{"agent:bot"}, identity.Groups)
+		require.Equal(t, []string{"agent:bot", "system:authenticated"}, identity.Groups)
 		require.Empty(t, identity.Actor, "M2M path must not set Actor")
 	})
 
@@ -1356,7 +1369,7 @@ func TestAccessTokenInjectorMiddleware_SubjectClaim(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, userEmail, identity.UserName)
 		require.Equal(t, sreAgentSub, identity.Actor)
-		require.Empty(t, identity.Groups)
+		require.Equal(t, []string{"system:authenticated"}, identity.Groups)
 	})
 
 	t.Run("subject outside the email pattern returns 403", func(t *testing.T) {
@@ -1443,7 +1456,7 @@ func TestAccessTokenInjectorMiddleware_MultiIssuerURL(t *testing.T) {
 		identity, ok := ImpersonationIdentityFromContext(capturedCtx)
 		require.True(t, ok)
 		require.Equal(t, agentUser, identity.UserName)
-		require.Equal(t, []string{agentGroup}, identity.Groups)
+		require.Equal(t, []string{agentGroup, "system:authenticated"}, identity.Groups)
 	})
 
 	t.Run("OBO token routes to email-pattern entry", func(t *testing.T) {
@@ -1471,7 +1484,7 @@ func TestAccessTokenInjectorMiddleware_MultiIssuerURL(t *testing.T) {
 		identity, ok := ImpersonationIdentityFromContext(capturedCtx)
 		require.True(t, ok)
 		require.Equal(t, humanEmail, identity.UserName)
-		require.Empty(t, identity.Groups)
+		require.Equal(t, []string{"system:authenticated"}, identity.Groups)
 	})
 
 	t.Run("token subject matching neither entry returns 403", func(t *testing.T) {


### PR DESCRIPTION
## What

Both the M2M and OBO impersonation paths in `createAccessTokenInjectorMiddleware` were omitting `system:authenticated` from the impersonated group set.

## Why

Kubernetes impersonation does not inherit the effective groups from real authentication. `system:discovery` is bound to `system:authenticated`. Without that group in the Impersonate-Group headers, the impersonated identity cannot call `/api`, `/apis` etc. `ServerPreferredResources()` silently returns nil on the 403, resource resolution iterates an empty list, and tools return "unknown resource type: pods" instead of a useful error.

The OBO code comment even said "kube-apiserver auto-adds system:authenticated" — that is only true for real authentication, not impersonation.

## Changes

- M2M path: `appendIfMissing(impersonateGroups, "system:authenticated")` after the group intersection
- OBO path: `Groups: []string{"system:authenticated"}` explicitly set; wrong comment removed
- New `appendIfMissing` helper (idempotent, won't double-add)
- All existing M2M/OBO identity assertions updated; 3 new unit tests for `appendIfMissing`

Fixes the "unknown resource type" E2E failure on glean after impersonation RBAC was applied.