### PR TITLE
feat(m2m): pure-projector trusted-issuer path (subject + groups)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* `trustedIssuers[].subject` and `trustedIssuers[].groups`: M2M entries project an exact `subject` as `Impersonate-User` and the intersection of `groups` with the token's minted groups as `Impersonate-Group`. A token carrying none of the listed groups is rejected. The chart scopes the impersonation RBAC exactly to these values (`users`, or namespaced `serviceaccounts` for a service-account-form subject, on `subject`; `groups` on the listed groups), with no unrestricted grant. `allowedTargetClusters` is required on M2M entries.
 * `trustedIssuers[].subjectClaim`: names the verified claim whose value becomes the impersonated subject, replacing the standard `sub` (set to `email` for the muster-obo issuer). When set, the impersonated-subject pattern lives under that key in `allowedClaims` (e.g. `allowedClaims.email`), and the token is rejected if the claim is absent. The in-process subject gate and startup validation key off this claim.
 * The OBO actor allow-list now matches any actor in the RFC 8693 `act` delegation chain (`act`, `act.act`, ...), not only the leaf, so multi-hop A2A delegation (human via agent A via agent B) is authorized.
 * OBO (Phase 2): external-issuer tokens carrying an RFC 8693 `act` claim now take the OBO impersonation branch. `Impersonate-User` is set to the human subject; `Impersonate-Extra-actor` is set to the agent SA sub, so the kube-apiserver audit log records both parties. Tokens without an `act` claim continue to use the existing M2M path unchanged.
@@ -22,8 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* M2M trusted-issuer entries now identify themselves with `subject` + `groups` (pure projection) instead of an `alias`-derived `system:serviceaccount:<alias>:<saName>` principal and a pinned `system:serviceaccounts:<alias>` group. `alias` is now for OBO/SSO entries only and must be omitted on M2M entries; an M2M entry with `groups` set but no `subject`, or with no `allowedTargetClusters`, is rejected at startup. This is a breaking values change for M2M issuers.
 * `trustedIssuers[].allowedActors` is now a list of objects (`{sub, allowedSubjects}`) instead of a flat list of strings. This is a breaking values change. OBO is disabled for an issuer when `allowedActors` is empty or omitted.
-* **deps:** update module github.com/giantswarm/mcp-oauth to v0.10.2.
+* **deps:** update module github.com/giantswarm/mcp-oauth to v0.14.0.
 
 ## [0.1.113](https://github.com/giantswarm/mcp-kubernetes/compare/v0.1.112...v0.1.113) (2026-06-03)
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -438,11 +438,12 @@ Downstream OAuth (--downstream-oauth):
 }
 
 // validateEncryptionKey validates an AES-256 encryption key for security weaknesses
-// validateTrustedIssuers checks per-issuer invariants: a present issuer URL and
-// JWKS URL, a DNS-1123 alias, and a non-wildcard subject pattern under the
-// issuer's effective subject claim. Aliases must be unique across all entries.
-// Multiple entries may share the same issuer URL (e.g. M2M + OBO from the same
-// STS), provided their aliases differ.
+// validateTrustedIssuers checks per-issuer invariants:
+//   - M2M entries (groups set): must omit alias; subject required.
+//   - OBO/SSO entries: alias must be a valid DNS-1123 label and unique.
+//   - All entries: non-wildcard subject pattern under the effective subject claim.
+//
+// Multiple entries may share the same issuer URL (e.g. M2M + OBO from the same STS).
 func validateTrustedIssuers(issuers []server.TrustedIssuerConfig) error {
 	seenAliases := make(map[string]struct{}, len(issuers))
 	for _, ti := range issuers {
@@ -452,10 +453,29 @@ func validateTrustedIssuers(issuers []server.TrustedIssuerConfig) error {
 		if ti.JwksURL == "" {
 			return fmt.Errorf("trusted issuer %q: jwksURL is required", ti.Issuer)
 		}
-		if !isDNS1123Label(ti.Alias) {
-			return fmt.Errorf("trusted issuer %q: alias %q is not a valid DNS-1123 label "+
-				"(lowercase alphanumeric and hyphens, must start/end with alphanumeric, max 63 chars)",
-				ti.Issuer, ti.Alias)
+		if len(ti.Groups) > 0 {
+			// M2M entry.
+			if ti.Alias != "" {
+				return fmt.Errorf("trusted issuer %q: M2M entries (groups set) must not set alias", ti.Issuer)
+			}
+			if ti.Subject == "" {
+				return fmt.Errorf("trusted issuer %q: subject is required when groups is set", ti.Issuer)
+			}
+			if len(ti.AllowedTargetClusters) == 0 {
+				return fmt.Errorf("trusted issuer %q: allowedTargetClusters is required for M2M entries "+
+					"(empty would let a centrally minted token impersonate on any reachable cluster that trusts this issuer and group)", ti.Issuer)
+			}
+		} else {
+			// OBO/SSO entry.
+			if !isDNS1123Label(ti.Alias) {
+				return fmt.Errorf("trusted issuer %q: alias %q is not a valid DNS-1123 label "+
+					"(lowercase alphanumeric and hyphens, must start/end with alphanumeric, max 63 chars)",
+					ti.Issuer, ti.Alias)
+			}
+			if _, seen := seenAliases[ti.Alias]; seen {
+				return fmt.Errorf("trusted issuer %q: alias %q is already used by another issuer", ti.Issuer, ti.Alias)
+			}
+			seenAliases[ti.Alias] = struct{}{}
 		}
 		subjectKey := ti.EffectiveSubjectKey()
 		subPattern, hasSub := ti.AllowedClaims[subjectKey]
@@ -463,10 +483,6 @@ func validateTrustedIssuers(issuers []server.TrustedIssuerConfig) error {
 			return fmt.Errorf("trusted issuer %q: allowedClaims.%s must be a non-empty pattern "+
 				"that is not bare '*' (prevents any identity from being impersonated)", ti.Issuer, subjectKey)
 		}
-		if _, seen := seenAliases[ti.Alias]; seen {
-			return fmt.Errorf("trusted issuer %q: alias %q is already used by another issuer", ti.Issuer, ti.Alias)
-		}
-		seenAliases[ti.Alias] = struct{}{}
 	}
 	return nil
 }

--- a/cmd/trusted_issuers_test.go
+++ b/cmd/trusted_issuers_test.go
@@ -84,6 +84,52 @@ func TestValidateTrustedIssuers(t *testing.T) {
 				{Issuer: issuerURL, JwksURL: jwksURL, Alias: "muster-obo", SubjectClaim: "email", AllowedClaims: map[string]string{"email": "*@giantswarm.io"}},
 			},
 		},
+		{
+			name: "M2M entry with subject, groups and allowedTargetClusters is valid",
+			issuers: []server.TrustedIssuerConfig{{
+				Issuer:                issuerURL,
+				JwksURL:               jwksURL,
+				Subject:               "automation",
+				Groups:                []string{"platform-admins"},
+				AllowedTargetClusters: []string{"graveler"},
+				AllowedClaims:         map[string]string{"sub": "system:serviceaccount:automation:*"},
+			}},
+		},
+		{
+			name: "M2M entry with an alias is rejected",
+			issuers: []server.TrustedIssuerConfig{{
+				Issuer:                issuerURL,
+				JwksURL:               jwksURL,
+				Alias:                 "glean",
+				Subject:               "automation",
+				Groups:                []string{"platform-admins"},
+				AllowedTargetClusters: []string{"graveler"},
+				AllowedClaims:         map[string]string{"sub": "system:serviceaccount:automation:*"},
+			}},
+			wantError: true,
+		},
+		{
+			name: "M2M entry with groups but no subject is rejected",
+			issuers: []server.TrustedIssuerConfig{{
+				Issuer:                issuerURL,
+				JwksURL:               jwksURL,
+				Groups:                []string{"platform-admins"},
+				AllowedTargetClusters: []string{"graveler"},
+				AllowedClaims:         map[string]string{"sub": "system:serviceaccount:automation:*"},
+			}},
+			wantError: true,
+		},
+		{
+			name: "M2M entry without allowedTargetClusters is rejected",
+			issuers: []server.TrustedIssuerConfig{{
+				Issuer:        issuerURL,
+				JwksURL:       jwksURL,
+				Subject:       "automation",
+				Groups:        []string{"platform-admins"},
+				AllowedClaims: map[string]string{"sub": "system:serviceaccount:automation:*"},
+			}},
+			wantError: true,
+		},
 	}
 
 	for _, tc := range tests {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.26.4
 
 require (
 	github.com/creativeprojects/go-selfupdate v1.5.2
-	github.com/giantswarm/mcp-oauth v0.13.2
+	github.com/giantswarm/mcp-oauth v0.14.0
 	github.com/giantswarm/mcp-toolkit v0.2.9
 	github.com/mark3labs/mcp-go v0.55.0
 	github.com/prometheus/client_golang v1.23.2

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/giantswarm/mcp-oauth v0.13.2 h1:4uwFEZ+B1KMxCCDbIZKw6BHJsRSE3Oy1Q6XuE+AtmKE=
-github.com/giantswarm/mcp-oauth v0.13.2/go.mod h1:Z/f5JZAz6JGs8A++hfXPUIN4CR1yuMb9cXRx4qrzzIA=
+github.com/giantswarm/mcp-oauth v0.14.0 h1:Znm9cMGjBS0wahVB27V4SrA1SORLYpcaJD6RR5fIZZ0=
+github.com/giantswarm/mcp-oauth v0.14.0/go.mod h1:Z/f5JZAz6JGs8A++hfXPUIN4CR1yuMb9cXRx4qrzzIA=
 github.com/giantswarm/mcp-toolkit v0.2.9 h1:U6HhPlHX5+SuCKqZWWMXzcmJmhdcZrobhOsq/+LpiVg=
 github.com/giantswarm/mcp-toolkit v0.2.9/go.mod h1:jwOmxo8+MCPJ6HHPRqFkI6S48A/cbqXOzvT5bydbRds=
 github.com/go-fed/httpsig v1.1.0 h1:9M+hb0jkEICD8/cAiNqEB66R87tTINszBRTjwjQzWcI=

--- a/helm/mcp-kubernetes/templates/rbac.yaml
+++ b/helm/mcp-kubernetes/templates/rbac.yaml
@@ -657,4 +657,107 @@ subjects:
 {{- end }}
 {{- end }}
 {{- end }}
+{{/*
+M2M pure-projector RBAC (entries with subject + groups, no alias).
+
+muster asserts the subject and groups; this grants the mck8s ServiceAccount
+permission to set the Impersonate-User / Impersonate-Group / Impersonate-Extra
+headers. Both gates are exact: impersonate-users (or -serviceaccounts) is scoped
+to resourceName = subject and impersonate-groups to resourceNames = groups, so no
+unrestricted grant is needed. Target-cluster authorization (what the impersonated
+group may actually do) is bound per-cluster via shared-configs, not here.
+
+A subject in service-account form (system:serviceaccount:<ns>:<name>) is granted
+via a namespaced Role scoped to that namespace and name; any other subject is
+treated as a user. Naming is keyed on a hash of issuer+subject so entries sharing
+a subject across issuers do not collide.
+*/}}
+{{- range .Values.mcpKubernetes.oauth.trustedIssuers }}
+{{- if and (not .alias) .subject .groups }}
+{{- $key := printf "%s|%s" .issuer .subject | sha256sum | trunc 10 }}
+{{- $parts := splitList ":" .subject }}
+{{- $isSA := and (eq (len $parts) 4) (eq (index $parts 0) "system") (eq (index $parts 1) "serviceaccount") }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "mcp-kubernetes.fullname" $ }}-m2m-proj-{{ $key }}
+  labels:
+    {{- include "mcp-kubernetes.labels" $ | nindent 4 }}
+  annotations:
+    mcp-kubernetes.giantswarm.io/m2m-issuer: {{ .issuer | quote }}
+    mcp-kubernetes.giantswarm.io/m2m-subject: {{ .subject | quote }}
+rules:
+  - apiGroups: [""]
+    resources: ["groups"]
+    verbs: ["impersonate"]
+    resourceNames:
+      {{- range .groups }}
+      - {{ . | quote }}
+      {{- end }}
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["userextras/agent"]
+    verbs: ["impersonate"]
+    resourceNames: ["mcp-kubernetes"]
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["userextras/issuer"]
+    verbs: ["impersonate"]
+    resourceNames: [{{ .issuer | quote }}]
+{{- if not $isSA }}
+  - apiGroups: [""]
+    resources: ["users"]
+    verbs: ["impersonate"]
+    resourceNames: [{{ .subject | quote }}]
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "mcp-kubernetes.fullname" $ }}-m2m-proj-{{ $key }}
+  labels:
+    {{- include "mcp-kubernetes.labels" $ | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "mcp-kubernetes.fullname" $ }}-m2m-proj-{{ $key }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "mcp-kubernetes.serviceAccountName" $ }}
+    namespace: {{ $.Release.Namespace }}
+{{- if $isSA }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "mcp-kubernetes.fullname" $ }}-m2m-proj-{{ $key }}
+  namespace: {{ index $parts 2 }}
+  labels:
+    {{- include "mcp-kubernetes.labels" $ | nindent 4 }}
+  annotations:
+    mcp-kubernetes.giantswarm.io/m2m-issuer: {{ .issuer | quote }}
+    mcp-kubernetes.giantswarm.io/m2m-subject: {{ .subject | quote }}
+rules:
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["impersonate"]
+    resourceNames: [{{ index $parts 3 | quote }}]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "mcp-kubernetes.fullname" $ }}-m2m-proj-{{ $key }}
+  namespace: {{ index $parts 2 }}
+  labels:
+    {{- include "mcp-kubernetes.labels" $ | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "mcp-kubernetes.fullname" $ }}-m2m-proj-{{ $key }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "mcp-kubernetes.serviceAccountName" $ }}
+    namespace: {{ $.Release.Namespace }}
+{{- end }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/helm/mcp-kubernetes/tests/rbac_test.yaml
+++ b/helm/mcp-kubernetes/tests/rbac_test.yaml
@@ -973,3 +973,86 @@ tests:
               - "https://issuer-a.example.com"
               - "https://issuer-b.example.com"
         documentIndex: 5
+
+  # ==========================================
+  # M2M pure-projector (subject + groups, no alias)
+  # ==========================================
+
+  - it: should create exact-scoped user impersonation RBAC for an M2M pure-projector entry
+    set:
+      serviceAccount.create: true
+      rbac.create: true
+      capiMode.enabled: false
+      mcpKubernetes.oauth.enabled: true
+      mcpKubernetes.oauth.trustedIssuers:
+        - issuer: "https://muster.example.com"
+          jwksURL: "https://muster.example.com/jwks"
+          subject: "automation"
+          groups: ["platform-admins"]
+          allowedTargetClusters: ["cluster-a"]
+    asserts:
+      # basic ClusterRole+CRB (0,1) + m2m-proj ClusterRole+CRB (2,3)
+      - hasDocuments:
+          count: 4
+      - isKind:
+          of: ClusterRole
+        documentIndex: 2
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["groups"]
+            verbs: ["impersonate"]
+            resourceNames:
+              - "platform-admins"
+        documentIndex: 2
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["users"]
+            verbs: ["impersonate"]
+            resourceNames:
+              - "automation"
+        documentIndex: 2
+
+  - it: should scope a service-account-form M2M subject via a namespaced Role
+    set:
+      serviceAccount.create: true
+      rbac.create: true
+      capiMode.enabled: false
+      mcpKubernetes.oauth.enabled: true
+      mcpKubernetes.oauth.trustedIssuers:
+        - issuer: "https://muster.example.com/ci"
+          jwksURL: "https://muster.example.com/jwks"
+          subject: "system:serviceaccount:robots:ci"
+          groups: ["ci-runners"]
+          allowedTargetClusters: ["cluster-a"]
+    asserts:
+      # basic ClusterRole+CRB (0,1) + m2m-proj ClusterRole+CRB (2,3) + Role+RoleBinding (4,5)
+      - hasDocuments:
+          count: 6
+      - isKind:
+          of: Role
+        documentIndex: 4
+      - equal:
+          path: metadata.namespace
+          value: robots
+        documentIndex: 4
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["serviceaccounts"]
+            verbs: ["impersonate"]
+            resourceNames:
+              - "ci"
+        documentIndex: 4
+      # no unrestricted users rule on the SA-form ClusterRole
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["users"]
+            verbs: ["impersonate"]
+        documentIndex: 2

--- a/helm/mcp-kubernetes/values.schema.json
+++ b/helm/mcp-kubernetes/values.schema.json
@@ -563,8 +563,19 @@
                   },
                   "alias": {
                     "type": "string",
-                    "description": "Required for M2M issuers. Stable short identifier used as the namespace name and in the impersonated subject: system:serviceaccount:<alias>:<saName>. Omit for OBO-only issuers (e.g. muster) where the human email is impersonated directly. Must be unique across all trusted issuers.",
+                    "description": "OBO/SSO issuers only. Stable short identifier used as the per-issuer namespace name and in the users/userextras impersonation ClusterRole. Must be omitted on M2M entries (which use subject + groups). Must be unique across all trusted issuers.",
                     "pattern": "^[a-z0-9][a-z0-9-]*[a-z0-9]$"
+                  },
+                  "subject": {
+                    "type": "string",
+                    "description": "M2M entries only. Exact subject this entry may project as Impersonate-User. The token's effective subject (after any subjectClaim remap) must equal this value verbatim. Requires groups and allowedTargetClusters; must not be combined with alias."
+                  },
+                  "groups": {
+                    "type": "array",
+                    "description": "M2M entries only. Exact allow-list of groups an M2M token may project as Impersonate-Group. The intersection of this list and the token's minted groups becomes the impersonated groups; a token carrying none of them is rejected. Requires subject.",
+                    "items": {
+                      "type": "string"
+                    }
                   },
                   "allowedAudiences": {
                     "type": "array",
@@ -575,7 +586,7 @@
                   },
                   "allowedTargetClusters": {
                     "type": "array",
-                    "description": "Optional list of workload cluster names this issuer's tokens may target. Empty list allows all clusters. Use to scope blast radius when federation is enabled.",
+                    "description": "List of workload cluster names this issuer's tokens may target. Required for M2M entries (an empty list there would let a centrally minted token impersonate on any reachable cluster trusting this issuer and group). For OBO/SSO an empty list allows all clusters.",
                     "items": {
                       "type": "string"
                     }

--- a/helm/mcp-kubernetes/values.yaml
+++ b/helm/mcp-kubernetes/values.yaml
@@ -546,34 +546,35 @@ mcpKubernetes:
     #                   scoping is enforced in-process by mcp-kubernetes before any
     #                   impersonation call reaches the kube-apiserver.
     #
-    # alias (optional): when set, the chart creates a <alias> namespace, a
-    # namespaced Role granting `impersonate serviceaccounts` in that namespace,
-    # and a ClusterRole granting `impersonate groups/extras` scoped to the alias.
-    # Required for M2M issuers (SA token impersonation). Omit for OBO-only
-    # issuers such as a muster token exchange endpoint, where the impersonated
-    # identity is the human email directly. Per-alias RBAC is only generated
-    # when serviceAccount.create and rbac.create are both true.
+    # M2M entries (subject + groups): muster asserts the subject and groups in the
+    # minted token; this entry projects them as Impersonate-User / Impersonate-Group.
+    #   subject:  required. Exact subject the entry may project. The token's effective
+    #             subject (after any subjectClaim remap) must equal it verbatim.
+    #   groups:   required. Exact allow-list of groups. The intersection with the
+    #             token's minted groups becomes Impersonate-Group; a token carrying
+    #             none of them is rejected.
+    #   allowedTargetClusters: required for M2M (an empty list would let a centrally
+    #             minted token impersonate on any reachable cluster trusting this
+    #             issuer and group).
+    #   M2M entries must NOT set alias. The chart grants the mck8s SA exact
+    #   impersonate-users (or -serviceaccounts) on subject and impersonate-groups on
+    #   groups; no unrestricted grant. Target-cluster authz is bound per-cluster via
+    #   shared-configs, not here.
     #
-    # Example (M2M only):
-    #   - issuer: "https://oidc.example.com/glean"
-    #     jwksURL: "https://oidc.example.com/glean/.well-known/jwks.json"
-    #     alias: "glean"
+    # alias (OBO/SSO only): when set, the chart creates a <alias> namespace and a
+    # ClusterRole granting `impersonate users/groups/extras` for human impersonation.
+    # Required on OBO/SSO entries; must be omitted on M2M entries. Per-alias RBAC is
+    # only generated when serviceAccount.create and rbac.create are both true.
+    #
+    # Example (M2M, pure projector):
+    #   - issuer: "https://muster.example.com"
+    #     jwksURL: "https://muster.example.com/.well-known/jwks.json"
+    #     subject: "automation"
+    #     groups: ["platform-admins"]
     #     allowedAudiences: ["https://mcp.example.com"]
     #     allowedTargetClusters: ["cluster-a", "cluster-b"]
-    #
-    # Example (M2M + OBO, glob subjects):
-    #   - issuer: "https://oidc.example.com/glean"
-    #     jwksURL: "https://oidc.example.com/glean/.well-known/jwks.json"
-    #     alias: "glean"
     #     allowedClaims:
-    #       sub: "system:serviceaccount:kagent:*"
-    #     allowedActors:
-    #       - sub: "system:serviceaccount:kagent:my-agent"
-    #         allowedSubjects:
-    #           - "*@example.com"
-    #       - sub: "system:serviceaccount:kagent:headless-agent"
-    #         # empty allowedSubjects: this actor may impersonate any human
-    #         # whose sub matches allowedClaims.sub
+    #       sub: "system:serviceaccount:automation:*"
     #
     # Example (OBO-only issuer, e.g. muster token exchange endpoint). muster keeps
     # sub opaque and carries the human in the email claim, so subjectClaim remaps

--- a/internal/server/oauth_http.go
+++ b/internal/server/oauth_http.go
@@ -13,8 +13,6 @@ import (
 	"strings"
 	"time"
 
-	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
-
 	oauth "github.com/giantswarm/mcp-oauth"
 	"github.com/giantswarm/mcp-oauth/handler"
 	oauthinstrumentation "github.com/giantswarm/mcp-oauth/instrumentation"
@@ -298,9 +296,31 @@ type OAuthConfig struct {
 	TrustedIssuers []TrustedIssuerConfig
 }
 
-// isDNS1123Label reports whether s is a valid Kubernetes DNS-1123 label.
-func isDNS1123Label(s string) bool {
-	return len(k8svalidation.IsDNS1123Label(s)) == 0
+// intersectGroups returns the members of tokenGroups present in allowList,
+// preserving allowList order and dropping duplicates. It is the allow-list gate
+// for M2M group impersonation: only configured groups carried by the token are
+// honored.
+func intersectGroups(allowList, tokenGroups []string) []string {
+	if len(allowList) == 0 || len(tokenGroups) == 0 {
+		return nil
+	}
+	present := make(map[string]struct{}, len(tokenGroups))
+	for _, g := range tokenGroups {
+		present[g] = struct{}{}
+	}
+	var matched []string
+	seen := make(map[string]struct{}, len(allowList))
+	for _, g := range allowList {
+		if _, ok := present[g]; !ok {
+			continue
+		}
+		if _, dup := seen[g]; dup {
+			continue
+		}
+		seen[g] = struct{}{}
+		matched = append(matched, g)
+	}
+	return matched
 }
 
 // matchesSubGlob reports whether s matches a sub-claim pattern.
@@ -372,10 +392,25 @@ type TrustedIssuerConfig struct {
 	Issuer string `json:"issuer"`
 	// JwksURL is the JWKS endpoint used to verify signatures.
 	JwksURL string `json:"jwksURL"`
-	// Alias is a required stable short identifier for this issuer (e.g. "glean", "mc-foo").
-	// It is encoded into the impersonated principal as the namespace component:
-	// system:serviceaccount:<alias>:<saName>
-	Alias string `json:"alias"`
+	// Alias is a stable short identifier for an OBO issuer (e.g. "muster-obo"). The
+	// chart keys the per-alias Namespace and users/userextras impersonation ClusterRole
+	// on this value. Required on OBO entries; must be omitted on M2M entries (which
+	// identify themselves via Subject / Groups instead).
+	Alias string `json:"alias,omitempty"`
+	// Subject is the exact subject this M2M entry may project as Impersonate-User.
+	// The token's effective subject (userInfo.ID, after any SubjectClaim remap) must
+	// equal this value verbatim; no glob matching applies (use AllowedClaims for
+	// routing patterns). The chart scopes the mck8s ServiceAccount's impersonate-users
+	// RBAC resourceName to exactly this value. Empty disables the M2M path for this
+	// issuer. Must be paired with a non-empty Groups.
+	Subject string `json:"subject,omitempty"`
+	// Groups is the exact allow-list of groups an M2M token from this issuer may
+	// project as Impersonate-Group. The intersection of this list and the token's
+	// minted groups claim becomes the set of impersonated groups; a token carrying
+	// none of these groups is rejected. The chart scopes the mck8s ServiceAccount's
+	// impersonate-groups RBAC resourceNames to exactly this list. Empty disables the
+	// M2M path for this issuer. Must be paired with a non-empty Subject.
+	Groups []string `json:"groups,omitempty"`
 	// AllowedAudiences restricts accepted `aud` values. Empty means any audience.
 	AllowedAudiences []string `json:"allowedAudiences,omitempty"`
 	// AllowedTargetClusters limits which management/workload cluster names this
@@ -1091,13 +1126,6 @@ func (s *OAuthHTTPServer) createAccessTokenInjectorMiddleware(next http.Handler)
 				http.Error(w, "forbidden: subject does not match allowed pattern", http.StatusForbidden)
 				return
 			}
-			if tiConfig.Alias == "" {
-				slog.Warn("AccessTokenInjector: trusted issuer has no alias configured",
-					"issuer", userInfo.Issuer)
-				http.Error(w, "internal configuration error: issuer alias missing", http.StatusInternalServerError)
-				return
-			}
-
 			// OBO path (Phase 2): sub=human, act.sub=agent SA.
 			// Impersonate the human subject; record the agent SA as the actor so the
 			// kube-apiserver audit log shows "human X via agent Z".
@@ -1169,37 +1197,34 @@ func (s *OAuthHTTPServer) createAccessTokenInjectorMiddleware(next http.Handler)
 				return
 			}
 
-			// M2M path (Phase 1B): sub=agent SA, no act claim.
-			// K8s SA token sub: "system:serviceaccount:<ns>:<name>" → extract <name>.
-			saName := userInfo.ID
-			if parts := strings.SplitN(userInfo.ID, ":", 4); len(parts) == 4 && parts[0] == "system" && parts[1] == "serviceaccount" {
-				saName = parts[3]
-			}
-			if saName == "" {
-				slog.Warn("AccessTokenInjector: empty service account name in token sub, rejecting",
-					"issuer", userInfo.Issuer)
-				http.Error(w, "forbidden: empty service account name", http.StatusForbidden)
+			// M2M path: pure projection. muster asserted the subject (GrantedSubject
+			// in mcp-oauth); Subject is the final exact gate here. The intersection of
+			// Groups and the minted token groups becomes Impersonate-Group; cluster
+			// RBAC (bound to the group) authorizes.
+			if tiConfig.Subject != userInfo.ID {
+				slog.Warn("AccessTokenInjector: M2M subject does not match configured subject, rejecting",
+					"issuer", userInfo.Issuer, "subject", userInfo.ID)
+				http.Error(w, "forbidden: subject not permitted for impersonation", http.StatusForbidden)
 				return
 			}
-			if !isDNS1123Label(saName) {
-				slog.Warn("AccessTokenInjector: service account name is not a valid DNS-1123 label, rejecting",
-					"issuer", userInfo.Issuer)
-				http.Error(w, "forbidden: invalid service account name", http.StatusForbidden)
+			impersonateGroups := intersectGroups(tiConfig.Groups, userInfo.Groups)
+			if len(impersonateGroups) == 0 {
+				slog.Warn("AccessTokenInjector: M2M token carries no allow-listed group, rejecting",
+					"issuer", userInfo.Issuer, "subject", userInfo.ID)
+				http.Error(w, "forbidden: no permitted group in token", http.StatusForbidden)
 				return
 			}
-			qualifiedUserName := "system:serviceaccount:" + tiConfig.Alias + ":" + saName
-			// Groups are pinned to the per-alias group; SA token group claims are not
-			// forwarded because they reflect the source namespace and would be rejected
-			// by the kube-apiserver impersonation RBAC.
 			identity := k8s.ImpersonationIdentity{
-				UserName: qualifiedUserName,
-				Groups:   []string{"system:serviceaccounts:" + tiConfig.Alias},
+				UserName: userInfo.ID,
+				Groups:   impersonateGroups,
 				Extra: map[string][]string{
 					"issuer": {userInfo.Issuer},
 					"agent":  {"mcp-kubernetes"},
 				},
 				AllowedTargetClusters: tiConfig.AllowedTargetClusters,
 			}
+			slog.Debug("AccessTokenInjector: M2M group impersonation",
+				"issuer", userInfo.Issuer, "subject", userInfo.ID, "groups", impersonateGroups)
 
 			ctx = ContextWithImpersonationIdentity(ctx, identity)
 			r = r.WithContext(ctx)

--- a/internal/server/oauth_http_test.go
+++ b/internal/server/oauth_http_test.go
@@ -772,28 +772,31 @@ func makeIssuerMap(c TrustedIssuerConfig) map[string][]TrustedIssuerConfig {
 func TestAccessTokenInjectorMiddleware_M2MToken(t *testing.T) {
 	const (
 		testIssuer = "https://oidc.example.com"
-		testAlias  = "glean"
+		agentUser  = "agent:sre"
+		agentGroup = "agent:sre"
 	)
 	issuerMap := makeIssuerMap(TrustedIssuerConfig{
 		Issuer:                testIssuer,
 		JwksURL:               "https://oidc.example.com/.well-known/jwks.json",
-		Alias:                 testAlias,
+		Subject:               agentUser,
+		Groups:                []string{agentGroup},
 		AllowedTargetClusters: []string{"cluster-a"},
-		AllowedClaims:         map[string]string{"sub": "system:serviceaccount:kagent:*"},
+		AllowedClaims:         map[string]string{"sub": agentUser},
 	})
 
-	newReq := func(issuer, id string) *http.Request {
+	newReq := func(issuer, id string, groups []string) *http.Request {
 		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
 		req.Header.Set("Authorization", "Bearer fake-m2m-token") //nolint:gosec // G101: test fixture
 		userInfo := &providers.UserInfo{
 			ID:          id,
 			Issuer:      issuer,
+			Groups:      groups,
 			TokenSource: providers.TokenSourceTrustedIssuer,
 		}
 		return req.WithContext(handler.ContextWithUserInfo(req.Context(), userInfo))
 	}
 
-	t.Run("K8s SA sub yields <alias>:<name>", func(t *testing.T) {
+	t.Run("sub matches subject and group intersects", func(t *testing.T) {
 		var capturedCtx context.Context
 		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			capturedCtx = r.Context()
@@ -802,77 +805,57 @@ func TestAccessTokenInjectorMiddleware_M2MToken(t *testing.T) {
 		s := &OAuthHTTPServer{trustedIssuersByIssuer: issuerMap}
 
 		rr := httptest.NewRecorder()
-		s.createAccessTokenInjectorMiddleware(next).ServeHTTP(rr, newReq(testIssuer, "system:serviceaccount:kagent:my-agent"))
+		s.createAccessTokenInjectorMiddleware(next).ServeHTTP(rr, newReq(testIssuer, agentUser, []string{agentGroup}))
 
 		require.Equal(t, http.StatusOK, rr.Code)
 		identity, ok := ImpersonationIdentityFromContext(capturedCtx)
 		require.True(t, ok)
-		require.Equal(t, "system:serviceaccount:glean:my-agent", identity.UserName)
-		require.Equal(t, []string{"system:serviceaccounts:glean"}, identity.Groups)
+		require.Equal(t, agentUser, identity.UserName)
+		require.Equal(t, []string{agentGroup}, identity.Groups)
 		require.Equal(t, []string{"cluster-a"}, identity.AllowedTargetClusters)
 		require.Equal(t, []string{testIssuer}, identity.Extra["issuer"])
 		require.Equal(t, []string{"mcp-kubernetes"}, identity.Extra["agent"])
 	})
 
-	t.Run("non-K8s sub used verbatim", func(t *testing.T) {
-		var capturedCtx context.Context
-		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			capturedCtx = r.Context()
-			w.WriteHeader(http.StatusOK)
-		})
-		nonK8sMap := makeIssuerMap(TrustedIssuerConfig{
-			Issuer:        testIssuer,
-			JwksURL:       "https://oidc.example.com/.well-known/jwks.json",
-			Alias:         testAlias,
-			AllowedClaims: map[string]string{"sub": "pipeline-*"},
-		})
-		s := &OAuthHTTPServer{trustedIssuersByIssuer: nonK8sMap}
-
+	t.Run("sub not matching subject returns 403", func(t *testing.T) {
+		s := &OAuthHTTPServer{trustedIssuersByIssuer: issuerMap}
 		rr := httptest.NewRecorder()
-		s.createAccessTokenInjectorMiddleware(next).ServeHTTP(rr, newReq(testIssuer, "pipeline-bot"))
-
-		require.Equal(t, http.StatusOK, rr.Code)
-		identity, ok := ImpersonationIdentityFromContext(capturedCtx)
-		require.True(t, ok)
-		require.Equal(t, "system:serviceaccount:glean:pipeline-bot", identity.UserName)
-		require.Equal(t, []string{"system:serviceaccounts:glean"}, identity.Groups)
+		s.createAccessTokenInjectorMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})).ServeHTTP(rr, newReq(testIssuer, "agent:other", []string{agentGroup}))
+		require.Equal(t, http.StatusForbidden, rr.Code)
 	})
 
-	t.Run("missing allowedClaims sub returns 403", func(t *testing.T) {
+	t.Run("token carrying no allow-listed group returns 403", func(t *testing.T) {
+		s := &OAuthHTTPServer{trustedIssuersByIssuer: issuerMap}
+		rr := httptest.NewRecorder()
+		s.createAccessTokenInjectorMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})).ServeHTTP(rr, newReq(testIssuer, agentUser, []string{"some:other-group"}))
+		require.Equal(t, http.StatusForbidden, rr.Code)
+	})
+
+	t.Run("missing allowedClaims.sub returns 403", func(t *testing.T) {
 		noClaimsMap := makeIssuerMap(TrustedIssuerConfig{
 			Issuer:  testIssuer,
 			JwksURL: "https://oidc.example.com/.well-known/jwks.json",
-			Alias:   testAlias,
+			Subject: agentUser,
+			Groups:  []string{agentGroup},
 		})
 		s := &OAuthHTTPServer{trustedIssuersByIssuer: noClaimsMap}
 		rr := httptest.NewRecorder()
 		s.createAccessTokenInjectorMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
-		})).ServeHTTP(rr, newReq(testIssuer, "system:serviceaccount:kagent:bot"))
+		})).ServeHTTP(rr, newReq(testIssuer, agentUser, []string{agentGroup}))
 		require.Equal(t, http.StatusForbidden, rr.Code)
 	})
 
-	t.Run("sub not matching allowedClaims pattern returns 403", func(t *testing.T) {
+	t.Run("sub not matching allowedClaims routing pattern returns 403", func(t *testing.T) {
 		s := &OAuthHTTPServer{trustedIssuersByIssuer: issuerMap}
 		rr := httptest.NewRecorder()
 		s.createAccessTokenInjectorMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
-		})).ServeHTTP(rr, newReq(testIssuer, "system:serviceaccount:other-ns:attacker"))
-		require.Equal(t, http.StatusForbidden, rr.Code)
-	})
-
-	t.Run("invalid DNS-1123 saName returns 403", func(t *testing.T) {
-		badSubMap := makeIssuerMap(TrustedIssuerConfig{
-			Issuer:        testIssuer,
-			JwksURL:       "https://oidc.example.com/.well-known/jwks.json",
-			Alias:         testAlias,
-			AllowedClaims: map[string]string{"sub": "*"},
-		})
-		s := &OAuthHTTPServer{trustedIssuersByIssuer: badSubMap}
-		rr := httptest.NewRecorder()
-		s.createAccessTokenInjectorMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(http.StatusOK)
-		})).ServeHTTP(rr, newReq(testIssuer, "Bad_Name"))
+		})).ServeHTTP(rr, newReq(testIssuer, "attacker:imposter", []string{agentGroup}))
 		require.Equal(t, http.StatusForbidden, rr.Code)
 	})
 
@@ -881,22 +864,26 @@ func TestAccessTokenInjectorMiddleware_M2MToken(t *testing.T) {
 		rr := httptest.NewRecorder()
 		s.createAccessTokenInjectorMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
-		})).ServeHTTP(rr, newReq("https://unknown.example.com", "system:serviceaccount:kagent:bot"))
+		})).ServeHTTP(rr, newReq("https://unknown.example.com", agentUser, []string{agentGroup}))
 		require.Equal(t, http.StatusForbidden, rr.Code)
 	})
+}
 
-	t.Run("alias empty returns 500", func(t *testing.T) {
-		noAlias := makeIssuerMap(TrustedIssuerConfig{
-			Issuer:        testIssuer,
-			JwksURL:       "https://oidc.example.com/.well-known/jwks.json",
-			AllowedClaims: map[string]string{"sub": "system:serviceaccount:kagent:*"},
-		})
-		s := &OAuthHTTPServer{trustedIssuersByIssuer: noAlias}
-		rr := httptest.NewRecorder()
-		s.createAccessTokenInjectorMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(http.StatusOK)
-		})).ServeHTTP(rr, newReq(testIssuer, "system:serviceaccount:kagent:bot"))
-		require.Equal(t, http.StatusInternalServerError, rr.Code)
+func TestIntersectGroups(t *testing.T) {
+	t.Run("intersection preserves allowList order", func(t *testing.T) {
+		require.Equal(t, []string{"b", "a"}, intersectGroups([]string{"b", "a", "c"}, []string{"a", "b", "d"}))
+	})
+	t.Run("deduplicates within allowList", func(t *testing.T) {
+		require.Equal(t, []string{"x"}, intersectGroups([]string{"x", "x"}, []string{"x"}))
+	})
+	t.Run("empty allowList returns nil", func(t *testing.T) {
+		require.Nil(t, intersectGroups(nil, []string{"a"}))
+	})
+	t.Run("empty tokenGroups returns nil", func(t *testing.T) {
+		require.Nil(t, intersectGroups([]string{"a"}, nil))
+	})
+	t.Run("no overlap returns nil", func(t *testing.T) {
+		require.Nil(t, intersectGroups([]string{"a"}, []string{"b"}))
 	})
 }
 
@@ -966,8 +953,9 @@ func TestAccessTokenInjectorMiddleware_OBOToken(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
 		req.Header.Set("Authorization", "Bearer fake-m2m-token") //nolint:gosec // G101: test fixture
 		userInfo := &providers.UserInfo{
-			ID:          "system:serviceaccount:kagent:bot",
+			ID:          "agent:bot",
 			Issuer:      testIssuer,
+			Groups:      []string{"agent:bot"},
 			TokenSource: providers.TokenSourceTrustedIssuer,
 			// ActorSubject intentionally absent
 		}
@@ -976,8 +964,9 @@ func TestAccessTokenInjectorMiddleware_OBOToken(t *testing.T) {
 		m2mMap := makeIssuerMap(TrustedIssuerConfig{
 			Issuer:        testIssuer,
 			JwksURL:       "https://oidc.example.com/.well-known/jwks.json",
-			Alias:         testAlias,
-			AllowedClaims: map[string]string{"sub": "system:serviceaccount:kagent:*"},
+			Subject:       "agent:bot",
+			Groups:        []string{"agent:bot"},
+			AllowedClaims: map[string]string{"sub": "agent:bot"},
 		})
 		s := &OAuthHTTPServer{trustedIssuersByIssuer: m2mMap}
 		rr := httptest.NewRecorder()
@@ -986,7 +975,8 @@ func TestAccessTokenInjectorMiddleware_OBOToken(t *testing.T) {
 		require.Equal(t, http.StatusOK, rr.Code)
 		identity, ok := ImpersonationIdentityFromContext(capturedCtx)
 		require.True(t, ok)
-		require.Equal(t, "system:serviceaccount:glean:bot", identity.UserName)
+		require.Equal(t, "agent:bot", identity.UserName)
+		require.Equal(t, []string{"agent:bot"}, identity.Groups)
 		require.Empty(t, identity.Actor, "M2M path must not set Actor")
 	})
 
@@ -1337,14 +1327,15 @@ func TestAccessTokenInjectorMiddleware_SubjectClaim(t *testing.T) {
 }
 
 // TestAccessTokenInjectorMiddleware_MultiIssuerURL covers the glean production
-// scenario: M2M (SA sub) and OBO (email sub) entries share the same muster
+// scenario: M2M (agent sub) and OBO (email sub) entries share the same muster
 // issuer URL. The middleware must route each token to the correct entry.
 func TestAccessTokenInjectorMiddleware_MultiIssuerURL(t *testing.T) {
 	const (
 		musterIssuer = "https://muster.glean.example.io"
-		m2mAlias     = "kagent-glean"
 		oboAlias     = "muster-obo"
 		agentSA      = "system:serviceaccount:kagent:sre-agent"
+		agentUser    = "agent:sre"
+		agentGroup   = "agent:sre"
 		humanEmail   = "alice@giantswarm.io"
 	)
 
@@ -1353,8 +1344,9 @@ func TestAccessTokenInjectorMiddleware_MultiIssuerURL(t *testing.T) {
 			{
 				Issuer:        musterIssuer,
 				JwksURL:       "https://muster.glean.example.io/.well-known/jwks.json",
-				Alias:         m2mAlias,
-				AllowedClaims: map[string]string{"sub": "system:serviceaccount:kagent:*"},
+				Subject:       agentUser,
+				Groups:        []string{agentGroup},
+				AllowedClaims: map[string]string{"sub": agentUser},
 			},
 			{
 				Issuer:        musterIssuer,
@@ -1367,7 +1359,7 @@ func TestAccessTokenInjectorMiddleware_MultiIssuerURL(t *testing.T) {
 		},
 	}
 
-	t.Run("M2M token routes to SA-pattern entry", func(t *testing.T) {
+	t.Run("M2M token routes to M2M entry", func(t *testing.T) {
 		var capturedCtx context.Context
 		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			capturedCtx = r.Context()
@@ -1376,8 +1368,9 @@ func TestAccessTokenInjectorMiddleware_MultiIssuerURL(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
 		req.Header.Set("Authorization", "Bearer fake-m2m-token") //nolint:gosec // G101: test fixture
 		userInfo := &providers.UserInfo{
-			ID:          agentSA,
+			ID:          agentUser,
 			Issuer:      musterIssuer,
+			Groups:      []string{agentGroup},
 			TokenSource: providers.TokenSourceTrustedIssuer,
 		}
 		req = req.WithContext(handler.ContextWithUserInfo(req.Context(), userInfo))
@@ -1389,8 +1382,8 @@ func TestAccessTokenInjectorMiddleware_MultiIssuerURL(t *testing.T) {
 		require.Equal(t, http.StatusOK, rr.Code)
 		identity, ok := ImpersonationIdentityFromContext(capturedCtx)
 		require.True(t, ok)
-		require.Equal(t, "system:serviceaccount:"+m2mAlias+":sre-agent", identity.UserName)
-		require.Equal(t, []string{"system:serviceaccounts:" + m2mAlias}, identity.Groups)
+		require.Equal(t, agentUser, identity.UserName)
+		require.Equal(t, []string{agentGroup}, identity.Groups)
 	})
 
 	t.Run("OBO token routes to email-pattern entry", func(t *testing.T) {


### PR DESCRIPTION
## What

Re-lands the pure-projector M2M model that was merged in #498 but never reached `main` (#498 merged into the squashed-away `fix/m2m-alias-dedup` base, so its commit is not an ancestor of `main`; `main` still carries the alias-based M2M path). Folds in the canonical field naming and the chart RBAC needed to make the path functional.

## Changes

- M2M trusted-issuer entries identify themselves with `subject` + `groups` (pure projection): `subject` is projected as `Impersonate-User`, and the intersection of `groups` with the token's minted groups becomes `Impersonate-Group`. A token carrying none of the listed groups is rejected.
- Replaces the alias-derived `system:serviceaccount:<alias>:<saName>` principal and pinned `system:serviceaccounts:<alias>` group. `alias` is now OBO/SSO-only and must be omitted on M2M entries.
- Chart grants the mck8s ServiceAccount exactly-scoped impersonation RBAC: `users` on `subject`, or a namespaced `serviceaccounts` Role when `subject` is in service-account form, plus `groups` scoped to the listed groups. No unrestricted grant (unlike the OBO actor path).
- `allowedTargetClusters` is now **required** on M2M entries and validated at startup: an empty list would let a centrally minted token impersonate on any reachable cluster that trusts the issuer and group.
- Bumps mcp-oauth v0.13.2 → v0.14.0.

## Naming

The consume-side fields are named `subject`/`groups` (not `impersonateUser`/`impersonateGroups` as in #498) so the same concept carries the same name as muster's mint-side `granted.subject`/`granted.groups`. `Impersonate-User`/`Impersonate-Group` are the K8s projection, not config vocabulary.

## Tests

- `go test ./...` (2230 pass), `go vet`, `gofmt` clean.
- `helm lint` + `helm unittest` (89 pass, +2 covering the user-form and service-account-form M2M RBAC).
- `helm template` verified: exact `users`/`serviceaccounts` and `groups` resourceNames render for both subject shapes.

Part of the cross-repo M2M/OBO/SSO config alignment (mcp-kubernetes#500, muster#891, mcp-oauth#474).