### PR TITLE
refactor: adopt mcp-oauth m2m/obo token source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * M2M path (external-issuer tokens without `act`) replaced the alias-namespace SA construction (`system:serviceaccount:<alias>:<saName>`) with pure projection: `impersonateUser` and `impersonateGroups` fields from the trusted-issuer config drive the impersonation headers directly. Tokens whose subject is not a `system:serviceaccount:...` path are no longer rejected.
 * `trustedIssuers[].allowedActors` is now a list of objects (`{sub, allowedSubjects}`) instead of a flat list of strings. This is a breaking values change. OBO is disabled for an issuer when `allowedActors` is empty or omitted.
-* **deps:** update module github.com/giantswarm/mcp-oauth to v0.14.0.
+* External-issuer tokens are now classified as M2M or OBO from the RFC 8693 `act` claim. The `validation_method` recorded in `token-missing-identity` audit events is `m2m` or `obo` (was `trusted-issuer`). Internally the OBO branch keys off `UserInfo.IsOBO()` and the email-check bypass off `UserInfo.IsExternalIssuer()`.
+* **deps:** update module github.com/giantswarm/mcp-oauth to v0.14.1.
 
 ## [0.1.113](https://github.com/giantswarm/mcp-kubernetes/compare/v0.1.112...v0.1.113) (2026-06-03)
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.26.4
 
 require (
 	github.com/creativeprojects/go-selfupdate v1.5.2
-	github.com/giantswarm/mcp-oauth v0.14.0
+	github.com/giantswarm/mcp-oauth v0.14.1
 	github.com/giantswarm/mcp-toolkit v0.2.9
 	github.com/mark3labs/mcp-go v0.55.0
 	github.com/prometheus/client_golang v1.23.2

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/giantswarm/mcp-oauth v0.14.0 h1:Znm9cMGjBS0wahVB27V4SrA1SORLYpcaJD6RR5fIZZ0=
-github.com/giantswarm/mcp-oauth v0.14.0/go.mod h1:Z/f5JZAz6JGs8A++hfXPUIN4CR1yuMb9cXRx4qrzzIA=
+github.com/giantswarm/mcp-oauth v0.14.1 h1:iYzYPuAI9ugYqpnldMLYRJ4J8QyycU8h2XO64o66CjA=
+github.com/giantswarm/mcp-oauth v0.14.1/go.mod h1:Z/f5JZAz6JGs8A++hfXPUIN4CR1yuMb9cXRx4qrzzIA=
 github.com/giantswarm/mcp-toolkit v0.2.9 h1:U6HhPlHX5+SuCKqZWWMXzcmJmhdcZrobhOsq/+LpiVg=
 github.com/giantswarm/mcp-toolkit v0.2.9/go.mod h1:jwOmxo8+MCPJ6HHPRqFkI6S48A/cbqXOzvT5bydbRds=
 github.com/go-fed/httpsig v1.1.0 h1:9M+hb0jkEICD8/cAiNqEB66R87tTINszBRTjwjQzWcI=

--- a/internal/server/middleware/identity.go
+++ b/internal/server/middleware/identity.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/giantswarm/mcp-oauth/handler"
-	"github.com/giantswarm/mcp-oauth/providers"
 	"github.com/giantswarm/mcp-oauth/security"
 )
 
@@ -43,9 +42,9 @@ func RequireIdentity(auditor *security.Auditor, logger *slog.Logger) func(http.H
 				next.ServeHTTP(w, r)
 				return
 			}
-			// Trusted-issuer tokens (M2M and OBO) carry no email in UserInfo;
+			// External-issuer tokens (M2M and OBO) carry no email in UserInfo;
 			// AccessTokenInjector handles their identity enforcement.
-			if userInfo.TokenSource == providers.TokenSourceTrustedIssuer {
+			if userInfo.IsExternalIssuer() {
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/internal/server/oauth_http.go
+++ b/internal/server/oauth_http.go
@@ -1190,7 +1190,7 @@ func (s *OAuthHTTPServer) createAccessTokenInjectorMiddleware(next http.Handler)
 			// OBO path (Phase 2): sub=human, act.sub=agent SA.
 			// Impersonate the human subject; record the agent SA as the actor so the
 			// kube-apiserver audit log shows "human X via agent Z".
-			if userInfo.IsDelegated() {
+			if userInfo.IsOBO() {
 				// Enforce actor allow-list and per-actor subject scoping in-process.
 				// K8s RBAC cannot couple impersonate-users to impersonate-userextras/actor
 				// (independent verbs) and does not support wildcards in resourceNames,

--- a/internal/server/oauth_http_test.go
+++ b/internal/server/oauth_http_test.go
@@ -851,7 +851,7 @@ func TestAccessTokenInjectorMiddleware_M2MToken(t *testing.T) {
 			ID:          id,
 			Issuer:      issuer,
 			Groups:      groups,
-			TokenSource: providers.TokenSourceTrustedIssuer,
+			TokenSource: providers.TokenSourceM2M,
 		}
 		return req.WithContext(handler.ContextWithUserInfo(req.Context(), userInfo))
 	}
@@ -988,7 +988,7 @@ func TestAccessTokenInjectorMiddleware_OBOToken(t *testing.T) {
 		userInfo := &providers.UserInfo{
 			ID:           humanSub,
 			Issuer:       testIssuer,
-			TokenSource:  providers.TokenSourceTrustedIssuer,
+			TokenSource:  providers.TokenSourceOBO,
 			ActorSubject: actorSub,
 			ActorIssuer:  agentSAIssuer,
 		}
@@ -1029,7 +1029,7 @@ func TestAccessTokenInjectorMiddleware_OBOToken(t *testing.T) {
 			ID:          "agent:bot",
 			Issuer:      testIssuer,
 			Groups:      []string{"agent:bot"},
-			TokenSource: providers.TokenSourceTrustedIssuer,
+			TokenSource: providers.TokenSourceM2M,
 			// ActorSubject intentionally absent
 		}
 		req = req.WithContext(handler.ContextWithUserInfo(req.Context(), userInfo))
@@ -1262,7 +1262,7 @@ func TestAccessTokenInjectorMiddleware_ActorChain(t *testing.T) {
 		userInfo := &providers.UserInfo{
 			ID:           human,
 			Issuer:       testIssuer,
-			TokenSource:  providers.TokenSourceTrustedIssuer,
+			TokenSource:  providers.TokenSourceOBO,
 			ActorSubject: agentLeaf, // mcp-oauth mirrors only the leaf
 			ActorIssuer:  "https://k8s.example.com",
 		}
@@ -1347,7 +1347,7 @@ func TestAccessTokenInjectorMiddleware_SubjectClaim(t *testing.T) {
 		userInfo := &providers.UserInfo{
 			ID:           remappedSubject, // mcp-oauth set this from the email claim
 			Issuer:       musterIssuer,
-			TokenSource:  providers.TokenSourceTrustedIssuer,
+			TokenSource:  providers.TokenSourceOBO,
 			ActorSubject: sreAgentSub,
 			ActorIssuer:  "https://k8s.example.com",
 		}
@@ -1444,7 +1444,7 @@ func TestAccessTokenInjectorMiddleware_MultiIssuerURL(t *testing.T) {
 			ID:          agentUser,
 			Issuer:      musterIssuer,
 			Groups:      []string{agentGroup},
-			TokenSource: providers.TokenSourceTrustedIssuer,
+			TokenSource: providers.TokenSourceM2M,
 		}
 		req = req.WithContext(handler.ContextWithUserInfo(req.Context(), userInfo))
 
@@ -1470,7 +1470,7 @@ func TestAccessTokenInjectorMiddleware_MultiIssuerURL(t *testing.T) {
 		userInfo := &providers.UserInfo{
 			ID:           humanEmail,
 			Issuer:       musterIssuer,
-			TokenSource:  providers.TokenSourceTrustedIssuer,
+			TokenSource:  providers.TokenSourceOBO,
 			ActorSubject: agentSA,
 			ActorIssuer:  "https://k8s.example.com",
 		}
@@ -1493,7 +1493,7 @@ func TestAccessTokenInjectorMiddleware_MultiIssuerURL(t *testing.T) {
 		userInfo := &providers.UserInfo{
 			ID:          "attacker@evil.com",
 			Issuer:      musterIssuer,
-			TokenSource: providers.TokenSourceTrustedIssuer,
+			TokenSource: providers.TokenSourceM2M,
 		}
 		req = req.WithContext(handler.ContextWithUserInfo(req.Context(), userInfo))
 


### PR DESCRIPTION
## What

Adopts the mcp-oauth token-model refactor (mcp-oauth#475, released as v0.14.1), which replaces `TokenSourceTrustedIssuer` with `TokenSourceM2M` / `TokenSourceOBO` and removes `IsDelegated()`.

## Changes

- `go.mod`: mcp-oauth v0.14.0 → v0.14.1.
- `internal/server/oauth_http.go`: OBO branch gate `userInfo.IsDelegated()` → `userInfo.IsOBO()`. The M2M fall-through is unchanged (still gated by the outer `IsExternalIssuer()` and the OBO branch returning).
- `internal/server/middleware/identity.go`: the emailless-token bypass compared `TokenSource` to the removed constant; now uses `userInfo.IsExternalIssuer()`. Drops the now-unused `providers` import.
- Test fixtures: `TokenSourceTrustedIssuer` → `TokenSourceOBO` (entries with `ActorSubject`) / `TokenSourceM2M` (without).

## Notes

- `validation_method` in `token-missing-identity` audit events changes `trusted-issuer` → `m2m`/`obo`.
- Based on current `main` (independent of the still-open #505); touches only the predicate usage, not the `impersonateUser`/`impersonateGroups` field names.

`go build ./...`, `go vet`, `go test ./internal/server/... ./cmd/...` (412 pass) clean.