### PR TITLE
feat(server): wire AllowPrivateIPJWKSHosts through TrustedIssuerConfig

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.26.4
 
 require (
 	github.com/creativeprojects/go-selfupdate v1.5.2
-	github.com/giantswarm/mcp-oauth v0.14.1
+	github.com/giantswarm/mcp-oauth v0.15.0
 	github.com/giantswarm/mcp-toolkit v0.2.9
 	github.com/mark3labs/mcp-go v0.55.0
 	github.com/prometheus/client_golang v1.23.2

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/giantswarm/mcp-oauth v0.14.1 h1:iYzYPuAI9ugYqpnldMLYRJ4J8QyycU8h2XO64o66CjA=
-github.com/giantswarm/mcp-oauth v0.14.1/go.mod h1:Z/f5JZAz6JGs8A++hfXPUIN4CR1yuMb9cXRx4qrzzIA=
+github.com/giantswarm/mcp-oauth v0.15.0 h1:QrMRAeoNgn2ppoN3Ho7rJXC5UQ2TP9NqE2hb8Bj7ZjM=
+github.com/giantswarm/mcp-oauth v0.15.0/go.mod h1:Z/f5JZAz6JGs8A++hfXPUIN4CR1yuMb9cXRx4qrzzIA=
 github.com/giantswarm/mcp-toolkit v0.2.9 h1:U6HhPlHX5+SuCKqZWWMXzcmJmhdcZrobhOsq/+LpiVg=
 github.com/giantswarm/mcp-toolkit v0.2.9/go.mod h1:jwOmxo8+MCPJ6HHPRqFkI6S48A/cbqXOzvT5bydbRds=
 github.com/go-fed/httpsig v1.1.0 h1:9M+hb0jkEICD8/cAiNqEB66R87tTINszBRTjwjQzWcI=

--- a/internal/server/oauth_http.go
+++ b/internal/server/oauth_http.go
@@ -461,7 +461,13 @@ type TrustedIssuerConfig struct {
 	// Set to ["", "JWT"] to accept Kubernetes ServiceAccount tokens.
 	AcceptedTypHeaders []string `json:"acceptedTypHeaders,omitempty"`
 	// AllowPrivateIPJWKS permits JWKS endpoints on private/loopback addresses.
+	// Prefer AllowPrivateIPJWKSHosts for a narrower escape hatch.
 	AllowPrivateIPJWKS bool `json:"allowPrivateIPJWKS,omitempty"`
+	// AllowPrivateIPJWKSHosts lists the specific hostnames whose JWKS URL is
+	// permitted to resolve to a private IP. All other hosts retain SSRF
+	// protection. Use instead of AllowPrivateIPJWKS when the endpoint is a
+	// known in-cluster service (e.g. muster.agentic-platform.svc.cluster.local).
+	AllowPrivateIPJWKSHosts []string `json:"allowPrivateIPJWKSHosts,omitempty"`
 	// AllowedActors lists the OBO actors permitted for this issuer and, per actor,
 	// the human subjects they may impersonate. Empty means OBO is disabled for
 	// this issuer (any request with an act claim is rejected).
@@ -802,13 +808,14 @@ func createOAuthServer(config OAuthConfig) (*oauth.Server, storage.TokenStore, e
 			if e, ok := merged[ti.Issuer]; !ok {
 				merged[ti.Issuer] = &mergedIssuer{
 					TrustedIssuer: oauthserver.TrustedIssuer{
-						Issuer:             ti.Issuer,
-						JwksURL:            ti.JwksURL,
-						AllowedAudiences:   ti.AllowedAudiences,
-						AllowedClaims:      ti.AllowedClaims,
-						SubjectClaim:       ti.SubjectClaim,
-						AcceptedTypHeaders: ti.AcceptedTypHeaders,
-						AllowPrivateIPJWKS: ti.AllowPrivateIPJWKS,
+						Issuer:                  ti.Issuer,
+						JwksURL:                 ti.JwksURL,
+						AllowedAudiences:        ti.AllowedAudiences,
+						AllowedClaims:           ti.AllowedClaims,
+						SubjectClaim:            ti.SubjectClaim,
+						AcceptedTypHeaders:      ti.AcceptedTypHeaders,
+						AllowPrivateIPJWKS:      ti.AllowPrivateIPJWKS,
+						AllowPrivateIPJWKSHosts: ti.AllowPrivateIPJWKSHosts,
 					},
 					entryCount: 1,
 				}
@@ -819,6 +826,7 @@ func createOAuthServer(config OAuthConfig) (*oauth.Server, storage.TokenStore, e
 				if ti.AllowPrivateIPJWKS {
 					e.AllowPrivateIPJWKS = true
 				}
+				e.AllowPrivateIPJWKSHosts = unionStrings(e.AllowPrivateIPJWKSHosts, ti.AllowPrivateIPJWKSHosts)
 			}
 		}
 		issuers := make([]oauthserver.TrustedIssuer, 0, len(merged))


### PR DESCRIPTION
## What

Exposes the new `AllowPrivateIPJWKSHosts []string` field from mcp-oauth in the `OAUTH_TRUSTED_ISSUERS` JSON config.

Operators can now write:

```json
{
  "issuer": "https://muster.glean.example.com",
  "jwksURL": "https://muster.agentic-platform.svc.cluster.local/oauth/jwks",
  "allowPrivateIPJWKSHosts": ["muster.agentic-platform.svc.cluster.local"]
}
```

instead of the blanket `"allowPrivateIPJWKS": true`.

## Why

Narrows the SSRF escape hatch to the specific known in-cluster endpoint. All other hosts retain the DNS-rebinding/SSRF guard.

Depends on mcp-oauth #476 (unreleased). The `go.mod` bump will follow once that PR is merged and tagged.