### PR TITLE
feat(schema): add allowPrivateIPJWKSHosts to trustedIssuers

### DIFF
--- a/helm/mcp-kubernetes/values.schema.json
+++ b/helm/mcp-kubernetes/values.schema.json
@@ -614,6 +614,13 @@
                     "description": "Allow the JWKS endpoint to resolve to a private/loopback IP. Required when the issuer runs on an internal network.",
                     "default": false
                   },
+                  "allowPrivateIPJWKSHosts": {
+                    "type": "array",
+                    "description": "Allowlist of hostnames whose JWKS endpoints may resolve to a private/loopback IP. Scoped alternative to allowPrivateIPJWKS — restricts the SSRF exception to specific hosts instead of all private IPs.",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
                   "allowedActors": {
                     "type": "array",
                     "description": "OBO (Phase 2): list of actor entries. Each entry names an agent SA (act.sub) and optionally restricts the human subjects it may impersonate. Empty (default) disables OBO for this issuer. The chart emits an unrestricted `impersonate users` grant when this list is non-empty; per-actor subject scoping is enforced in-process by mcp-kubernetes.",

--- a/internal/server/oauth_http.go
+++ b/internal/server/oauth_http.go
@@ -461,7 +461,13 @@ type TrustedIssuerConfig struct {
 	// Set to ["", "JWT"] to accept Kubernetes ServiceAccount tokens.
 	AcceptedTypHeaders []string `json:"acceptedTypHeaders,omitempty"`
 	// AllowPrivateIPJWKS permits JWKS endpoints on private/loopback addresses.
+	// Prefer AllowPrivateIPJWKSHosts for a narrower escape hatch.
 	AllowPrivateIPJWKS bool `json:"allowPrivateIPJWKS,omitempty"`
+	// AllowPrivateIPJWKSHosts lists the specific hostnames whose JWKS URL is
+	// permitted to resolve to a private IP. All other hosts retain SSRF
+	// protection. Use instead of AllowPrivateIPJWKS when the endpoint is a
+	// known in-cluster service (e.g. muster.agentic-platform.svc.cluster.local).
+	AllowPrivateIPJWKSHosts []string `json:"allowPrivateIPJWKSHosts,omitempty"`
 	// AllowedActors lists the OBO actors permitted for this issuer and, per actor,
 	// the human subjects they may impersonate. Empty means OBO is disabled for
 	// this issuer (any request with an act claim is rejected).
@@ -802,13 +808,14 @@ func createOAuthServer(config OAuthConfig) (*oauth.Server, storage.TokenStore, e
 			if e, ok := merged[ti.Issuer]; !ok {
 				merged[ti.Issuer] = &mergedIssuer{
 					TrustedIssuer: oauthserver.TrustedIssuer{
-						Issuer:             ti.Issuer,
-						JwksURL:            ti.JwksURL,
-						AllowedAudiences:   ti.AllowedAudiences,
-						AllowedClaims:      ti.AllowedClaims,
-						SubjectClaim:       ti.SubjectClaim,
-						AcceptedTypHeaders: ti.AcceptedTypHeaders,
-						AllowPrivateIPJWKS: ti.AllowPrivateIPJWKS,
+						Issuer:                  ti.Issuer,
+						JwksURL:                 ti.JwksURL,
+						AllowedAudiences:        ti.AllowedAudiences,
+						AllowedClaims:           ti.AllowedClaims,
+						SubjectClaim:            ti.SubjectClaim,
+						AcceptedTypHeaders:      ti.AcceptedTypHeaders,
+						AllowPrivateIPJWKS:      ti.AllowPrivateIPJWKS,
+						AllowPrivateIPJWKSHosts: ti.AllowPrivateIPJWKSHosts,
 					},
 					entryCount: 1,
 				}
@@ -819,6 +826,7 @@ func createOAuthServer(config OAuthConfig) (*oauth.Server, storage.TokenStore, e
 				if ti.AllowPrivateIPJWKS {
 					e.AllowPrivateIPJWKS = true
 				}
+				e.AllowPrivateIPJWKSHosts = unionStrings(e.AllowPrivateIPJWKSHosts, ti.AllowPrivateIPJWKSHosts)
 			}
 		}
 		issuers := make([]oauthserver.TrustedIssuer, 0, len(merged))


### PR DESCRIPTION
## What

Adds `allowPrivateIPJWKSHosts` to the `trustedIssuers.items` schema so the field can be set in values without triggering Helm schema validation errors.

The field is already wired in the Go server layer (`feat(server): wire AllowPrivateIPJWKSHosts through TrustedIssuerConfig`, HEAD~1). The schema was the only thing blocking it from being usable in configs.

## Why

`allowPrivateIPJWKS: true` (boolean, existing field) allows any private IP for JWKS fetches. `allowPrivateIPJWKSHosts` restricts the exception to a named set of hostnames, shrinking the SSRF surface to exactly the configured issuer hosts. The shared-configs mcp-kubernetes template and per-cluster configs have already been updated to use the host-scoped form.