### PR TITLE
trustedIssuers: per-field opt-in enforcement

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -439,11 +439,14 @@ Downstream OAuth (--downstream-oauth):
 
 // validateEncryptionKey validates an AES-256 encryption key for security weaknesses
 // validateTrustedIssuers checks per-issuer invariants:
-//   - M2M entries (impersonateGroups set): must omit alias; impersonateUser required.
-//   - OBO/SSO entries: alias must be a valid DNS-1123 label and unique.
-//   - All entries: non-wildcard subject pattern under the effective subject claim.
+//   - issuer and jwksURL are required.
+//   - alias, if set, must be a valid DNS-1123 label and unique across entries.
+//   - allowedClaims subject pattern, if set, must not be bare '*'.
+//   - subjectClaim, if set, requires a matching allowedClaims entry under that key
+//     (having allowedClaims entries for a different key is a misconfiguration).
 //
-// Multiple entries may share the same issuer URL (e.g. M2M + OBO from the same STS).
+// All other fields are independently optional. Multiple entries may share the same
+// issuer URL (e.g. a specific-pattern entry and a permissive fallback entry).
 func validateTrustedIssuers(issuers []server.TrustedIssuerConfig) error {
 	seenAliases := make(map[string]struct{}, len(issuers))
 	for _, ti := range issuers {
@@ -453,16 +456,7 @@ func validateTrustedIssuers(issuers []server.TrustedIssuerConfig) error {
 		if ti.JwksURL == "" {
 			return fmt.Errorf("trusted issuer %q: jwksURL is required", ti.Issuer)
 		}
-		if len(ti.ImpersonateGroups) > 0 {
-			// M2M entry.
-			if ti.Alias != "" {
-				return fmt.Errorf("trusted issuer %q: M2M entries (impersonateGroups set) must not set alias", ti.Issuer)
-			}
-			if ti.ImpersonateUser == "" {
-				return fmt.Errorf("trusted issuer %q: impersonateUser is required when impersonateGroups is set", ti.Issuer)
-			}
-		} else {
-			// OBO/SSO entry.
+		if ti.Alias != "" {
 			if !isDNS1123Label(ti.Alias) {
 				return fmt.Errorf("trusted issuer %q: alias %q is not a valid DNS-1123 label "+
 					"(lowercase alphanumeric and hyphens, must start/end with alphanumeric, max 63 chars)",
@@ -475,9 +469,14 @@ func validateTrustedIssuers(issuers []server.TrustedIssuerConfig) error {
 		}
 		subjectKey := ti.EffectiveSubjectKey()
 		subPattern, hasSub := ti.AllowedClaims[subjectKey]
-		if !hasSub || subPattern == "" || subPattern == "*" {
-			return fmt.Errorf("trusted issuer %q: allowedClaims.%s must be a non-empty pattern "+
-				"that is not bare '*' (prevents any identity from being impersonated)", ti.Issuer, subjectKey)
+		if hasSub && subPattern == "*" {
+			return fmt.Errorf("trusted issuer %q: allowedClaims.%s must not be bare '*' "+
+				"(prevents any identity from being impersonated)", ti.Issuer, subjectKey)
+		}
+		if ti.SubjectClaim != "" && len(ti.AllowedClaims) > 0 && !hasSub {
+			return fmt.Errorf("trusted issuer %q: subjectClaim is %q but allowedClaims has no entry "+
+				"for that key; set allowedClaims.%s or clear allowedClaims entirely",
+				ti.Issuer, ti.SubjectClaim, ti.SubjectClaim)
 		}
 	}
 	return nil

--- a/cmd/trusted_issuers_test.go
+++ b/cmd/trusted_issuers_test.go
@@ -61,13 +61,19 @@ func TestValidateTrustedIssuers(t *testing.T) {
 			wantError: true,
 		},
 		{
-			name: "missing subject pattern on default sub key is rejected",
+			name: "no allowedClaims is valid (permissive entry — JWKS is the boundary)",
 			issuers: []server.TrustedIssuerConfig{{
 				Issuer:  issuerURL,
 				JwksURL: jwksURL,
 				Alias:   "glean",
 			}},
-			wantError: true,
+		},
+		{
+			name: "no alias is valid",
+			issuers: []server.TrustedIssuerConfig{{
+				Issuer:  issuerURL,
+				JwksURL: jwksURL,
+			}},
 		},
 		{
 			name: "duplicate alias is rejected",

--- a/helm/mcp-kubernetes/values.yaml
+++ b/helm/mcp-kubernetes/values.yaml
@@ -506,88 +506,75 @@ mcpKubernetes:
     # Default: [] (only accept tokens issued directly to this server's client_id)
     trustedAudiences: []
 
-    # Trusted external JWT issuers for M2M authentication (mcp-oauth v0.2.175+)
-    # Enables autonomous agents (e.g., kagent pods with projected SA tokens) to call /mcp
-    # directly without a human SSO flow. mcp-kubernetes validates the token via JWKS, then
-    # impersonates the SA identity on the kube-apiserver using its own in-cluster credentials.
+    # Trusted external JWT issuers for impersonation-based access.
+    # Tokens from these issuers bypass the normal OAuth flow: mcp-kubernetes validates
+    # the signature via JWKS, then sets Impersonate-User / Impersonate-Group headers on
+    # outbound kube-apiserver requests.
+    #
+    # The JWKS URL is the trust boundary — adding an issuer is the explicit trust decision.
+    # All enforcement fields are independently optional; absent fields place no restriction
+    # on that dimension. Multiple entries may share the same issuer URL (e.g. a specific
+    # AllowedClaims entry for agent tokens and a permissive fallback for human tokens).
     #
     # Required per entry:
-    #   issuer:             expected `iss` claim in the JWT (exact match, no wildcards)
-    #   jwksURL:            JWKS endpoint for signature verification
-    #   alias:              stable short id for this issuer cluster (e.g. "glean");
-    #                       used to build system:serviceaccount:<alias>:<saName>
+    #   issuer:   expected `iss` claim in the JWT (exact match)
+    #   jwksURL:  JWKS endpoint for signature verification
     #
-    # Optional per entry:
-    #   allowedAudiences:       accepted `aud` values (empty = accept any)
-    #   allowedTargetClusters:  workload clusters this issuer may target (empty = all)
-    #   allowedClaims:          required claim key/value pairs (e.g. sub prefix check)
+    # Optional per entry (all independently optional):
+    #   allowedAudiences:       restrict accepted `aud` values; empty = any audience
+    #   allowedTargetClusters:  workload clusters this issuer may target; empty = all
+    #   allowedClaims:          claim key/value patterns to gate candidate selection
+    #                           (e.g. sub prefix check); empty = permissive fallback
     #   subjectClaim:           claim whose value becomes the impersonated subject,
-    #                           replacing sub (e.g. "email"). When set, the subject
-    #                           pattern lives under that key in allowedClaims.
-    #   acceptedTypHeaders:     accepted `typ` header values (empty = any)
+    #                           replacing sub (e.g. "email"); mcp-oauth fails closed
+    #                           if the claim is absent. When set, allowedClaims must
+    #                           use that key (not "sub") for the subject pattern.
+    #   impersonateUser:        pin Impersonate-User to this exact value; token subject
+    #                           must match; empty = use token subject as-is
+    #   impersonateGroups:      allow-list for Impersonate-Group; intersection with token
+    #                           groups is used; 403 if intersection empty; empty = use
+    #                           token groups as-is
+    #   allowedActors:          OBO actor entries (RFC 8693 act.sub); empty = any actor
+    #                           accepted (the JWKS boundary still applies)
+    #   acceptedTypHeaders:     accepted `typ` header values; empty = RFC 9068 default
     #   allowPrivateIPJWKS:     true when the JWKS endpoint is on a private network
+    #   allowPrivateIPJWKSHosts: per-hostname escape hatch (preferred over allowPrivateIPJWKS)
+    #   alias:                  stable short id (DNS-1123 label, unique); the chart keys
+    #                           per-alias RBAC (Namespace + ClusterRole) on this value
     #
-    # OBO (on-behalf-of) fields — only needed when agents carry a delegated human token
-    # (RFC 8693 act claim). Leave empty for pure M2M (autonomous agent) deployments.
+    # Actor entry fields (under allowedActors):
+    #   sub:              required. Agent SA sub, e.g. "system:serviceaccount:kagent:my-agent".
+    #   allowedSubjects:  optional. Human subject patterns this actor may impersonate.
+    #                     Supports leading (*@domain.com) or trailing (ns:*) wildcard.
+    #                     Empty = any subject.
     #
-    #   allowedActors:  list of OBO actor entries. Each entry specifies an agent SA
-    #                   (act.sub claim) and the human subjects it may impersonate.
+    # SECURITY: K8s RBAC cannot couple impersonate-users to impersonate-actor (independent
+    # verbs) or express wildcard subjects in resourceNames. Per-actor subject scoping is
+    # enforced in-process by mcp-kubernetes before any impersonation call reaches kube-apiserver.
     #
-    #     sub:              required. Agent SA sub, e.g. "system:serviceaccount:kagent:my-agent".
-    #     allowedSubjects:  optional. Human subject patterns the actor may impersonate.
-    #                       Supports a single leading (*@domain.com) or trailing
-    #                       (system:serviceaccount:ns:*) wildcard. Empty means any
-    #                       subject is allowed, still bounded by allowedClaims.sub.
+    # Example (muster-behind, minimal — only cluster-scoping needed):
+    #   - issuer: "https://muster.example.io"
+    #     jwksURL: "https://muster.internal/jwks"
+    #     allowPrivateIPJWKSHosts: ["muster.internal"]
+    #     allowedAudiences: ["https://mcp-kubernetes.mycluster.example.io"]
     #
-    #                   SECURITY: the chart emits an unrestricted `impersonate users`
-    #                   ClusterRole rule when allowedActors is set. K8s RBAC cannot
-    #                   couple impersonate-users to impersonate-actor (independent verbs)
-    #                   or express wildcard subjects in resourceNames. Per-actor subject
-    #                   scoping is enforced in-process by mcp-kubernetes before any
-    #                   impersonation call reaches the kube-apiserver.
-    #
-    # alias (optional): when set, the chart creates a <alias> namespace, a
-    # namespaced Role granting `impersonate serviceaccounts` in that namespace,
-    # and a ClusterRole granting `impersonate groups/extras` scoped to the alias.
-    # Required for M2M issuers (SA token impersonation). Omit for OBO-only
-    # issuers such as a muster token exchange endpoint, where the impersonated
-    # identity is the human email directly. Per-alias RBAC is only generated
-    # when serviceAccount.create and rbac.create are both true.
-    #
-    # Example (M2M only):
-    #   - issuer: "https://oidc.example.com/glean"
-    #     jwksURL: "https://oidc.example.com/glean/.well-known/jwks.json"
-    #     alias: "glean"
-    #     allowedAudiences: ["https://mcp.example.com"]
-    #     allowedTargetClusters: ["cluster-a", "cluster-b"]
-    #
-    # Example (M2M + OBO, glob subjects):
-    #   - issuer: "https://oidc.example.com/glean"
-    #     jwksURL: "https://oidc.example.com/glean/.well-known/jwks.json"
+    # Example (standalone M2M, subject + group enforcement):
+    #   - issuer: "https://oidc.example.com"
+    #     jwksURL: "https://oidc.example.com/.well-known/jwks.json"
     #     alias: "glean"
     #     allowedClaims:
     #       sub: "system:serviceaccount:kagent:*"
-    #     allowedActors:
-    #       - sub: "system:serviceaccount:kagent:my-agent"
-    #         allowedSubjects:
-    #           - "*@example.com"
-    #       - sub: "system:serviceaccount:kagent:headless-agent"
-    #         # empty allowedSubjects: this actor may impersonate any human
-    #         # whose sub matches allowedClaims.sub
+    #     impersonateGroups: ["mcp:readers"]
     #
-    # Example (OBO-only issuer, e.g. muster token exchange endpoint). muster keeps
-    # sub opaque and carries the human in the email claim, so subjectClaim remaps
-    # the subject to email and the pattern lives under allowedClaims.email:
+    # Example (OBO with actor + subject restrictions):
     #   - issuer: "https://muster.example.com"
     #     jwksURL: "https://muster.example.com/.well-known/jwks.json"
     #     subjectClaim: "email"
     #     allowedClaims:
     #       email: "*@example.com"
-    #     acceptedTypHeaders: ["at+jwt"]
     #     allowedActors:
     #       - sub: "system:serviceaccount:kagent:my-agent"
-    #         allowedSubjects:
-    #           - "*@example.com"
+    #         allowedSubjects: ["*@example.com"]
     #
     # Default: [] (no external issuers trusted)
     trustedIssuers: []

--- a/internal/server/oauth_http.go
+++ b/internal/server/oauth_http.go
@@ -399,6 +399,28 @@ func actorChainSubjects(token string) map[string]struct{} {
 	return subjects
 }
 
+// tokenAudiences extracts the aud claim from a raw JWT without signature verification.
+// The token has already been verified upstream by the mcp-oauth middleware.
+func tokenAudiences(rawToken string) []string {
+	claims, err := oidc.ParseUnverifiedClaims(rawToken)
+	if err != nil {
+		return nil
+	}
+	switch v := claims["aud"].(type) {
+	case string:
+		return []string{v}
+	case []any:
+		auds := make([]string, 0, len(v))
+		for _, a := range v {
+			if s, ok := a.(string); ok {
+				auds = append(auds, s)
+			}
+		}
+		return auds
+	}
+	return nil
+}
+
 // ActorConfig defines an OBO actor (RFC 8693 act.sub) and the human subjects it
 // is permitted to act on behalf of.
 type ActorConfig struct {
@@ -418,26 +440,19 @@ type TrustedIssuerConfig struct {
 	Issuer string `json:"issuer"`
 	// JwksURL is the JWKS endpoint used to verify signatures.
 	JwksURL string `json:"jwksURL"`
-	// Alias is a stable short identifier for an OBO issuer (e.g. "muster-obo"). The
+	// Alias is a stable short identifier for this issuer (e.g. "muster-obo"). The
 	// chart keys the per-alias Namespace and users/userextras impersonation ClusterRole
-	// on this value. Required on OBO entries; must be omitted on M2M entries (which
-	// identify themselves via ImpersonateUser / ImpersonateGroups instead).
+	// on this value. Optional; must be a valid DNS-1123 label if set.
 	Alias string `json:"alias,omitempty"`
-	// ImpersonateUser is the exact subject this M2M entry may project as
-	// Impersonate-User. The token's effective subject (userInfo.ID, after any
-	// SubjectClaim remap) must equal this value verbatim; no glob matching applies
-	// (use AllowedClaims for routing patterns). The chart scopes the mck8s
-	// ServiceAccount's impersonate-users RBAC resourceName to exactly this value.
-	// Empty disables the M2M path for this issuer.
-	// Must be paired with a non-empty ImpersonateGroups.
+	// ImpersonateUser pins the Impersonate-User value for tokens from this issuer.
+	// The token's effective subject must equal this value exactly; the request is
+	// rejected if they differ. Empty means no subject enforcement — the token's
+	// effective subject is used as-is.
 	ImpersonateUser string `json:"impersonateUser,omitempty"`
-	// ImpersonateGroups is the exact allow-list of groups an M2M token from this
-	// issuer may project as Impersonate-Group. The intersection of this list and the
-	// token's minted groups claim becomes the set of impersonated groups; a token
-	// carrying none of these groups is rejected. The chart scopes the mck8s
-	// ServiceAccount's impersonate-groups RBAC resourceNames to exactly this list.
-	// Empty disables the M2M path for this issuer.
-	// Must be paired with a non-empty ImpersonateUser.
+	// ImpersonateGroups is an allow-list of groups for Impersonate-Group. The
+	// intersection of this list and the token's groups claim is used; the request is
+	// rejected if the intersection is empty. Empty means no group restriction — the
+	// token's groups are forwarded as-is.
 	ImpersonateGroups []string `json:"impersonateGroups,omitempty"`
 	// AllowedAudiences restricts accepted `aud` values. Empty means any audience.
 	AllowedAudiences []string `json:"allowedAudiences,omitempty"`
@@ -445,12 +460,11 @@ type TrustedIssuerConfig struct {
 	// issuer's tokens may be impersonated onto. Empty means any cluster.
 	AllowedTargetClusters []string `json:"allowedTargetClusters,omitempty"`
 	// AllowedClaims constrains accepted tokens to those whose JWT claims match
-	// all entries exactly (e.g. {"sub": "system:serviceaccount:kagent:*"}).
-	// Wildcard suffix matching is supported for the "sub" claim only.
+	// all entries (e.g. {"sub": "system:serviceaccount:kagent:*"}). Wildcard
+	// suffix/prefix matching is supported for the effective subject key only.
 	// When SubjectClaim is set, the entry under that key (not "sub") gates the
-	// impersonated subject; mcp-oauth evaluates AllowedClaims against the raw
-	// token before the subject is remapped, so the opaque sub cannot carry the
-	// remapped pattern.
+	// impersonated subject. Empty means no claim restriction — only JWKS
+	// signature verification applies.
 	AllowedClaims map[string]string `json:"allowedClaims,omitempty"`
 	// SubjectClaim names the verified claim whose value becomes the impersonated
 	// subject, replacing the standard sub claim. Set to "email" on the muster-obo
@@ -468,9 +482,9 @@ type TrustedIssuerConfig struct {
 	// protection. Use instead of AllowPrivateIPJWKS when the endpoint is a
 	// known in-cluster service (e.g. muster.agentic-platform.svc.cluster.local).
 	AllowPrivateIPJWKSHosts []string `json:"allowPrivateIPJWKSHosts,omitempty"`
-	// AllowedActors lists the OBO actors permitted for this issuer and, per actor,
-	// the human subjects they may impersonate. Empty means OBO is disabled for
-	// this issuer (any request with an act claim is rejected).
+	// AllowedActors lists the OBO actors (RFC 8693 act.sub) permitted for this
+	// issuer and, per actor, the human subjects they may impersonate. Empty means
+	// any actor is accepted without restriction (the JWKS boundary applies).
 	AllowedActors []ActorConfig `json:"allowedActors,omitempty"`
 }
 
@@ -1175,19 +1189,30 @@ func (s *OAuthHTTPServer) createAccessTokenInjectorMiddleware(next http.Handler)
 				http.Error(w, "forbidden: unknown trusted issuer", http.StatusForbidden)
 				return
 			}
-			// Defense-in-depth: find the configured entry whose allowedClaims pattern
-			// matches this token's effective subject. When a single issuer URL serves
-			// multiple trust domains (e.g. M2M SA pattern + OBO email pattern), the
-			// correct entry is selected here rather than at map-build time.
+			// Select the matching TrustedIssuerConfig entry.
+			// Entries with AllowedClaims are tried first (specific routing for same-issuer
+			// multi-entry deployments). Entries without AllowedClaims serve as permissive
+			// fallback — JWKS signature verification is the trust boundary.
 			// userInfo.ID already holds the remapped value when SubjectClaim is set.
 			var tiConfig *TrustedIssuerConfig
+			var permissive *TrustedIssuerConfig
 			for i := range candidates {
-				subjectKey := candidates[i].EffectiveSubjectKey()
-				subPattern, ok := candidates[i].AllowedClaims[subjectKey]
+				c := &candidates[i]
+				if len(c.AllowedClaims) == 0 {
+					if permissive == nil {
+						permissive = c
+					}
+					continue
+				}
+				subjectKey := c.EffectiveSubjectKey()
+				subPattern, ok := c.AllowedClaims[subjectKey]
 				if ok && subPattern != "" && matchesSubGlob(subPattern, userInfo.ID) {
-					tiConfig = &candidates[i]
+					tiConfig = c
 					break
 				}
+			}
+			if tiConfig == nil {
+				tiConfig = permissive
 			}
 			if tiConfig == nil {
 				slog.Warn("AccessTokenInjector: subject does not match allowedClaims pattern, rejecting",
@@ -1195,28 +1220,65 @@ func (s *OAuthHTTPServer) createAccessTokenInjectorMiddleware(next http.Handler)
 				http.Error(w, "forbidden: subject does not match allowed pattern", http.StatusForbidden)
 				return
 			}
-			// OBO path (Phase 2): sub=human, act.sub=agent SA.
-			// Impersonate the human subject; record the agent SA as the actor so the
-			// kube-apiserver audit log shows "human X via agent Z".
-			if userInfo.IsOBO() {
-				// Enforce actor allow-list and per-actor subject scoping in-process.
-				// K8s RBAC cannot couple impersonate-users to impersonate-userextras/actor
-				// (independent verbs) and does not support wildcards in resourceNames,
-				// so both checks must live here.
-				//
-				// Walk the full RFC 8693 act chain: a configured actor is authorized
-				// when its sub appears anywhere in the chain, so multi-hop A2A
-				// (human -> agentA -> agentB -> MCP) is honored, not only the leaf.
-				// The leaf comes from the validated UserInfo; deeper hops are read
-				// from the authentic token payload.
-				actorSub := userInfo.ActorSubject
+
+			// Per-field enforcement: each field is independently optional.
+
+			// Audience restriction.
+			if len(tiConfig.AllowedAudiences) > 0 {
+				tokenAuds := tokenAudiences(bearerToken)
+				matched := false
+			outer:
+				for _, allowed := range tiConfig.AllowedAudiences {
+					for _, got := range tokenAuds {
+						if allowed == got {
+							matched = true
+							break outer
+						}
+					}
+				}
+				if !matched {
+					slog.Warn("AccessTokenInjector: token audience not in allowedAudiences, rejecting",
+						"issuer", userInfo.Issuer, "subject", userInfo.ID)
+					http.Error(w, "forbidden: audience not permitted", http.StatusForbidden)
+					return
+				}
+			}
+
+			// Subject enforcement.
+			subject := userInfo.ID
+			if tiConfig.ImpersonateUser != "" && tiConfig.ImpersonateUser != subject {
+				slog.Warn("AccessTokenInjector: subject does not match impersonateUser, rejecting",
+					"issuer", userInfo.Issuer, "subject", subject)
+				http.Error(w, "forbidden: subject not permitted for impersonation", http.StatusForbidden)
+				return
+			}
+
+			// Group enforcement.
+			impersonateGroups := userInfo.Groups
+			if len(tiConfig.ImpersonateGroups) > 0 {
+				impersonateGroups = intersectGroups(tiConfig.ImpersonateGroups, userInfo.Groups)
+				if len(impersonateGroups) == 0 {
+					slog.Warn("AccessTokenInjector: token carries no allow-listed group, rejecting",
+						"issuer", userInfo.Issuer, "subject", subject)
+					http.Error(w, "forbidden: no permitted group in token", http.StatusForbidden)
+					return
+				}
+			}
+
+			// Actor enforcement (OBO path: act claim present).
+			// K8s RBAC cannot couple impersonate-users to impersonate-userextras/actor
+			// (independent verbs) and does not support wildcards in resourceNames,
+			// so this check must live in-process.
+			actorSub := userInfo.ActorSubject
+			if actorSub != "" && len(tiConfig.AllowedActors) > 0 {
+				// Walk the full RFC 8693 act chain so multi-hop A2A
+				// (human -> agentA -> agentB -> MCP) is honored.
 				chainSubjects := actorChainSubjects(bearerToken)
 				if chainSubjects == nil {
 					chainSubjects = make(map[string]struct{}, 1)
 				}
-				if actorSub != "" {
-					chainSubjects[actorSub] = struct{}{}
-				}
+				chainSubjects[actorSub] = struct{}{}
+
 				var matchedActor *ActorConfig
 				for i := range tiConfig.AllowedActors {
 					if _, ok := chainSubjects[tiConfig.AllowedActors[i].Sub]; ok {
@@ -1231,28 +1293,30 @@ func (s *OAuthHTTPServer) createAccessTokenInjectorMiddleware(next http.Handler)
 					return
 				}
 				if len(matchedActor.AllowedSubjects) > 0 {
-					humanSub := userInfo.ID
 					subAllowed := false
 					for _, pattern := range matchedActor.AllowedSubjects {
-						if matchesSubGlob(pattern, humanSub) {
+						if matchesSubGlob(pattern, subject) {
 							subAllowed = true
 							break
 						}
 					}
 					if !subAllowed {
 						slog.Warn("AccessTokenInjector: OBO human subject not in actor's allowedSubjects, rejecting",
-							"issuer", userInfo.Issuer, "actor", actorSub, "subject", humanSub)
+							"issuer", userInfo.Issuer, "actor", actorSub, "subject", subject)
 						http.Error(w, "forbidden: subject not permitted for this actor", http.StatusForbidden)
 						return
 					}
 				}
+			}
 
+			// Build the impersonation identity.
+			if actorSub != "" {
+				// OBO: delegation does not carry group membership through impersonation.
+				// system:authenticated must be explicit; impersonation does not
+				// inherit the real-auth group set.
 				identity := k8s.ImpersonationIdentity{
-					UserName: userInfo.ID,
-					// system:authenticated must be explicit; impersonation does not
-					// inherit the real-auth group set. Human access is governed by
-					// RoleBindings to the user subject on each target cluster.
-					Groups: []string{"system:authenticated"},
+					UserName: subject,
+					Groups:   []string{"system:authenticated"},
 					Extra: map[string][]string{
 						"issuer": {userInfo.Issuer},
 						"agent":  {"mcp-kubernetes"},
@@ -1267,29 +1331,13 @@ func (s *OAuthHTTPServer) createAccessTokenInjectorMiddleware(next http.Handler)
 				return
 			}
 
-			// M2M path: pure projection. muster asserted the subject (GrantedSubject
-			// in mcp-oauth); ImpersonateUser is the final exact gate here. The
-			// intersection of ImpersonateGroups and the minted token groups becomes
-			// Impersonate-Group; cluster RBAC (bound to the group) authorizes.
-			if tiConfig.ImpersonateUser != userInfo.ID {
-				slog.Warn("AccessTokenInjector: M2M subject does not match impersonateUser, rejecting",
-					"issuer", userInfo.Issuer, "subject", userInfo.ID)
-				http.Error(w, "forbidden: subject not permitted for impersonation", http.StatusForbidden)
-				return
-			}
-			impersonateGroups := intersectGroups(tiConfig.ImpersonateGroups, userInfo.Groups)
-			if len(impersonateGroups) == 0 {
-				slog.Warn("AccessTokenInjector: M2M token carries no allow-listed group, rejecting",
-					"issuer", userInfo.Issuer, "subject", userInfo.ID)
-				http.Error(w, "forbidden: no permitted group in token", http.StatusForbidden)
-				return
-			}
+			// M2M: no act claim.
 			// system:authenticated is not added automatically for impersonation (unlike
 			// real auth); without it the impersonated identity lacks system:discovery
 			// access and API resource enumeration silently returns empty results.
 			impersonateGroups = appendIfMissing(impersonateGroups, "system:authenticated")
 			identity := k8s.ImpersonationIdentity{
-				UserName: userInfo.ID,
+				UserName: subject,
 				Groups:   impersonateGroups,
 				Extra: map[string][]string{
 					"issuer": {userInfo.Issuer},
@@ -1297,9 +1345,8 @@ func (s *OAuthHTTPServer) createAccessTokenInjectorMiddleware(next http.Handler)
 				},
 				AllowedTargetClusters: tiConfig.AllowedTargetClusters,
 			}
-			slog.Debug("AccessTokenInjector: M2M group impersonation",
-				"issuer", userInfo.Issuer, "subject", userInfo.ID, "groups", impersonateGroups)
-
+			slog.Debug("AccessTokenInjector: external-issuer group impersonation",
+				"issuer", userInfo.Issuer, "subject", subject, "groups", impersonateGroups)
 			ctx = ContextWithImpersonationIdentity(ctx, identity)
 			r = r.WithContext(ctx)
 			next.ServeHTTP(w, r)

--- a/internal/server/oauth_http_test.go
+++ b/internal/server/oauth_http_test.go
@@ -895,7 +895,12 @@ func TestAccessTokenInjectorMiddleware_M2MToken(t *testing.T) {
 		require.Equal(t, http.StatusForbidden, rr.Code)
 	})
 
-	t.Run("missing allowedClaims.sub returns 403", func(t *testing.T) {
+	t.Run("no allowedClaims is permissive — ImpersonateUser and ImpersonateGroups still enforce", func(t *testing.T) {
+		var capturedCtx context.Context
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedCtx = r.Context()
+			w.WriteHeader(http.StatusOK)
+		})
 		noClaimsMap := makeIssuerMap(TrustedIssuerConfig{
 			Issuer:            testIssuer,
 			JwksURL:           "https://oidc.example.com/.well-known/jwks.json",
@@ -904,10 +909,12 @@ func TestAccessTokenInjectorMiddleware_M2MToken(t *testing.T) {
 		})
 		s := &OAuthHTTPServer{trustedIssuersByIssuer: noClaimsMap}
 		rr := httptest.NewRecorder()
-		s.createAccessTokenInjectorMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(http.StatusOK)
-		})).ServeHTTP(rr, newReq(testIssuer, agentUser, []string{agentGroup}))
-		require.Equal(t, http.StatusForbidden, rr.Code)
+		s.createAccessTokenInjectorMiddleware(next).ServeHTTP(rr, newReq(testIssuer, agentUser, []string{agentGroup}))
+		require.Equal(t, http.StatusOK, rr.Code)
+		identity, ok := ImpersonationIdentityFromContext(capturedCtx)
+		require.True(t, ok)
+		require.Equal(t, agentUser, identity.UserName)
+		require.Equal(t, []string{agentGroup, "system:authenticated"}, identity.Groups)
 	})
 
 	t.Run("sub not matching allowedClaims routing pattern returns 403", func(t *testing.T) {
@@ -1071,20 +1078,27 @@ func TestAccessTokenInjectorMiddleware_OBOToken(t *testing.T) {
 		require.Equal(t, http.StatusForbidden, rr.Code)
 	})
 
-	t.Run("OBO allowedActors empty rejects any OBO request", func(t *testing.T) {
+	t.Run("OBO allowedActors empty accepts any actor (JWKS is the boundary)", func(t *testing.T) {
+		var capturedCtx context.Context
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedCtx = r.Context()
+			w.WriteHeader(http.StatusOK)
+		})
 		noActorMap := makeIssuerMap(TrustedIssuerConfig{
 			Issuer:        testIssuer,
 			JwksURL:       "https://oidc.example.com/.well-known/jwks.json",
 			Alias:         testAlias,
 			AllowedClaims: map[string]string{"sub": humanSubject},
-			// AllowedActors intentionally empty — OBO disabled.
+			// AllowedActors empty: any actor accepted.
 		})
 		s := &OAuthHTTPServer{trustedIssuersByIssuer: noActorMap}
 		rr := httptest.NewRecorder()
-		s.createAccessTokenInjectorMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(http.StatusOK)
-		})).ServeHTTP(rr, newOBOReq(humanSubject, agentSASub))
-		require.Equal(t, http.StatusForbidden, rr.Code)
+		s.createAccessTokenInjectorMiddleware(next).ServeHTTP(rr, newOBOReq(humanSubject, agentSASub))
+		require.Equal(t, http.StatusOK, rr.Code)
+		identity, ok := ImpersonationIdentityFromContext(capturedCtx)
+		require.True(t, ok)
+		require.Equal(t, humanSubject, identity.UserName)
+		require.Equal(t, agentSASub, identity.Actor)
 	})
 
 	t.Run("OBO actor with allowedSubjects glob allows matching human", func(t *testing.T) {
@@ -1189,6 +1203,199 @@ func TestAccessTokenInjectorMiddleware_OBOToken(t *testing.T) {
 		identity, ok := ImpersonationIdentityFromContext(capturedCtx)
 		require.True(t, ok)
 		require.Equal(t, "other@example.com", identity.UserName)
+	})
+}
+
+func TestAccessTokenInjectorMiddleware_PerFieldOptIn(t *testing.T) {
+	const (
+		testIssuer = "https://muster.example.io"
+		humanSub   = "quentin@giantswarm.io"
+		agentSA    = "system:serviceaccount:kagent:sre-agent"
+	)
+
+	newM2MReq := func(sub string, groups []string) *http.Request {
+		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		req.Header.Set("Authorization", "Bearer fake-token") //nolint:gosec // G101: test fixture
+		userInfo := &providers.UserInfo{
+			ID:          sub,
+			Issuer:      testIssuer,
+			Groups:      groups,
+			TokenSource: providers.TokenSourceM2M,
+		}
+		return req.WithContext(handler.ContextWithUserInfo(req.Context(), userInfo))
+	}
+
+	newOBOReq := func(sub, actor string) *http.Request {
+		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		req.Header.Set("Authorization", "Bearer fake-obo-token") //nolint:gosec // G101: test fixture
+		userInfo := &providers.UserInfo{
+			ID:           sub,
+			Issuer:       testIssuer,
+			TokenSource:  providers.TokenSourceOBO,
+			ActorSubject: actor,
+		}
+		return req.WithContext(handler.ContextWithUserInfo(req.Context(), userInfo))
+	}
+
+	t.Run("no restrictions: token sub and groups forwarded as-is", func(t *testing.T) {
+		var capturedCtx context.Context
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedCtx = r.Context()
+			w.WriteHeader(http.StatusOK)
+		})
+		permissiveMap := makeIssuerMap(TrustedIssuerConfig{
+			Issuer:  testIssuer,
+			JwksURL: "https://muster.example.io/.well-known/jwks.json",
+		})
+		s := &OAuthHTTPServer{trustedIssuersByIssuer: permissiveMap}
+		rr := httptest.NewRecorder()
+		s.createAccessTokenInjectorMiddleware(next).ServeHTTP(rr, newM2MReq(humanSub, []string{"eng"}))
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		identity, ok := ImpersonationIdentityFromContext(capturedCtx)
+		require.True(t, ok)
+		require.Equal(t, humanSub, identity.UserName)
+		require.Equal(t, []string{"eng", "system:authenticated"}, identity.Groups)
+		require.Empty(t, identity.Actor)
+	})
+
+	t.Run("no restrictions OBO: actor accepted, groups collapsed to system:authenticated", func(t *testing.T) {
+		var capturedCtx context.Context
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedCtx = r.Context()
+			w.WriteHeader(http.StatusOK)
+		})
+		permissiveMap := makeIssuerMap(TrustedIssuerConfig{
+			Issuer:  testIssuer,
+			JwksURL: "https://muster.example.io/.well-known/jwks.json",
+		})
+		s := &OAuthHTTPServer{trustedIssuersByIssuer: permissiveMap}
+		rr := httptest.NewRecorder()
+		s.createAccessTokenInjectorMiddleware(next).ServeHTTP(rr, newOBOReq(humanSub, agentSA))
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		identity, ok := ImpersonationIdentityFromContext(capturedCtx)
+		require.True(t, ok)
+		require.Equal(t, humanSub, identity.UserName)
+		require.Equal(t, []string{"system:authenticated"}, identity.Groups)
+		require.Equal(t, agentSA, identity.Actor)
+	})
+
+	t.Run("allowedAudiences set: matching audience accepted", func(t *testing.T) {
+		audToken := makeDelegatedJWT(t, map[string]any{
+			"iss": testIssuer,
+			"sub": humanSub,
+			"aud": "https://mcp-kubernetes.cluster.example.io",
+		})
+		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		req.Header.Set("Authorization", "Bearer "+audToken)
+		req = req.WithContext(handler.ContextWithUserInfo(req.Context(), &providers.UserInfo{
+			ID:          humanSub,
+			Issuer:      testIssuer,
+			TokenSource: providers.TokenSourceM2M,
+		}))
+
+		audMap := makeIssuerMap(TrustedIssuerConfig{
+			Issuer:           testIssuer,
+			JwksURL:          "https://muster.example.io/.well-known/jwks.json",
+			AllowedAudiences: []string{"https://mcp-kubernetes.cluster.example.io"},
+		})
+		s := &OAuthHTTPServer{trustedIssuersByIssuer: audMap}
+		rr := httptest.NewRecorder()
+		s.createAccessTokenInjectorMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})).ServeHTTP(rr, req)
+		require.Equal(t, http.StatusOK, rr.Code)
+	})
+
+	t.Run("allowedAudiences set: wrong audience rejected", func(t *testing.T) {
+		audToken := makeDelegatedJWT(t, map[string]any{
+			"iss": testIssuer,
+			"sub": humanSub,
+			"aud": "https://other-cluster.example.io",
+		})
+		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		req.Header.Set("Authorization", "Bearer "+audToken)
+		req = req.WithContext(handler.ContextWithUserInfo(req.Context(), &providers.UserInfo{
+			ID:          humanSub,
+			Issuer:      testIssuer,
+			TokenSource: providers.TokenSourceM2M,
+		}))
+
+		audMap := makeIssuerMap(TrustedIssuerConfig{
+			Issuer:           testIssuer,
+			JwksURL:          "https://muster.example.io/.well-known/jwks.json",
+			AllowedAudiences: []string{"https://mcp-kubernetes.cluster.example.io"},
+		})
+		s := &OAuthHTTPServer{trustedIssuersByIssuer: audMap}
+		rr := httptest.NewRecorder()
+		s.createAccessTokenInjectorMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})).ServeHTTP(rr, req)
+		require.Equal(t, http.StatusForbidden, rr.Code)
+	})
+
+	t.Run("same-issuer: specific AllowedClaims entry wins over permissive fallback", func(t *testing.T) {
+		specificEntry := TrustedIssuerConfig{
+			Issuer:        testIssuer,
+			JwksURL:       "https://muster.example.io/.well-known/jwks.json",
+			AllowedClaims: map[string]string{"sub": "system:serviceaccount:kagent:*"},
+			ImpersonateGroups: []string{"agent-group"},
+		}
+		permissiveEntry := TrustedIssuerConfig{
+			Issuer:  testIssuer,
+			JwksURL: "https://muster.example.io/.well-known/jwks.json",
+		}
+		multiMap := map[string][]TrustedIssuerConfig{
+			testIssuer: {specificEntry, permissiveEntry},
+		}
+
+		var capturedCtx context.Context
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedCtx = r.Context()
+			w.WriteHeader(http.StatusOK)
+		})
+		s := &OAuthHTTPServer{trustedIssuersByIssuer: multiMap}
+		rr := httptest.NewRecorder()
+		agentSub := "system:serviceaccount:kagent:bot"
+		s.createAccessTokenInjectorMiddleware(next).ServeHTTP(rr, newM2MReq(agentSub, []string{"agent-group"}))
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		identity, ok := ImpersonationIdentityFromContext(capturedCtx)
+		require.True(t, ok)
+		// Specific entry selected: ImpersonateGroups intersection applied.
+		require.Equal(t, []string{"agent-group", "system:authenticated"}, identity.Groups)
+	})
+
+	t.Run("same-issuer: permissive entry used when specific AllowedClaims does not match", func(t *testing.T) {
+		specificEntry := TrustedIssuerConfig{
+			Issuer:        testIssuer,
+			JwksURL:       "https://muster.example.io/.well-known/jwks.json",
+			AllowedClaims: map[string]string{"sub": "system:serviceaccount:kagent:*"},
+		}
+		permissiveEntry := TrustedIssuerConfig{
+			Issuer:  testIssuer,
+			JwksURL: "https://muster.example.io/.well-known/jwks.json",
+		}
+		multiMap := map[string][]TrustedIssuerConfig{
+			testIssuer: {specificEntry, permissiveEntry},
+		}
+
+		var capturedCtx context.Context
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedCtx = r.Context()
+			w.WriteHeader(http.StatusOK)
+		})
+		s := &OAuthHTTPServer{trustedIssuersByIssuer: multiMap}
+		rr := httptest.NewRecorder()
+		s.createAccessTokenInjectorMiddleware(next).ServeHTTP(rr, newM2MReq(humanSub, []string{"eng"}))
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		identity, ok := ImpersonationIdentityFromContext(capturedCtx)
+		require.True(t, ok)
+		// Permissive entry selected: all groups forwarded.
+		require.Equal(t, humanSub, identity.UserName)
+		require.Equal(t, []string{"eng", "system:authenticated"}, identity.Groups)
 	})
 }
 


### PR DESCRIPTION
## What changed

Every restriction field in `TrustedIssuerConfig` is now independently optional. Previously the validator required `allowedClaims` with a non-empty subject pattern on every entry, paired M2M (`impersonateGroups` set) and OBO (`alias` required) into distinct modes, and treated empty `allowedActors` as OBO-disabled.

Now: JWKS URL is the trust boundary. Absent fields place no restriction on that dimension.

**Candidate selection** (for same-issuer multi-entry deployments): entries with `AllowedClaims` are tried first; entries without serve as permissive fallback.

**Enforcement order** (each applied only when the field is set):
- `allowedAudiences` — `aud` claim intersect; useful for per-cluster scoping
- `impersonateUser` — subject must equal this value exactly
- `impersonateGroups` — token groups intersected with allow-list; 403 if empty
- `allowedActors` — delegation chain validated; empty = any actor accepted

**Validation relaxed:**
- `issuer` + `jwksURL` are the only required fields
- `alias` is optional; if set must be DNS-1123 and unique
- bare `*` in `AllowedClaims` subject key is still rejected
- `subjectClaim` set with non-matching `allowedClaims` keys is still rejected (misconfiguration guard)

## Why

When mcp-kubernetes runs behind muster, muster already validates tokens, enforces delegation policy, and mints per-backend JWTs with the right sub/groups/act claims. The old config forced operators to duplicate all of that in `allowedClaims` / `allowedActors` / `impersonateUser` / `impersonateGroups`.

The minimal muster-behind config is now:

```yaml
trustedIssuers:
  - issuer: "https://muster.example.io"
    jwksURL: "https://muster.internal/jwks"
    allowPrivateIPJWKSHosts: ["muster.internal"]
    allowedAudiences: ["https://mcp-kubernetes.mycluster.example.io"]
```

Standalone deployments (no muster) use the restriction fields as before — they are opt-in rather than mandatory.

## Behaviour changes

| Scenario | Before | After |
|---|---|---|
| No `allowedClaims` | 403 (required) | Permissive match |
| Empty `allowedActors` + OBO token | 403 (OBO disabled) | Actor accepted |
| No `alias` | 403 (required for OBO) | Valid |
| No `impersonateUser`/`impersonateGroups` | 403 (required for M2M) | Token subject/groups forwarded |