### PR TITLE
feat(trusted-issuers): make all restriction fields independently optional

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -439,11 +439,11 @@ Downstream OAuth (--downstream-oauth):
 
 // validateEncryptionKey validates an AES-256 encryption key for security weaknesses
 // validateTrustedIssuers checks per-issuer invariants:
-//   - M2M entries (impersonateGroups set): must omit alias; impersonateUser required.
-//   - OBO/SSO entries: alias must be a valid DNS-1123 label and unique.
-//   - All entries: non-wildcard subject pattern under the effective subject claim.
+//   - issuer and jwksURL are required.
+//   - alias, if set, must be a valid DNS-1123 label and unique across entries.
+//   - allowedClaims values may not be bare '*'.
 //
-// Multiple entries may share the same issuer URL (e.g. M2M + OBO from the same STS).
+// Multiple entries may share the same issuer URL (e.g. restricted + passthrough).
 func validateTrustedIssuers(issuers []server.TrustedIssuerConfig) error {
 	seenAliases := make(map[string]struct{}, len(issuers))
 	for _, ti := range issuers {
@@ -453,16 +453,7 @@ func validateTrustedIssuers(issuers []server.TrustedIssuerConfig) error {
 		if ti.JwksURL == "" {
 			return fmt.Errorf("trusted issuer %q: jwksURL is required", ti.Issuer)
 		}
-		if len(ti.ImpersonateGroups) > 0 {
-			// M2M entry.
-			if ti.Alias != "" {
-				return fmt.Errorf("trusted issuer %q: M2M entries (impersonateGroups set) must not set alias", ti.Issuer)
-			}
-			if ti.ImpersonateUser == "" {
-				return fmt.Errorf("trusted issuer %q: impersonateUser is required when impersonateGroups is set", ti.Issuer)
-			}
-		} else {
-			// OBO/SSO entry.
+		if ti.Alias != "" {
 			if !isDNS1123Label(ti.Alias) {
 				return fmt.Errorf("trusted issuer %q: alias %q is not a valid DNS-1123 label "+
 					"(lowercase alphanumeric and hyphens, must start/end with alphanumeric, max 63 chars)",
@@ -473,11 +464,10 @@ func validateTrustedIssuers(issuers []server.TrustedIssuerConfig) error {
 			}
 			seenAliases[ti.Alias] = struct{}{}
 		}
-		subjectKey := ti.EffectiveSubjectKey()
-		subPattern, hasSub := ti.AllowedClaims[subjectKey]
-		if !hasSub || subPattern == "" || subPattern == "*" {
-			return fmt.Errorf("trusted issuer %q: allowedClaims.%s must be a non-empty pattern "+
-				"that is not bare '*' (prevents any identity from being impersonated)", ti.Issuer, subjectKey)
+		for claim, pattern := range ti.AllowedClaims {
+			if pattern == "*" {
+				return fmt.Errorf("trusted issuer %q: allowedClaims.%s must not be bare '*'", ti.Issuer, claim)
+			}
 		}
 	}
 	return nil

--- a/cmd/trusted_issuers_test.go
+++ b/cmd/trusted_issuers_test.go
@@ -20,7 +20,14 @@ func TestValidateTrustedIssuers(t *testing.T) {
 		wantError bool
 	}{
 		{
-			name: "sub-keyed issuer is valid",
+			name: "issuer and jwksURL only is valid",
+			issuers: []server.TrustedIssuerConfig{{
+				Issuer:  issuerURL,
+				JwksURL: jwksURL,
+			}},
+		},
+		{
+			name: "sub-keyed issuer with alias is valid",
 			issuers: []server.TrustedIssuerConfig{{
 				Issuer:        issuerURL,
 				JwksURL:       jwksURL,
@@ -29,7 +36,7 @@ func TestValidateTrustedIssuers(t *testing.T) {
 			}},
 		},
 		{
-			name: "email-remapped issuer gates on allowedClaims.email",
+			name: "email-remapped issuer is valid",
 			issuers: []server.TrustedIssuerConfig{{
 				Issuer:        issuerURL,
 				JwksURL:       jwksURL,
@@ -39,7 +46,7 @@ func TestValidateTrustedIssuers(t *testing.T) {
 			}},
 		},
 		{
-			name: "SubjectClaim set but no pattern under that key is rejected",
+			name: "SubjectClaim set without matching allowedClaims key is valid",
 			issuers: []server.TrustedIssuerConfig{{
 				Issuer:        issuerURL,
 				JwksURL:       jwksURL,
@@ -47,25 +54,30 @@ func TestValidateTrustedIssuers(t *testing.T) {
 				SubjectClaim:  "email",
 				AllowedClaims: map[string]string{"sub": "*@giantswarm.io"},
 			}},
-			wantError: true,
 		},
 		{
-			name: "bare wildcard under the effective key is rejected",
-			issuers: []server.TrustedIssuerConfig{{
-				Issuer:        issuerURL,
-				JwksURL:       jwksURL,
-				Alias:         "muster-obo",
-				SubjectClaim:  "email",
-				AllowedClaims: map[string]string{"email": "*"},
-			}},
-			wantError: true,
-		},
-		{
-			name: "missing subject pattern on default sub key is rejected",
+			name: "no allowedClaims is valid",
 			issuers: []server.TrustedIssuerConfig{{
 				Issuer:  issuerURL,
 				JwksURL: jwksURL,
 				Alias:   "glean",
+			}},
+		},
+		{
+			name: "bare wildcard in allowedClaims is rejected",
+			issuers: []server.TrustedIssuerConfig{{
+				Issuer:        issuerURL,
+				JwksURL:       jwksURL,
+				AllowedClaims: map[string]string{"sub": "*"},
+			}},
+			wantError: true,
+		},
+		{
+			name: "bare wildcard on non-subject claim is rejected",
+			issuers: []server.TrustedIssuerConfig{{
+				Issuer:        issuerURL,
+				JwksURL:       jwksURL,
+				AllowedClaims: map[string]string{"email": "*"},
 			}},
 			wantError: true,
 		},
@@ -78,11 +90,40 @@ func TestValidateTrustedIssuers(t *testing.T) {
 			wantError: true,
 		},
 		{
-			name: "same issuer URL with distinct aliases is valid (M2M + OBO)",
+			name: "invalid alias label is rejected",
+			issuers: []server.TrustedIssuerConfig{{
+				Issuer:  issuerURL,
+				JwksURL: jwksURL,
+				Alias:   "Not-Valid!",
+			}},
+			wantError: true,
+		},
+		{
+			name: "same issuer URL with distinct aliases is valid",
 			issuers: []server.TrustedIssuerConfig{
 				{Issuer: issuerURL, JwksURL: jwksURL, Alias: "kagent-glean", AllowedClaims: map[string]string{"sub": "system:serviceaccount:kagent:*"}},
 				{Issuer: issuerURL, JwksURL: jwksURL, Alias: "muster-obo", SubjectClaim: "email", AllowedClaims: map[string]string{"email": "*@giantswarm.io"}},
 			},
+		},
+		{
+			name: "same issuer URL with one passthrough entry (no alias, no allowedClaims) is valid",
+			issuers: []server.TrustedIssuerConfig{
+				{Issuer: issuerURL, JwksURL: jwksURL},
+			},
+		},
+		{
+			name: "empty issuer URL is rejected",
+			issuers: []server.TrustedIssuerConfig{{
+				JwksURL: jwksURL,
+			}},
+			wantError: true,
+		},
+		{
+			name: "empty jwksURL is rejected",
+			issuers: []server.TrustedIssuerConfig{{
+				Issuer: issuerURL,
+			}},
+			wantError: true,
 		},
 	}
 

--- a/helm/mcp-kubernetes/values.yaml
+++ b/helm/mcp-kubernetes/values.yaml
@@ -506,88 +506,71 @@ mcpKubernetes:
     # Default: [] (only accept tokens issued directly to this server's client_id)
     trustedAudiences: []
 
-    # Trusted external JWT issuers for M2M authentication (mcp-oauth v0.2.175+)
-    # Enables autonomous agents (e.g., kagent pods with projected SA tokens) to call /mcp
-    # directly without a human SSO flow. mcp-kubernetes validates the token via JWKS, then
-    # impersonates the SA identity on the kube-apiserver using its own in-cluster credentials.
+    # Trusted external JWT issuers for direct token authentication (mcp-oauth v0.2.175+).
+    # Enables autonomous agents and delegated human tokens to call /mcp without a human
+    # SSO flow. mcp-kubernetes validates the token via JWKS and builds an impersonation
+    # identity from the token's claims.
     #
     # Required per entry:
-    #   issuer:             expected `iss` claim in the JWT (exact match, no wildcards)
-    #   jwksURL:            JWKS endpoint for signature verification
-    #   alias:              stable short id for this issuer cluster (e.g. "glean");
-    #                       used to build system:serviceaccount:<alias>:<saName>
+    #   issuer:   expected `iss` claim in the JWT (exact match)
+    #   jwksURL:  JWKS endpoint for signature verification — this is the trust boundary.
+    #             Use a private/in-cluster URL for issuers you fully control (e.g. muster).
     #
-    # Optional per entry:
-    #   allowedAudiences:       accepted `aud` values (empty = accept any)
-    #   allowedTargetClusters:  workload clusters this issuer may target (empty = all)
-    #   allowedClaims:          required claim key/value pairs (e.g. sub prefix check)
+    # All other fields are optional and independently enforced when set.
+    # Omitting a field means no restriction for that dimension.
+    #
+    #   alias:                  stable short identifier (DNS-1123 label); the chart keys
+    #                           per-alias RBAC on this value. Optional.
+    #   allowedAudiences:       accepted `aud` values. Empty = any audience.
+    #   allowedTargetClusters:  workload clusters this issuer may target. Empty = any.
+    #   allowedClaims:          claim patterns that must match; values support a single
+    #                           leading (*@domain.com) or trailing (ns:*) glob. Bare '*'
+    #                           is rejected. Empty = any claims accepted.
     #   subjectClaim:           claim whose value becomes the impersonated subject,
-    #                           replacing sub (e.g. "email"). When set, the subject
-    #                           pattern lives under that key in allowedClaims.
-    #   acceptedTypHeaders:     accepted `typ` header values (empty = any)
-    #   allowPrivateIPJWKS:     true when the JWKS endpoint is on a private network
-    #
-    # OBO (on-behalf-of) fields — only needed when agents carry a delegated human token
-    # (RFC 8693 act claim). Leave empty for pure M2M (autonomous agent) deployments.
-    #
-    #   allowedActors:  list of OBO actor entries. Each entry specifies an agent SA
-    #                   (act.sub claim) and the human subjects it may impersonate.
-    #
-    #     sub:              required. Agent SA sub, e.g. "system:serviceaccount:kagent:my-agent".
-    #     allowedSubjects:  optional. Human subject patterns the actor may impersonate.
-    #                       Supports a single leading (*@domain.com) or trailing
-    #                       (system:serviceaccount:ns:*) wildcard. Empty means any
-    #                       subject is allowed, still bounded by allowedClaims.sub.
+    #                           replacing sub (e.g. "email"). Routing uses that key in
+    #                           allowedClaims when set.
+    #   acceptedTypHeaders:     accepted JWT `typ` header values. Empty = any.
+    #   allowPrivateIPJWKS:     allow JWKS endpoint to resolve to a private IP.
+    #   allowPrivateIPJWKSHosts: per-hostname private-IP exception (preferred over the above).
+    #   impersonateUser:        when set, enforces that the token subject equals this value.
+    #   impersonateGroups:      when set, intersects this allow-list with the token's groups;
+    #                           rejects if intersection is empty.
+    #   allowedActors:          when set, restricts which OBO actors (act.sub) are accepted
+    #                           and, per actor, which human subjects they may impersonate.
+    #                           Empty = any actor accepted (JWKS URL is the trust boundary).
     #
     #                   SECURITY: the chart emits an unrestricted `impersonate users`
-    #                   ClusterRole rule when allowedActors is set. K8s RBAC cannot
-    #                   couple impersonate-users to impersonate-actor (independent verbs)
-    #                   or express wildcard subjects in resourceNames. Per-actor subject
-    #                   scoping is enforced in-process by mcp-kubernetes before any
-    #                   impersonation call reaches the kube-apiserver.
+    #                   ClusterRole rule when allowedActors is set. Per-actor subject
+    #                   scoping is enforced in-process before any impersonation call
+    #                   reaches the kube-apiserver.
     #
-    # alias (optional): when set, the chart creates a <alias> namespace, a
-    # namespaced Role granting `impersonate serviceaccounts` in that namespace,
-    # and a ClusterRole granting `impersonate groups/extras` scoped to the alias.
-    # Required for M2M issuers (SA token impersonation). Omit for OBO-only
-    # issuers such as a muster token exchange endpoint, where the impersonated
-    # identity is the human email directly. Per-alias RBAC is only generated
-    # when serviceAccount.create and rbac.create are both true.
+    # When multiple entries share the same issuer URL, entries with allowedClaims are
+    # tried first (subject pattern match); entries without allowedClaims are fallback.
     #
-    # Example (M2M only):
-    #   - issuer: "https://oidc.example.com/glean"
-    #     jwksURL: "https://oidc.example.com/glean/.well-known/jwks.json"
-    #     alias: "glean"
-    #     allowedAudiences: ["https://mcp.example.com"]
-    #     allowedTargetClusters: ["cluster-a", "cluster-b"]
+    # Example (muster behind — minimal config, JWKS is the trust boundary):
+    #   - issuer: "https://muster.example.com"
+    #     jwksURL: "https://muster.internal/jwks"
+    #     allowPrivateIPJWKSHosts: ["muster.internal"]
+    #     allowedAudiences: ["https://mcp-kubernetes.mycluster.example.com"]  # optional
     #
-    # Example (M2M + OBO, glob subjects):
+    # Example (direct M2M — SA token, restrict by subject + groups):
     #   - issuer: "https://oidc.example.com/glean"
     #     jwksURL: "https://oidc.example.com/glean/.well-known/jwks.json"
     #     alias: "glean"
     #     allowedClaims:
     #       sub: "system:serviceaccount:kagent:*"
-    #     allowedActors:
-    #       - sub: "system:serviceaccount:kagent:my-agent"
-    #         allowedSubjects:
-    #           - "*@example.com"
-    #       - sub: "system:serviceaccount:kagent:headless-agent"
-    #         # empty allowedSubjects: this actor may impersonate any human
-    #         # whose sub matches allowedClaims.sub
+    #     impersonateUser: "system:serviceaccount:kagent:sre-agent"
+    #     impersonateGroups: ["agent:sre"]
     #
-    # Example (OBO-only issuer, e.g. muster token exchange endpoint). muster keeps
-    # sub opaque and carries the human in the email claim, so subjectClaim remaps
-    # the subject to email and the pattern lives under allowedClaims.email:
+    # Example (OBO — restrict by actor and subject domain):
     #   - issuer: "https://muster.example.com"
     #     jwksURL: "https://muster.example.com/.well-known/jwks.json"
     #     subjectClaim: "email"
     #     allowedClaims:
     #       email: "*@example.com"
-    #     acceptedTypHeaders: ["at+jwt"]
     #     allowedActors:
     #       - sub: "system:serviceaccount:kagent:my-agent"
-    #         allowedSubjects:
-    #           - "*@example.com"
+    #         allowedSubjects: ["*@example.com"]
     #
     # Default: [] (no external issuers trusted)
     trustedIssuers: []

--- a/internal/server/oauth_http.go
+++ b/internal/server/oauth_http.go
@@ -418,26 +418,20 @@ type TrustedIssuerConfig struct {
 	Issuer string `json:"issuer"`
 	// JwksURL is the JWKS endpoint used to verify signatures.
 	JwksURL string `json:"jwksURL"`
-	// Alias is a stable short identifier for an OBO issuer (e.g. "muster-obo"). The
-	// chart keys the per-alias Namespace and users/userextras impersonation ClusterRole
-	// on this value. Required on OBO entries; must be omitted on M2M entries (which
-	// identify themselves via ImpersonateUser / ImpersonateGroups instead).
+	// Alias is a stable short identifier used by the chart to key per-issuer
+	// Namespaces and impersonation ClusterRoles. Optional; must be a valid
+	// DNS-1123 label if set and unique across entries.
 	Alias string `json:"alias,omitempty"`
-	// ImpersonateUser is the exact subject this M2M entry may project as
-	// Impersonate-User. The token's effective subject (userInfo.ID, after any
-	// SubjectClaim remap) must equal this value verbatim; no glob matching applies
-	// (use AllowedClaims for routing patterns). The chart scopes the mck8s
-	// ServiceAccount's impersonate-users RBAC resourceName to exactly this value.
-	// Empty disables the M2M path for this issuer.
-	// Must be paired with a non-empty ImpersonateGroups.
+	// ImpersonateUser, when set, enforces that the token's effective subject
+	// (userInfo.ID, after any SubjectClaim remap) equals this value verbatim.
+	// The chart scopes the mcp-kubernetes ServiceAccount's impersonate-users
+	// RBAC resourceName to exactly this value. Empty means no subject restriction.
 	ImpersonateUser string `json:"impersonateUser,omitempty"`
-	// ImpersonateGroups is the exact allow-list of groups an M2M token from this
-	// issuer may project as Impersonate-Group. The intersection of this list and the
-	// token's minted groups claim becomes the set of impersonated groups; a token
-	// carrying none of these groups is rejected. The chart scopes the mck8s
-	// ServiceAccount's impersonate-groups RBAC resourceNames to exactly this list.
-	// Empty disables the M2M path for this issuer.
-	// Must be paired with a non-empty ImpersonateUser.
+	// ImpersonateGroups, when set, is the allow-list of groups this issuer's
+	// tokens may project as Impersonate-Group. The intersection of this list and
+	// the token's groups claim becomes the set of impersonated groups; a token
+	// carrying none of these groups is rejected. Empty means the token's groups
+	// are used directly without restriction.
 	ImpersonateGroups []string `json:"impersonateGroups,omitempty"`
 	// AllowedAudiences restricts accepted `aud` values. Empty means any audience.
 	AllowedAudiences []string `json:"allowedAudiences,omitempty"`
@@ -468,9 +462,9 @@ type TrustedIssuerConfig struct {
 	// protection. Use instead of AllowPrivateIPJWKS when the endpoint is a
 	// known in-cluster service (e.g. muster.agentic-platform.svc.cluster.local).
 	AllowPrivateIPJWKSHosts []string `json:"allowPrivateIPJWKSHosts,omitempty"`
-	// AllowedActors lists the OBO actors permitted for this issuer and, per actor,
-	// the human subjects they may impersonate. Empty means OBO is disabled for
-	// this issuer (any request with an act claim is rejected).
+	// AllowedActors, when set, restricts which OBO actors (act.sub) are permitted
+	// for this issuer and, per actor, which human subjects they may impersonate.
+	// Empty means any actor is accepted (the issuer's JWKS is the trust boundary).
 	AllowedActors []ActorConfig `json:"allowedActors,omitempty"`
 }
 
@@ -1175,83 +1169,90 @@ func (s *OAuthHTTPServer) createAccessTokenInjectorMiddleware(next http.Handler)
 				http.Error(w, "forbidden: unknown trusted issuer", http.StatusForbidden)
 				return
 			}
-			// Defense-in-depth: find the configured entry whose allowedClaims pattern
-			// matches this token's effective subject. When a single issuer URL serves
-			// multiple trust domains (e.g. M2M SA pattern + OBO email pattern), the
-			// correct entry is selected here rather than at map-build time.
-			// userInfo.ID already holds the remapped value when SubjectClaim is set.
+			// Select the best matching entry for this issuer+subject combination.
+			// Entries with an allowedClaims subject pattern are tried first; entries
+			// without one are eligible as a fallback for any subject (the JWKS URL
+			// is the trust boundary for passthrough entries).
 			var tiConfig *TrustedIssuerConfig
+			var fallback *TrustedIssuerConfig
 			for i := range candidates {
 				subjectKey := candidates[i].EffectiveSubjectKey()
-				subPattern, ok := candidates[i].AllowedClaims[subjectKey]
-				if ok && subPattern != "" && matchesSubGlob(subPattern, userInfo.ID) {
+				subPattern, hasSubPattern := candidates[i].AllowedClaims[subjectKey]
+				if !hasSubPattern || subPattern == "" {
+					if fallback == nil {
+						fallback = &candidates[i]
+					}
+					continue
+				}
+				if matchesSubGlob(subPattern, userInfo.ID) {
 					tiConfig = &candidates[i]
 					break
 				}
 			}
 			if tiConfig == nil {
-				slog.Warn("AccessTokenInjector: subject does not match allowedClaims pattern, rejecting",
+				tiConfig = fallback
+			}
+			if tiConfig == nil {
+				slog.Warn("AccessTokenInjector: subject does not match any configured entry, rejecting",
 					"issuer", userInfo.Issuer, "subject", userInfo.ID)
 				http.Error(w, "forbidden: subject does not match allowed pattern", http.StatusForbidden)
 				return
 			}
-			// OBO path (Phase 2): sub=human, act.sub=agent SA.
-			// Impersonate the human subject; record the agent SA as the actor so the
-			// kube-apiserver audit log shows "human X via agent Z".
+
+			// OBO path: sub=human, act.sub=agent SA.
 			if userInfo.IsOBO() {
-				// Enforce actor allow-list and per-actor subject scoping in-process.
-				// K8s RBAC cannot couple impersonate-users to impersonate-userextras/actor
-				// (independent verbs) and does not support wildcards in resourceNames,
-				// so both checks must live here.
-				//
-				// Walk the full RFC 8693 act chain: a configured actor is authorized
-				// when its sub appears anywhere in the chain, so multi-hop A2A
-				// (human -> agentA -> agentB -> MCP) is honored, not only the leaf.
-				// The leaf comes from the validated UserInfo; deeper hops are read
-				// from the authentic token payload.
 				actorSub := userInfo.ActorSubject
-				chainSubjects := actorChainSubjects(bearerToken)
-				if chainSubjects == nil {
-					chainSubjects = make(map[string]struct{}, 1)
-				}
-				if actorSub != "" {
-					chainSubjects[actorSub] = struct{}{}
-				}
-				var matchedActor *ActorConfig
-				for i := range tiConfig.AllowedActors {
-					if _, ok := chainSubjects[tiConfig.AllowedActors[i].Sub]; ok {
-						matchedActor = &tiConfig.AllowedActors[i]
-						break
+
+				// When allowedActors is configured, enforce the actor allow-list and
+				// per-actor subject scoping. K8s RBAC cannot couple impersonate-users
+				// to impersonate-userextras/actor (independent verbs) so both checks
+				// must live here. Walk the full RFC 8693 act chain: a configured actor
+				// is authorized when its sub appears anywhere in the chain, so multi-hop
+				// A2A (human → agentA → agentB → MCP) is honored.
+				// Empty allowedActors means any actor is accepted.
+				if len(tiConfig.AllowedActors) > 0 {
+					chainSubjects := actorChainSubjects(bearerToken)
+					if chainSubjects == nil {
+						chainSubjects = make(map[string]struct{}, 1)
 					}
-				}
-				if matchedActor == nil {
-					slog.Warn("AccessTokenInjector: no actor in delegation chain matches allowedActors, rejecting",
-						"issuer", userInfo.Issuer, "leafActor", actorSub, "chainLen", len(chainSubjects))
-					http.Error(w, "forbidden: actor not permitted for this issuer", http.StatusForbidden)
-					return
-				}
-				if len(matchedActor.AllowedSubjects) > 0 {
-					humanSub := userInfo.ID
-					subAllowed := false
-					for _, pattern := range matchedActor.AllowedSubjects {
-						if matchesSubGlob(pattern, humanSub) {
-							subAllowed = true
+					if actorSub != "" {
+						chainSubjects[actorSub] = struct{}{}
+					}
+					var matchedActor *ActorConfig
+					for i := range tiConfig.AllowedActors {
+						if _, ok := chainSubjects[tiConfig.AllowedActors[i].Sub]; ok {
+							matchedActor = &tiConfig.AllowedActors[i]
 							break
 						}
 					}
-					if !subAllowed {
-						slog.Warn("AccessTokenInjector: OBO human subject not in actor's allowedSubjects, rejecting",
-							"issuer", userInfo.Issuer, "actor", actorSub, "subject", humanSub)
-						http.Error(w, "forbidden: subject not permitted for this actor", http.StatusForbidden)
+					if matchedActor == nil {
+						slog.Warn("AccessTokenInjector: no actor in delegation chain matches allowedActors, rejecting",
+							"issuer", userInfo.Issuer, "leafActor", actorSub, "chainLen", len(chainSubjects))
+						http.Error(w, "forbidden: actor not permitted for this issuer", http.StatusForbidden)
 						return
+					}
+					if len(matchedActor.AllowedSubjects) > 0 {
+						humanSub := userInfo.ID
+						subAllowed := false
+						for _, pattern := range matchedActor.AllowedSubjects {
+							if matchesSubGlob(pattern, humanSub) {
+								subAllowed = true
+								break
+							}
+						}
+						if !subAllowed {
+							slog.Warn("AccessTokenInjector: OBO human subject not in actor's allowedSubjects, rejecting",
+								"issuer", userInfo.Issuer, "actor", actorSub, "subject", humanSub)
+							http.Error(w, "forbidden: subject not permitted for this actor", http.StatusForbidden)
+							return
+						}
 					}
 				}
 
 				identity := k8s.ImpersonationIdentity{
 					UserName: userInfo.ID,
 					// system:authenticated must be explicit; impersonation does not
-					// inherit the real-auth group set. Human access is governed by
-					// RoleBindings to the user subject on each target cluster.
+					// inherit the real-auth group set.
 					Groups: []string{"system:authenticated"},
 					Extra: map[string][]string{
 						"issuer": {userInfo.Issuer},
@@ -1267,27 +1268,33 @@ func (s *OAuthHTTPServer) createAccessTokenInjectorMiddleware(next http.Handler)
 				return
 			}
 
-			// M2M path: pure projection. muster asserted the subject (GrantedSubject
-			// in mcp-oauth); ImpersonateUser is the final exact gate here. The
-			// intersection of ImpersonateGroups and the minted token groups becomes
-			// Impersonate-Group; cluster RBAC (bound to the group) authorizes.
-			if tiConfig.ImpersonateUser != userInfo.ID {
+			// M2M path.
+			// If impersonateUser is set, enforce exact subject match.
+			if tiConfig.ImpersonateUser != "" && tiConfig.ImpersonateUser != userInfo.ID {
 				slog.Warn("AccessTokenInjector: M2M subject does not match impersonateUser, rejecting",
 					"issuer", userInfo.Issuer, "subject", userInfo.ID)
 				http.Error(w, "forbidden: subject not permitted for impersonation", http.StatusForbidden)
 				return
 			}
-			impersonateGroups := intersectGroups(tiConfig.ImpersonateGroups, userInfo.Groups)
-			if len(impersonateGroups) == 0 {
-				slog.Warn("AccessTokenInjector: M2M token carries no allow-listed group, rejecting",
-					"issuer", userInfo.Issuer, "subject", userInfo.ID)
-				http.Error(w, "forbidden: no permitted group in token", http.StatusForbidden)
-				return
+
+			var impersonateGroups []string
+			if len(tiConfig.ImpersonateGroups) > 0 {
+				// Intersect configured group allow-list with token groups.
+				impersonateGroups = intersectGroups(tiConfig.ImpersonateGroups, userInfo.Groups)
+				if len(impersonateGroups) == 0 {
+					slog.Warn("AccessTokenInjector: M2M token carries no allow-listed group, rejecting",
+						"issuer", userInfo.Issuer, "subject", userInfo.ID)
+					http.Error(w, "forbidden: no permitted group in token", http.StatusForbidden)
+					return
+				}
+			} else {
+				impersonateGroups = userInfo.Groups
 			}
 			// system:authenticated is not added automatically for impersonation (unlike
 			// real auth); without it the impersonated identity lacks system:discovery
 			// access and API resource enumeration silently returns empty results.
 			impersonateGroups = appendIfMissing(impersonateGroups, "system:authenticated")
+
 			identity := k8s.ImpersonationIdentity{
 				UserName: userInfo.ID,
 				Groups:   impersonateGroups,
@@ -1297,7 +1304,7 @@ func (s *OAuthHTTPServer) createAccessTokenInjectorMiddleware(next http.Handler)
 				},
 				AllowedTargetClusters: tiConfig.AllowedTargetClusters,
 			}
-			slog.Debug("AccessTokenInjector: M2M group impersonation",
+			slog.Debug("AccessTokenInjector: M2M impersonation",
 				"issuer", userInfo.Issuer, "subject", userInfo.ID, "groups", impersonateGroups)
 
 			ctx = ContextWithImpersonationIdentity(ctx, identity)

--- a/internal/server/oauth_http_test.go
+++ b/internal/server/oauth_http_test.go
@@ -1298,9 +1298,9 @@ func TestAccessTokenInjectorMiddleware_Passthrough(t *testing.T) {
 // the restricted entry is tried first and the passthrough entry is used as a fallback.
 func TestAccessTokenInjectorMiddleware_FallbackOrdering(t *testing.T) {
 	const (
-		testIssuer   = "https://muster.example.io"
-		m2mSub       = "system:serviceaccount:kagent:sre-agent"
-		humanSub     = "quentin@giantswarm.io"
+		testIssuer = "https://muster.example.io"
+		m2mSub     = "system:serviceaccount:kagent:sre-agent"
+		humanSub   = "quentin@giantswarm.io"
 	)
 
 	// Two entries for the same issuer: one with allowedClaims (SA pattern), one passthrough.

--- a/internal/server/oauth_http_test.go
+++ b/internal/server/oauth_http_test.go
@@ -895,7 +895,29 @@ func TestAccessTokenInjectorMiddleware_M2MToken(t *testing.T) {
 		require.Equal(t, http.StatusForbidden, rr.Code)
 	})
 
-	t.Run("missing allowedClaims.sub returns 403", func(t *testing.T) {
+	t.Run("no allowedClaims: entry used as fallback, ImpersonateUser still enforced", func(t *testing.T) {
+		var capturedCtx context.Context
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedCtx = r.Context()
+			w.WriteHeader(http.StatusOK)
+		})
+		noClaimsMap := makeIssuerMap(TrustedIssuerConfig{
+			Issuer:            testIssuer,
+			JwksURL:           "https://oidc.example.com/.well-known/jwks.json",
+			ImpersonateUser:   agentUser,
+			ImpersonateGroups: []string{agentGroup},
+		})
+		s := &OAuthHTTPServer{trustedIssuersByIssuer: noClaimsMap}
+		rr := httptest.NewRecorder()
+		s.createAccessTokenInjectorMiddleware(next).ServeHTTP(rr, newReq(testIssuer, agentUser, []string{agentGroup}))
+		require.Equal(t, http.StatusOK, rr.Code)
+		identity, ok := ImpersonationIdentityFromContext(capturedCtx)
+		require.True(t, ok)
+		require.Equal(t, agentUser, identity.UserName)
+		require.Equal(t, []string{agentGroup, "system:authenticated"}, identity.Groups)
+	})
+
+	t.Run("no allowedClaims fallback: wrong subject still rejected by ImpersonateUser", func(t *testing.T) {
 		noClaimsMap := makeIssuerMap(TrustedIssuerConfig{
 			Issuer:            testIssuer,
 			JwksURL:           "https://oidc.example.com/.well-known/jwks.json",
@@ -906,7 +928,7 @@ func TestAccessTokenInjectorMiddleware_M2MToken(t *testing.T) {
 		rr := httptest.NewRecorder()
 		s.createAccessTokenInjectorMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
-		})).ServeHTTP(rr, newReq(testIssuer, agentUser, []string{agentGroup}))
+		})).ServeHTTP(rr, newReq(testIssuer, "agent:other", []string{agentGroup}))
 		require.Equal(t, http.StatusForbidden, rr.Code)
 	})
 
@@ -1071,20 +1093,27 @@ func TestAccessTokenInjectorMiddleware_OBOToken(t *testing.T) {
 		require.Equal(t, http.StatusForbidden, rr.Code)
 	})
 
-	t.Run("OBO allowedActors empty rejects any OBO request", func(t *testing.T) {
+	t.Run("OBO allowedActors empty: any actor accepted", func(t *testing.T) {
+		var capturedCtx context.Context
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedCtx = r.Context()
+			w.WriteHeader(http.StatusOK)
+		})
 		noActorMap := makeIssuerMap(TrustedIssuerConfig{
 			Issuer:        testIssuer,
 			JwksURL:       "https://oidc.example.com/.well-known/jwks.json",
 			Alias:         testAlias,
 			AllowedClaims: map[string]string{"sub": humanSubject},
-			// AllowedActors intentionally empty — OBO disabled.
+			// AllowedActors intentionally empty — any actor accepted.
 		})
 		s := &OAuthHTTPServer{trustedIssuersByIssuer: noActorMap}
 		rr := httptest.NewRecorder()
-		s.createAccessTokenInjectorMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(http.StatusOK)
-		})).ServeHTTP(rr, newOBOReq(humanSubject, agentSASub))
-		require.Equal(t, http.StatusForbidden, rr.Code)
+		s.createAccessTokenInjectorMiddleware(next).ServeHTTP(rr, newOBOReq(humanSubject, agentSASub))
+		require.Equal(t, http.StatusOK, rr.Code)
+		identity, ok := ImpersonationIdentityFromContext(capturedCtx)
+		require.True(t, ok)
+		require.Equal(t, humanSubject, identity.UserName)
+		require.Equal(t, agentSASub, identity.Actor)
 	})
 
 	t.Run("OBO actor with allowedSubjects glob allows matching human", func(t *testing.T) {
@@ -1189,6 +1218,163 @@ func TestAccessTokenInjectorMiddleware_OBOToken(t *testing.T) {
 		identity, ok := ImpersonationIdentityFromContext(capturedCtx)
 		require.True(t, ok)
 		require.Equal(t, "other@example.com", identity.UserName)
+	})
+}
+
+// TestAccessTokenInjectorMiddleware_Passthrough verifies that an entry with no
+// restriction fields forwards the token's claims unchanged (muster-behind case).
+func TestAccessTokenInjectorMiddleware_Passthrough(t *testing.T) {
+	const (
+		testIssuer = "https://muster.example.io"
+		humanSub   = "quentin@giantswarm.io"
+		agentSub   = "system:serviceaccount:kagent:sre-agent"
+	)
+
+	passthroughMap := makeIssuerMap(TrustedIssuerConfig{
+		Issuer:  testIssuer,
+		JwksURL: "https://muster.internal/jwks",
+		// No allowedClaims, allowedActors, impersonateUser, impersonateGroups.
+	})
+
+	t.Run("M2M passthrough: token groups used directly", func(t *testing.T) {
+		var capturedCtx context.Context
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedCtx = r.Context()
+			w.WriteHeader(http.StatusOK)
+		})
+		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		req.Header.Set("Authorization", "Bearer fake-m2m-token") //nolint:gosec // G101: test fixture
+		userInfo := &providers.UserInfo{
+			ID:          "agent:sre",
+			Issuer:      testIssuer,
+			Groups:      []string{"agent:sre", "platform:ops"},
+			TokenSource: providers.TokenSourceM2M,
+		}
+		req = req.WithContext(handler.ContextWithUserInfo(req.Context(), userInfo))
+
+		s := &OAuthHTTPServer{trustedIssuersByIssuer: passthroughMap}
+		rr := httptest.NewRecorder()
+		s.createAccessTokenInjectorMiddleware(next).ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		identity, ok := ImpersonationIdentityFromContext(capturedCtx)
+		require.True(t, ok)
+		require.Equal(t, "agent:sre", identity.UserName)
+		require.Equal(t, []string{"agent:sre", "platform:ops", "system:authenticated"}, identity.Groups)
+		require.Empty(t, identity.Actor)
+	})
+
+	t.Run("OBO passthrough: actor accepted without allowedActors restriction", func(t *testing.T) {
+		var capturedCtx context.Context
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedCtx = r.Context()
+			w.WriteHeader(http.StatusOK)
+		})
+		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		req.Header.Set("Authorization", "Bearer fake-obo-token") //nolint:gosec // G101: test fixture
+		userInfo := &providers.UserInfo{
+			ID:           humanSub,
+			Issuer:       testIssuer,
+			TokenSource:  providers.TokenSourceOBO,
+			ActorSubject: agentSub,
+		}
+		req = req.WithContext(handler.ContextWithUserInfo(req.Context(), userInfo))
+
+		s := &OAuthHTTPServer{trustedIssuersByIssuer: passthroughMap}
+		rr := httptest.NewRecorder()
+		s.createAccessTokenInjectorMiddleware(next).ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		identity, ok := ImpersonationIdentityFromContext(capturedCtx)
+		require.True(t, ok)
+		require.Equal(t, humanSub, identity.UserName)
+		require.Equal(t, []string{"system:authenticated"}, identity.Groups)
+		require.Equal(t, agentSub, identity.Actor)
+	})
+}
+
+// TestAccessTokenInjectorMiddleware_FallbackOrdering verifies that when an issuer has
+// both a restricted entry (allowedClaims set) and a passthrough entry (no allowedClaims),
+// the restricted entry is tried first and the passthrough entry is used as a fallback.
+func TestAccessTokenInjectorMiddleware_FallbackOrdering(t *testing.T) {
+	const (
+		testIssuer   = "https://muster.example.io"
+		m2mSub       = "system:serviceaccount:kagent:sre-agent"
+		humanSub     = "quentin@giantswarm.io"
+	)
+
+	// Two entries for the same issuer: one with allowedClaims (SA pattern), one passthrough.
+	multiMap := map[string][]TrustedIssuerConfig{
+		testIssuer: {
+			{
+				Issuer:            testIssuer,
+				JwksURL:           "https://muster.internal/jwks",
+				AllowedClaims:     map[string]string{"sub": "system:serviceaccount:kagent:*"},
+				ImpersonateUser:   m2mSub,
+				ImpersonateGroups: []string{"agent:sre"},
+			},
+			{
+				Issuer:  testIssuer,
+				JwksURL: "https://muster.internal/jwks",
+				// passthrough fallback
+			},
+		},
+	}
+
+	t.Run("SA subject hits restricted entry", func(t *testing.T) {
+		var capturedCtx context.Context
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedCtx = r.Context()
+			w.WriteHeader(http.StatusOK)
+		})
+		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		req.Header.Set("Authorization", "Bearer fake-token") //nolint:gosec // G101: test fixture
+		userInfo := &providers.UserInfo{
+			ID:          m2mSub,
+			Issuer:      testIssuer,
+			Groups:      []string{"agent:sre"},
+			TokenSource: providers.TokenSourceM2M,
+		}
+		req = req.WithContext(handler.ContextWithUserInfo(req.Context(), userInfo))
+
+		s := &OAuthHTTPServer{trustedIssuersByIssuer: multiMap}
+		rr := httptest.NewRecorder()
+		s.createAccessTokenInjectorMiddleware(next).ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		identity, ok := ImpersonationIdentityFromContext(capturedCtx)
+		require.True(t, ok)
+		require.Equal(t, m2mSub, identity.UserName)
+		// Groups came from intersect(ImpersonateGroups, token.Groups).
+		require.Equal(t, []string{"agent:sre", "system:authenticated"}, identity.Groups)
+	})
+
+	t.Run("human subject falls back to passthrough entry", func(t *testing.T) {
+		var capturedCtx context.Context
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedCtx = r.Context()
+			w.WriteHeader(http.StatusOK)
+		})
+		req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		req.Header.Set("Authorization", "Bearer fake-token") //nolint:gosec // G101: test fixture
+		userInfo := &providers.UserInfo{
+			ID:          humanSub,
+			Issuer:      testIssuer,
+			Groups:      []string{"platform:admin"},
+			TokenSource: providers.TokenSourceM2M,
+		}
+		req = req.WithContext(handler.ContextWithUserInfo(req.Context(), userInfo))
+
+		s := &OAuthHTTPServer{trustedIssuersByIssuer: multiMap}
+		rr := httptest.NewRecorder()
+		s.createAccessTokenInjectorMiddleware(next).ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		identity, ok := ImpersonationIdentityFromContext(capturedCtx)
+		require.True(t, ok)
+		require.Equal(t, humanSub, identity.UserName)
+		// Passthrough: token groups used directly.
+		require.Equal(t, []string{"platform:admin", "system:authenticated"}, identity.Groups)
 	})
 }
 
@@ -1381,13 +1567,17 @@ func TestAccessTokenInjectorMiddleware_SubjectClaim(t *testing.T) {
 		require.Equal(t, http.StatusForbidden, rr.Code)
 	})
 
-	t.Run("SubjectClaim set but no allowedClaims entry under that key returns 403", func(t *testing.T) {
+	t.Run("SubjectClaim set but allowedClaims under wrong key: entry used as fallback", func(t *testing.T) {
+		// AllowedClaims has "sub" key but SubjectClaim="email", so EffectiveSubjectKey
+		// is "email" which is absent. The entry has no effective subject constraint and
+		// is used as a passthrough fallback. AllowedClaims["sub"] is enforced by
+		// mcp-oauth at token-validation time, not in the middleware.
 		misconfigured := makeIssuerMap(TrustedIssuerConfig{
 			Issuer:        musterIssuer,
 			JwksURL:       "https://muster.glean.example.io/.well-known/jwks.json",
 			Alias:         musterAlias,
 			SubjectClaim:  "email",
-			AllowedClaims: map[string]string{"sub": "*@giantswarm.io"}, // wrong key
+			AllowedClaims: map[string]string{"sub": "*@giantswarm.io"}, // wrong key for routing
 			AllowedActors: []ActorConfig{{Sub: sreAgentSub}},
 		})
 		s := &OAuthHTTPServer{trustedIssuersByIssuer: misconfigured}
@@ -1395,7 +1585,7 @@ func TestAccessTokenInjectorMiddleware_SubjectClaim(t *testing.T) {
 		s.createAccessTokenInjectorMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		})).ServeHTTP(rr, newReq(userEmail))
-		require.Equal(t, http.StatusForbidden, rr.Code)
+		require.Equal(t, http.StatusOK, rr.Code)
 	})
 }
 


### PR DESCRIPTION
## What

Every field on a `trustedIssuer` entry is now independently enforced when set; absent fields impose no restriction for that dimension. The JWKS URL is the trust boundary.

**allowedClaims** — optional. Entries without an effective subject pattern act as a passthrough fallback for any subject from that issuer. When multiple entries share an issuer URL, entries with a subject pattern are tried first; the first entry without one is the fallback.

**allowedActors** — empty now accepts any OBO actor. A populated list still enforces actor + per-actor `allowedSubjects` as before.

**impersonateUser / impersonateGroups** — enforced only when non-empty. Omitting both forwards the token's `sub`/`groups` directly.

**alias** — optional on all entries; validated as DNS-1123 only when set.

`validateTrustedIssuers` is relaxed: only `issuer` + `jwksURL` are required. The M2M/OBO binary mode distinction and mandatory subject-pattern checks are removed. Bare `*` in any `allowedClaims` value is still rejected.

## Why

mcp-kubernetes deployed behind muster was forced to duplicate every policy field that muster already enforces (subject patterns, actor lists, impersonation targets). With per-field opt-in, a muster-behind deployment needs only:

```yaml
trustedIssuers:
  - issuer: "https://muster.example.io"
    jwksURL: "https://muster.internal/jwks"
    allowPrivateIPJWKSHosts: ["muster.internal"]
    # allowedAudiences: [...] optional, for cross-cluster token scoping
```

Direct (non-muster) deployments can still lock down every dimension independently.

## Security

The JWKS URL is the explicit trust decision: adding an issuer with a private JWKS endpoint is equivalent to trusting that issuer fully. For public OIDC providers (e.g. Google), `allowedAudiences` + `allowedClaims` remain the recommended guards. Bare `*` in `allowedClaims` is still rejected at startup.