### PR TITLE
fix: team ownership labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Team ownership: chart now labels resources `application.giantswarm.io/team: bumblebee` (was `team-bumblebee`, which did not match `team="bumblebee"` routing), and defaults the alert team to `bumblebee` (was `planeteers`).
+
 * SSO forwarded-ID-token validation now works against an internal-CA Dex. When `oauth.dex.caSecret` (`DEX_CA_FILE`) is set, the CA is now also installed on `http.DefaultTransport`, which the mcp-oauth SSO forwarded-token JWKS client uses when `oauth.sso.allowPrivateIPs` (`SSO_ALLOW_PRIVATE_IPS`) is enabled. Previously `DEX_CA_FILE` only applied to the Dex provider client, so forwarded ID tokens from an internal-CA Dex were rejected with `x509: certificate signed by unknown authority` and every downstream Kubernetes tool call failed with `authentication required: please log in to access this resource`. This relies on the matching mcp-oauth `getJWKSClient` change (mcp-oauth#492), pulled in by the bump to `mcp-oauth v0.18.8` in this PR. See https://github.com/giantswarm/giantswarm/issues/37059.
 
 ### Added

--- a/helm/mcp-kubernetes/Chart.yaml
+++ b/helm/mcp-kubernetes/Chart.yaml
@@ -17,7 +17,7 @@ maintainers:
     email: team-bumblebee@giantswarm.io
 annotations:
   # Team ownership (OCI-compliant format)
-  io.giantswarm.application.team: team-bumblebee
+  io.giantswarm.application.team: bumblebee
   # Target audience: customers (default catalog)
   io.giantswarm.application.audience: customers
   # App is managed/supported by Giant Swarm

--- a/helm/mcp-kubernetes/values.yaml
+++ b/helm/mcp-kubernetes/values.yaml
@@ -974,7 +974,7 @@ prometheusRules:
   # Additional annotations for the PrometheusRule resource
   annotations: {}
   # Team responsible for these alerts (used in alert labels)
-  team: "planeteers"
+  team: "bumblebee"
   # Base URL for runbook links
   runbookBaseUrl: "https://github.com/giantswarm/mcp-kubernetes/blob/main/docs/runbooks"
 


### PR DESCRIPTION
The chart labelled its resources `application.giantswarm.io/team: team-bumblebee` (from the `Chart.yaml` annotation), but alerts and PagerDuty route on the bare `team="bumblebee"`, so team-derived metrics/dashboards did not attribute to bumblebee. Also the alert-team default was `planeteers`.

- `Chart.yaml`: `io.giantswarm.application.team` `team-bumblebee` → `bumblebee`
- `values.yaml`: `prometheusRules.team` `planeteers` → `bumblebee`