### PR TITLE
feat(oauth)!: pass Dex CA to mcp-oauth as explicit config (prep for mcp-oauth #498)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* Dex CA trust for the SSO forwarded-ID-token JWKS path is now passed to mcp-oauth as explicit config instead of being installed on `http.DefaultTransport`. `--dex-ca-file` / `oauth.dex.caSecret` now builds a CA pool that is set on the mcp-oauth server config (`JWKSRootCAs`) and trusted-issuer entries, and on the Dex provider client — removing `installDexCAOnDefaultTransport`. Pairs with the mcp-oauth change that drops the `http.DefaultTransport` CA read ([mcp-oauth#498](https://github.com/giantswarm/mcp-oauth/pull/498) / [#495](https://github.com/giantswarm/mcp-oauth/issues/495)); requires the mcp-oauth release containing it. No behavior change for garm and other internal-CA installs once deployed. See https://github.com/giantswarm/giantswarm/issues/37059.
+
 ### Fixed
 
 * Team ownership: chart now labels resources `application.giantswarm.io/team: bumblebee` (was `team-bumblebee`, which did not match `team="bumblebee"` routing), and defaults the alert team to `bumblebee` (was `planeteers`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-* Dex CA trust for the SSO forwarded-ID-token JWKS path is now passed to mcp-oauth as explicit config instead of being installed on `http.DefaultTransport`. `--dex-ca-file` / `oauth.dex.caSecret` now builds a CA pool that is set on the mcp-oauth server config (`JWKSRootCAs`) and trusted-issuer entries, and on the Dex provider client — removing `installDexCAOnDefaultTransport`. Pairs with the mcp-oauth change that drops the `http.DefaultTransport` CA read ([mcp-oauth#498](https://github.com/giantswarm/mcp-oauth/pull/498) / [#495](https://github.com/giantswarm/mcp-oauth/issues/495)); requires the mcp-oauth release containing it. No behavior change for garm and other internal-CA installs once deployed. See https://github.com/giantswarm/giantswarm/issues/37059.
-
 ### Fixed
 
 * Team ownership: chart now labels resources `application.giantswarm.io/team: bumblebee` (was `team-bumblebee`, which did not match `team="bumblebee"` routing), and defaults the alert team to `bumblebee` (was `planeteers`).
@@ -28,8 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Dex CA trust for the SSO forwarded-ID-token JWKS path is now passed to mcp-oauth as explicit config instead of being installed on `http.DefaultTransport`. `--dex-ca-file` / `oauth.dex.caSecret` now builds a CA pool that is set on the mcp-oauth server config (`JWKSRootCAs`) and trusted-issuer entries, and on the Dex provider client — removing `installDexCAOnDefaultTransport`. Pairs with the mcp-oauth change that drops the `http.DefaultTransport` CA read ([mcp-oauth#498](https://github.com/giantswarm/mcp-oauth/pull/498) / [#495](https://github.com/giantswarm/mcp-oauth/issues/495)), released in mcp-oauth v1.0.0. No behavior change for garm and other internal-CA installs once deployed. See https://github.com/giantswarm/giantswarm/issues/37059.
 * External-issuer tokens are classified as `trusted-issuer`; the on-behalf-of branch keys off `UserInfo.IsOBO()` (the RFC 8693 `act` claim) and the email-check bypass off `UserInfo.IsExternalIssuer()`.
-* **deps:** update module github.com/giantswarm/mcp-oauth to v0.18.7.
+* **deps:** update module github.com/giantswarm/mcp-oauth to v1.0.0.
 
 ## [0.1.113](https://github.com/giantswarm/mcp-kubernetes/compare/v0.1.112...v0.1.113) (2026-06-03)
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -384,7 +384,7 @@ Downstream OAuth (--downstream-oauth):
 	cmd.Flags().StringVar(&dexClientID, "dex-client-id", "", "Dex OAuth Client ID (can also be set via DEX_CLIENT_ID env var)")
 	cmd.Flags().StringVar(&dexClientSecret, "dex-client-secret", "", "Dex OAuth Client Secret (can also be set via DEX_CLIENT_SECRET env var)")
 	cmd.Flags().StringVar(&dexConnectorID, "dex-connector-id", "", "Dex connector ID to bypass connector selection (optional, can also be set via DEX_CONNECTOR_ID env var)")
-	cmd.Flags().StringVar(&dexCAFile, "dex-ca-file", "", "Path to CA certificate file for Dex TLS verification. Applies to the Dex provider client and is also installed on http.DefaultTransport, which the SSO forwarded-ID-token JWKS validation uses when --sso-allow-private-ips is set. (optional, can also be set via DEX_CA_FILE env var)")
+	cmd.Flags().StringVar(&dexCAFile, "dex-ca-file", "", "Path to CA certificate file for Dex TLS verification. Applies to the Dex provider client and, passed explicitly to mcp-oauth, to the SSO forwarded-ID-token JWKS validation when --sso-allow-private-ips is set. (optional, can also be set via DEX_CA_FILE env var)")
 	cmd.Flags().StringVar(&dexKubernetesAuthenticatorClientID, "dex-k8s-authenticator-client-id", "", "Dex client ID for Kubernetes API authentication (enables cross-client audience, can also be set via DEX_K8S_AUTHENTICATOR_CLIENT_ID env var)")
 	cmd.Flags().BoolVar(&disableStreaming, "disable-streaming", false, "Disable streaming for streamable-http transport")
 	cmd.Flags().StringVar(&registrationToken, "registration-token", "", "OAuth client registration access token (required if public registration is disabled)")

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.26.4
 
 require (
 	github.com/creativeprojects/go-selfupdate v1.5.2
-	github.com/giantswarm/mcp-oauth v0.18.9
+	github.com/giantswarm/mcp-oauth v0.18.11-0.20260702143043-874da71d9f6a
 	github.com/giantswarm/mcp-toolkit v0.2.9
 	github.com/mark3labs/mcp-go v0.55.1
 	github.com/prometheus/client_golang v1.23.2

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.26.4
 
 require (
 	github.com/creativeprojects/go-selfupdate v1.5.2
-	github.com/giantswarm/mcp-oauth v0.18.11-0.20260702143043-874da71d9f6a
+	github.com/giantswarm/mcp-oauth v1.0.0
 	github.com/giantswarm/mcp-toolkit v0.2.9
 	github.com/mark3labs/mcp-go v0.55.1
 	github.com/prometheus/client_golang v1.23.2

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/giantswarm/mcp-oauth v0.18.9 h1:oLrbAirWD5mR1FcCH8NuEfSoB4m1FrYHNIjRzOfK5u4=
-github.com/giantswarm/mcp-oauth v0.18.9/go.mod h1:Z/f5JZAz6JGs8A++hfXPUIN4CR1yuMb9cXRx4qrzzIA=
+github.com/giantswarm/mcp-oauth v0.18.11-0.20260702143043-874da71d9f6a h1:jfyCBnmmlk0mbWI/KO8lfZ5R0ZZFmsIe8/gV5JqIst4=
+github.com/giantswarm/mcp-oauth v0.18.11-0.20260702143043-874da71d9f6a/go.mod h1:Z/f5JZAz6JGs8A++hfXPUIN4CR1yuMb9cXRx4qrzzIA=
 github.com/giantswarm/mcp-toolkit v0.2.9 h1:U6HhPlHX5+SuCKqZWWMXzcmJmhdcZrobhOsq/+LpiVg=
 github.com/giantswarm/mcp-toolkit v0.2.9/go.mod h1:jwOmxo8+MCPJ6HHPRqFkI6S48A/cbqXOzvT5bydbRds=
 github.com/go-fed/httpsig v1.1.0 h1:9M+hb0jkEICD8/cAiNqEB66R87tTINszBRTjwjQzWcI=

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/giantswarm/mcp-oauth v0.18.11-0.20260702143043-874da71d9f6a h1:jfyCBnmmlk0mbWI/KO8lfZ5R0ZZFmsIe8/gV5JqIst4=
-github.com/giantswarm/mcp-oauth v0.18.11-0.20260702143043-874da71d9f6a/go.mod h1:Z/f5JZAz6JGs8A++hfXPUIN4CR1yuMb9cXRx4qrzzIA=
+github.com/giantswarm/mcp-oauth v1.0.0 h1:k/1Dj0jtV6GuitQ7JanITWW79kWMhdg771WJD+B+Yg0=
+github.com/giantswarm/mcp-oauth v1.0.0/go.mod h1:Z/f5JZAz6JGs8A++hfXPUIN4CR1yuMb9cXRx4qrzzIA=
 github.com/giantswarm/mcp-toolkit v0.2.9 h1:U6HhPlHX5+SuCKqZWWMXzcmJmhdcZrobhOsq/+LpiVg=
 github.com/giantswarm/mcp-toolkit v0.2.9/go.mod h1:jwOmxo8+MCPJ6HHPRqFkI6S48A/cbqXOzvT5bydbRds=
 github.com/go-fed/httpsig v1.1.0 h1:9M+hb0jkEICD8/cAiNqEB66R87tTINszBRTjwjQzWcI=

--- a/helm/mcp-kubernetes/values.yaml
+++ b/helm/mcp-kubernetes/values.yaml
@@ -277,10 +277,10 @@ mcpKubernetes:
       kubernetesAuthenticatorClientID: ""
       # CA certificate for Dex TLS verification (optional)
       # Use this when Dex uses a private/internal CA.
-      # Applies to the Dex provider client and is also installed on
-      # http.DefaultTransport, which the SSO forwarded-ID-token JWKS validation uses
-      # when oauth.sso.allowPrivateIPs is true. For an internal-CA Dex that forwards
-      # SSO tokens, set this together with oauth.sso.allowPrivateIPs.
+      # Applies to the Dex provider client and, passed explicitly to mcp-oauth,
+      # to the SSO forwarded-ID-token JWKS validation when oauth.sso.allowPrivateIPs
+      # is true. For an internal-CA Dex that forwards SSO tokens, set this together
+      # with oauth.sso.allowPrivateIPs.
       # Can reference a secret containing the CA certificate
       caSecret:
         # Name of the secret containing the CA certificate

--- a/internal/server/oauth_http.go
+++ b/internal/server/oauth_http.go
@@ -79,75 +79,42 @@ var (
 	}
 )
 
-// createHTTPClientWithCA creates an HTTP client that trusts certificates signed by
-// the CA in the specified file. The CA file should contain PEM-encoded certificate(s).
-// This is used for Dex deployments with private/internal CAs.
-func createHTTPClientWithCA(caFile string) (*http.Client, error) {
+// dexCACertPool builds a certificate pool from the system pool plus the CA
+// certificate(s) in caFile (PEM-encoded). Used for Dex deployments with a
+// private/internal CA. The resulting pool is passed explicitly to the mcp-oauth
+// server config and the Dex provider client — mcp-oauth no longer reads a CA
+// installed on http.DefaultTransport (see mcp-oauth #495/#498).
+func dexCACertPool(caFile string) (*x509.CertPool, error) {
 	// #nosec G304 -- caFile is a configuration value from operator, not user input
 	caCert, err := os.ReadFile(caFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read CA file %s: %w", caFile, err)
 	}
 
-	// Create a certificate pool with system CAs and add the custom CA
-	caCertPool, err := x509.SystemCertPool()
-	if err != nil {
-		// If we can't load system certs, start with an empty pool
-		caCertPool = x509.NewCertPool()
-	}
-
-	if !caCertPool.AppendCertsFromPEM(caCert) {
-		return nil, fmt.Errorf("failed to parse CA certificate from %s", caFile)
-	}
-
-	tlsConfig := &tls.Config{
-		RootCAs:    caCertPool,
-		MinVersion: tls.VersionTLS12,
-	}
-
-	transport := &http.Transport{
-		TLSClientConfig: tlsConfig,
-	}
-
-	return &http.Client{
-		Transport: transport,
-		Timeout:   30 * time.Second,
-	}, nil
-}
-
-// installDexCAOnDefaultTransport adds the CA in caFile to http.DefaultTransport's
-// root CA pool (additive to the system pool). This is required so mcp-oauth's SSO
-// forwarded-ID-token JWKS client — which backs itself with http.DefaultTransport
-// when AllowPrivateIPJWKS is set — trusts an internal Dex CA. Called once during
-// OAuth server construction, before the JWKS client is first used.
-func installDexCAOnDefaultTransport(caFile string) error {
-	// #nosec G304 -- caFile is a configuration value from operator, not user input
-	caCert, err := os.ReadFile(caFile)
-	if err != nil {
-		return fmt.Errorf("failed to read CA file %s: %w", caFile, err)
-	}
-
+	// Start from the system pool and add the custom CA (additive).
 	pool, err := x509.SystemCertPool()
 	if err != nil {
+		// If we can't load system certs, start with an empty pool
 		pool = x509.NewCertPool()
 	}
 	if !pool.AppendCertsFromPEM(caCert) {
-		return fmt.Errorf("failed to parse CA certificate from %s", caFile)
+		return nil, fmt.Errorf("failed to parse CA certificate from %s", caFile)
 	}
+	return pool, nil
+}
 
-	base, ok := http.DefaultTransport.(*http.Transport)
-	if !ok {
-		return fmt.Errorf("http.DefaultTransport is %T, not *http.Transport; cannot install Dex CA", http.DefaultTransport)
+// httpClientWithRootCAs returns an HTTP client whose transport verifies TLS
+// against the given root CA pool.
+func httpClientWithRootCAs(pool *x509.CertPool) *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:    pool,
+				MinVersion: tls.VersionTLS12,
+			},
+		},
+		Timeout: 30 * time.Second,
 	}
-	cloned := base.Clone()
-	if cloned.TLSClientConfig == nil {
-		cloned.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12}
-	} else {
-		cloned.TLSClientConfig = cloned.TLSClientConfig.Clone()
-	}
-	cloned.TLSClientConfig.RootCAs = pool
-	http.DefaultTransport = cloned
-	return nil
 }
 
 // OAuthStorageType represents the type of token storage backend.
@@ -423,6 +390,13 @@ func createOAuthServer(config OAuthConfig) (*oauth.Server, storage.TokenStore, e
 	var provider providers.Provider
 	var err error
 
+	// dexCAPool, when set from DexCAFile, is the CA pool for verifying an
+	// internal-CA Dex. It is passed explicitly to the Dex provider client, the
+	// mcp-oauth server's forwarded-ID-token JWKS validation (Config.JWKSRootCAs),
+	// and any trusted-issuer JWKS. nil = system pool. mcp-oauth no longer reads a
+	// CA installed on http.DefaultTransport (mcp-oauth #495/#498).
+	var dexCAPool *x509.CertPool
+
 	switch config.Provider {
 	case OAuthProviderDex:
 		// Build scopes list, adding cross-client audience if configured
@@ -448,26 +422,21 @@ func createOAuthServer(config OAuthConfig) (*oauth.Server, storage.TokenStore, e
 		if config.DexConnectorID != "" {
 			dexConfig.ConnectorID = config.DexConnectorID
 		}
-		// Configure custom HTTP client with CA if provided
+		// Configure custom CA if provided. The pool is used for BOTH the Dex
+		// provider client (discovery, code flow, userinfo) AND — passed
+		// explicitly below via serverConfig.JWKSRootCAs / trusted-issuer RootCAs
+		// — the SSO forwarded-ID-token JWKS validation. mcp-oauth no longer reads
+		// a CA installed on http.DefaultTransport (#495/#498), so without passing
+		// the pool explicitly, forwarded ID tokens from an internal-CA Dex would
+		// fail with "x509: certificate signed by unknown authority".
 		if config.DexCAFile != "" {
-			httpClient, err := createHTTPClientWithCA(config.DexCAFile)
+			pool, err := dexCACertPool(config.DexCAFile)
 			if err != nil {
-				return nil, nil, fmt.Errorf("failed to create HTTP client with CA: %w", err)
+				return nil, nil, fmt.Errorf("failed to load Dex CA: %w", err)
 			}
-			dexConfig.HTTPClient = httpClient
+			dexCAPool = pool
+			dexConfig.HTTPClient = httpClientWithRootCAs(pool)
 			logger.Info("Using custom CA for Dex TLS verification", "caFile", config.DexCAFile)
-
-			// Also install the CA on http.DefaultTransport. dexConfig.HTTPClient
-			// only covers the Dex provider path (discovery, code flow, userinfo).
-			// The SSO forwarded-ID-token path in mcp-oauth (Server.getJWKSClient
-			// with AllowPrivateIPJWKS) backs its JWKS client with
-			// http.DefaultTransport precisely so a host-installed CA is honored;
-			// without this, forwarded ID tokens from an internal-CA Dex fail with
-			// "x509: certificate signed by unknown authority".
-			if err := installDexCAOnDefaultTransport(config.DexCAFile); err != nil {
-				return nil, nil, fmt.Errorf("failed to install Dex CA on default transport: %w", err)
-			}
-			logger.Info("Installed custom Dex CA on http.DefaultTransport for SSO JWKS validation", "caFile", config.DexCAFile)
 		}
 		provider, err = dex.NewProvider(dexConfig)
 		if err != nil {
@@ -616,6 +585,11 @@ func createOAuthServer(config OAuthConfig) (*oauth.Server, storage.TokenStore, e
 		// AllowPrivateIPJWKS for JWKS fetching from internal IdPs (mcp-oauth v0.2.40+)
 		// Enables SSO token forwarding when IdP (e.g., Dex) is on a private network
 		AllowPrivateIPJWKS: config.SSOAllowPrivateIPs,
+
+		// JWKSRootCAs is the CA pool for verifying the forwarded-ID-token JWKS
+		// endpoint's TLS (mcp-oauth #495/#498). Built from DexCAFile; nil = system
+		// pool. Replaces the previous http.DefaultTransport CA install.
+		JWKSRootCAs: dexCAPool,
 	}
 
 	// Debug logging for registration token configuration
@@ -699,6 +673,9 @@ func createOAuthServer(config OAuthConfig) (*oauth.Server, storage.TokenStore, e
 				AcceptedTypHeaders:      ti.AcceptedTypHeaders,
 				AllowPrivateIPJWKS:      ti.AllowPrivateIPJWKS,
 				AllowPrivateIPJWKSHosts: ti.AllowPrivateIPJWKSHosts,
+				// Trust the internal Dex CA for the issuer's JWKS TLS when a
+				// DexCAFile is configured (mcp-oauth #495/#498). nil = system pool.
+				RootCAs: dexCAPool,
 			})
 		}
 		opts = append(opts, oauthserver.WithTrustedIssuers(issuers))


### PR DESCRIPTION
> **Update:** mcp-oauth #498 has been released as **v1.0.0** and `go.mod` now pins that tag — the previous DO-NOT-MERGE blocker is resolved.

## What
Migrates mcp-kubernetes to pass the Dex CA to mcp-oauth as **explicit config**, ahead of the mcp-oauth breaking change ([#498](https://github.com/giantswarm/mcp-oauth/pull/498) / [#495](https://github.com/giantswarm/mcp-oauth/issues/495)) that removes the `http.DefaultTransport` CA read.

## Why
mcp-oauth #498 stops reading a CA installed on `http.DefaultTransport`. mcp-kubernetes' current mechanism (`installDexCAOnDefaultTransport`, from #531) would then no longer be honored, and the SSO forwarded-ID-token JWKS validation on internal-CA installs (e.g. **garm**, `CN=gigantic.internal`) would regress to `x509: certificate signed by unknown authority`. This PR keeps that path working by handing mcp-oauth the CA explicitly.

## Change
- `--dex-ca-file` / `oauth.dex.caSecret` now builds a CA pool (`dexCACertPool`, shared with the Dex provider client) and passes it to the mcp-oauth server config as `JWKSRootCAs` and on each trusted-issuer entry as `RootCAs`.
- **Removed `installDexCAOnDefaultTransport`** — nothing mutates `http.DefaultTransport` anymore. The Dex provider client wiring (`dexConfig.HTTPClient`) is unchanged.
- Bumped `mcp-oauth` to **v1.0.0** (the release containing #498).
- Updated `--dex-ca-file` help + `values.yaml` comment; CHANGELOG entry.

## Rollout coordination
mcp-oauth v1.0.0 (containing #498) is released and this PR now pins it, so the ordering constraint is satisfied. The public-cert installs (gerbil/glippy/grouse/finch/sardine/wallaby) are unaffected — they use the system pool; only internal-CA garm needs this.

Refs giantswarm/giantswarm#37059, mcp-oauth#498, mcp-oauth#495.

https://claude.ai/code/session_01UBsCu5zwKLQkH3bpauxL3a
